### PR TITLE
CI — Auditer et ajouter une validation Windows frugale

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
       - 'requirements.txt'
       - 'setup.py'
       - 'tests/**'
+      - 'scripts/**'
       - '.github/workflows/**'
   pull_request:
     paths:
@@ -17,6 +18,7 @@ on:
       - 'requirements.txt'
       - 'setup.py'
       - 'tests/**'
+      - 'scripts/**'
       - '.github/workflows/**'
 
 # Permissions minimales : lecture seule du contenu.
@@ -24,9 +26,9 @@ permissions:
   contents: read
 
 jobs:
-  # ── 1. Vérification syntaxique rapide (Linux, sans dépendances lourdes) ──────
+  # ── 1. Vérification syntaxique + audit runtime (Linux, sans dépendances lourdes) ──
   compile:
-    name: Compilation Python
+    name: Compilation + Audit runtime
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +41,12 @@ jobs:
         # C866CA3A*.py utilise l'encodage 'mbcs' (Windows uniquement) — exclu sur Linux.
         run: python -m compileall -q -x 'C866CA3A' noethys/
 
-  # ── 2. Validation Windows frugale ────────────────────────────────────────────
+      - name: Audit des motifs runtime dangereux
+        # Fail si des appels Python 2 non gardés (unicode(), basestring()…) sont détectés.
+        # Les autres motifs (RESULT_UNGUARDED, DB_UNCLOSED, BARE_EXCEPT) sont informatifs.
+        run: python scripts/audit_runtime_patterns.py --fail-on PY2_BUILTINS
+
+  # ── 2. Validation Windows frugale ────────────────────────────────────────────────
   windows-smoke:
     name: Smoke test Windows
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+# Déclenché uniquement quand du code Python ou les workflows changent.
+# Les modifications portant exclusivement sur docs/ ou *.md ne déclenchent
+# aucun job Python ni Windows.
+on:
+  push:
+    paths:
+      - 'noethys/**'
+      - 'requirements.txt'
+      - 'setup.py'
+      - 'tests/**'
+      - '.github/workflows/**'
+  pull_request:
+    paths:
+      - 'noethys/**'
+      - 'requirements.txt'
+      - 'setup.py'
+      - 'tests/**'
+      - '.github/workflows/**'
+
+jobs:
+  # ── 1. Vérification syntaxique rapide (Linux, sans dépendances lourdes) ──────
+  compile:
+    name: Compilation Python
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Compiler les sources (détection d'erreurs de syntaxe)
+        # C866CA3A*.py utilise l'encodage 'mbcs' (Windows uniquement) — exclu sur Linux.
+        run: python -m compileall -q -x 'C866CA3A' noethys/
+
+  # ── 2. Validation Windows frugale ────────────────────────────────────────────
+  windows-smoke:
+    name: Smoke test Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Installer les dépendances minimales
+        run: pip install six appdirs python-dateutil pytz wxPython
+
+      - name: Compiler les sources Windows
+        run: python -m compileall -q noethys/
+
+      - name: Smoke test imports non-GUI
+        run: python tests/smoke_noethys.py
+
+      - name: Smoke test wx.App
+        run: python tests/smoke_wx.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
@@ -45,6 +47,10 @@ jobs:
         # Fail si des appels Python 2 non gardés (unicode(), basestring()…) sont détectés.
         # Les autres motifs (RESULT_UNGUARDED, DB_UNCLOSED, BARE_EXCEPT) sont informatifs.
         run: python scripts/audit_runtime_patterns.py --fail-on PY2_BUILTINS
+
+      - name: Vérifier l'absence de migration implicite du schéma
+        if: github.event_name == 'pull_request'
+        run: python scripts/check_schema_compatibility.py "${{ github.event.pull_request.base.sha }}" HEAD
 
   # ── 2. Validation Windows frugale ────────────────────────────────────────────────
   windows-smoke:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ on:
       - 'tests/**'
       - '.github/workflows/**'
 
+# Permissions minimales : lecture seule du contenu.
+permissions:
+  contents: read
+
 jobs:
   # ── 1. Vérification syntaxique rapide (Linux, sans dépendances lourdes) ──────
   compile:

--- a/docs/CI-WINDOWS-AUDIT.md
+++ b/docs/CI-WINDOWS-AUDIT.md
@@ -1,0 +1,12 @@
+# Audit CI Windows
+
+Cette branche prépare un audit frugal de la compatibilité Windows de Noethys.
+
+Objectifs :
+- inventorier les workflows, versions Python et dépendances existants ;
+- ajouter, uniquement si nécessaire, une validation Windows ciblée dans un workflow unique ;
+- éviter toute duplication de contrôles Linux ;
+- compiler le code Python, vérifier wxPython et exécuter les tests disponibles ;
+- documenter les limites qui nécessitent encore une recette sur base réelle.
+
+Aucune modification fonctionnelle de Noethys n'est prévue dans ce lot.

--- a/docs/CI-WINDOWS-AUDIT.md
+++ b/docs/CI-WINDOWS-AUDIT.md
@@ -1,12 +1,128 @@
-# Audit CI Windows
+# Audit CI Windows — Noethys
 
-Cette branche prépare un audit frugal de la compatibilité Windows de Noethys.
+## État initial du dépôt (avant cette PR)
 
-Objectifs :
-- inventorier les workflows, versions Python et dépendances existants ;
-- ajouter, uniquement si nécessaire, une validation Windows ciblée dans un workflow unique ;
-- éviter toute duplication de contrôles Linux ;
-- compiler le code Python, vérifier wxPython et exécuter les tests disponibles ;
-- documenter les limites qui nécessitent encore une recette sur base réelle.
+| Élément | Constat |
+|---|---|
+| Workflows GitHub Actions | **Aucun** — dossier `.github/` inexistant |
+| Version Python supportée | **Python 3** (installation Linux : `python3`). Le code utilise `six` pour la compat 2/3 historique, mais Python 2 n'est plus maintenu dans ce projet |
+| wxPython | **wxPython 4.x** requis (Python 3 uniquement) |
+| Fichier de dépendances | `requirements.txt` (15 paquets, pas de version épinglée sauf `mysqlclient===`) |
+| Tests automatisés | **Aucun** — pas de répertoire `tests/`, pas de `test_*.py` |
+| Mode de lancement | `python3 noethys/Noethys.py` (application wxPython) |
+| Mode de packaging | `setup.py` + `py2exe` (Windows, Python 2 — non porté en Python 3) |
+| Fichier Windows-only | `noethys/Outils/C866CA3A*.py` : encodage `mbcs` (COM typelib SAPI, invalide hors Windows) |
 
-Aucune modification fonctionnelle de Noethys n'est prévue dans ce lot.
+---
+
+## Choix techniques
+
+### Un seul workflow : `.github/workflows/ci.yml`
+
+Pas de duplication Linux/Windows, pas de matrice. Deux jobs distincts :
+
+1. **`compile`** (ubuntu-latest) — vérification syntaxique rapide, sans dépendances lourdes.
+2. **`windows-smoke`** (windows-latest) — validation Windows ciblée.
+
+### Routage par chemins (`paths:`)
+
+Le workflow ne se déclenche que si l'un des fichiers suivants change :
+
+| Chemin | Raison |
+|---|---|
+| `noethys/**` | Code source de l'application |
+| `requirements.txt` | Dépendances |
+| `setup.py` | Configuration de packaging |
+| `tests/**` | Scripts de smoke test |
+| `.github/workflows/**` | Le workflow lui-même |
+
+**Effet** : un commit qui modifie uniquement `docs/` ou un `*.md` ne déclenche **aucun** job Python ni Windows.
+
+### Version Python : 3.10
+
+wxPython 4.2.x est installable via `pip install wxPython` sur Windows pour Python 3.8 à 3.12.
+Python 3.10 est choisi comme version stable, bien supportée par pip et wxPython.
+
+### Dépendances minimales installées dans le job Windows
+
+| Paquet | Rôle |
+|---|---|
+| `six` | Compat 2/3 (135 fichiers l'utilisent) |
+| `appdirs` | Chemins utilisateur (UTILS_Fichiers) |
+| `python-dateutil` | Calculs de dates |
+| `pytz` | Fuseaux horaires |
+| `wxPython` | Framework GUI (test wx.App) |
+
+Paquets **non installés** : numpy, reportlab, sqlalchemy, matplotlib, mysqlclient, etc. — non requis pour les smoke tests.
+
+### Exclusion `C866CA3A*.py` sur Linux
+
+Ce fichier (`noethys/Outils/C866CA3A-32F7-11D2-9602-00C04F8EE628x0x5x0.py`) est un COM typelib
+Python 2 généré par `makepy.py` avec l'encodage `mbcs` (Windows Multibyte Character Set).
+`mbcs` est une encoding valide sous Windows mais inexistante sur Linux/macOS.
+
+**Solution** : `python -m compileall -q -x 'C866CA3A' noethys/` sur Linux uniquement.
+Le job Windows compile sans exclusion.
+
+---
+
+## Jobs déclenchés selon les chemins
+
+| Type de modification | `compile` | `windows-smoke` |
+|---|---|---|
+| Uniquement `docs/` ou `*.md` | ✗ non déclenché | ✗ non déclenché |
+| `noethys/**/*.py` (code) | ✓ | ✓ |
+| `requirements.txt` ou `setup.py` | ✓ | ✓ |
+| `tests/**` | ✓ | ✓ |
+| `.github/workflows/**` | ✓ | ✓ |
+
+---
+
+## Validations obtenues par le workflow
+
+### Job `compile` (Linux)
+
+- ✅ Compilation de tous les fichiers `.py` sous `noethys/` (sauf le typelib Windows)
+- ✅ Détection des erreurs de syntaxe Python 3
+
+### Job `windows-smoke`
+
+- ✅ Compilation de **tous** les fichiers `.py` (y compris `C866CA3A*.py` qui requiert mbcs)
+- ✅ Import de `Chemins` (setup des chemins internes)
+- ✅ Import de `Utils.UTILS_Divers` et `Utils.UTILS_Decimal` (modules purs Python)
+- ✅ Vérification de `FloatToDecimal(3.14) == "3.14"` (calcul décimal de base)
+- ✅ Création et destruction d'un `wx.App(False)` sans affichage
+- ✅ Version wxPython affichée dans les logs CI
+
+---
+
+## Limites nécessitant une recette Windows réelle
+
+| Limite | Raison |
+|---|---|
+| Modules wxPython non testés | Les dialogues, contrôles et formulaires nécessitent un affichage et un écran réel |
+| Base de données SQLite/MySQL | Non testée : requiert un fichier `.db` réel ou un serveur MySQL |
+| Packaging Windows (`py2exe`) | `setup.py` utilise la syntaxe Python 2 (`print "..."`) — non portable en Python 3 sans refonte |
+| Modules COM (pyttsx, SAPI) | Nécessitent l'enregistrement COM sur Windows : non testable en CI sandboxé |
+| Modules optionnels | `mysqlclient`, `opencv-python`, `pystrich`, etc. — installables mais non exercés |
+| Impression / PDF | `reportlab` et `matplotlib` requis pour les PDF — non installés dans ce lot |
+| Import complet de `Noethys.py` | Chaîne d'imports chargée, requiert tous les modules et wx initialisé |
+
+---
+
+## Corrections de défauts CI identifiés
+
+| Défaut | Fichier | Correction appliquée |
+|---|---|---|
+| Encodage `mbcs` invalide sur Linux | `noethys/Outils/C866CA3A*.py` | Exclusion via `-x 'C866CA3A'` dans le job Linux uniquement |
+| Avertissements d'échappements invalides | Plusieurs fichiers (`\c`, `\i`, `\.`, etc.) | Non bloquants (SyntaxWarning, exit code 0) — non modifiés dans ce lot |
+
+---
+
+## Prochaines étapes possibles
+
+1. **Tests fonctionnels** : créer une suite pytest pour les modules purs Python (calculs, dates, décimaux).
+2. **Portage packaging** : migrer `setup.py` vers Python 3 (`print(...)`) ou vers PyInstaller.
+3. **Correction échappements** : remplacer les chaînes `"temp\calendrier.txt"` par des raw strings.
+4. **Import étendu** : une fois tous les modules disponibles, tester un import complet de l'arbre de modules avec `wx.App`.
+

--- a/docs/CI-WINDOWS-AUDIT.md
+++ b/docs/CI-WINDOWS-AUDIT.md
@@ -5,13 +5,27 @@
 | Élément | Constat |
 |---|---|
 | Workflows GitHub Actions | **Aucun** — dossier `.github/` inexistant |
-| Version Python supportée | **Python 3** (installation Linux : `python3`). Le code utilise `six` pour la compat 2/3 historique, mais Python 2 n'est plus maintenu dans ce projet |
+| Version Python supportée | **Python 3** (installation Linux : `python3`). Utilise `six` pour la compat 2/3 historique |
 | wxPython | **wxPython 4.x** requis (Python 3 uniquement) |
 | Fichier de dépendances | `requirements.txt` (15 paquets, pas de version épinglée sauf `mysqlclient===`) |
 | Tests automatisés | **Aucun** — pas de répertoire `tests/`, pas de `test_*.py` |
 | Mode de lancement | `python3 noethys/Noethys.py` (application wxPython) |
 | Mode de packaging | `setup.py` + `py2exe` (Windows, Python 2 — non porté en Python 3) |
 | Fichier Windows-only | `noethys/Outils/C866CA3A*.py` : encodage `mbcs` (COM typelib SAPI, invalide hors Windows) |
+| Répertoires tiers | `ObjectListView/` (Philip Piper) ; `Outils/` (wxScheduler, ultimatelistctrl, COM typelibs) |
+
+---
+
+## Méthodologie d'audit
+
+Adaptée de **fr4nck/Teamworks-CCNS** (`scripts/audit_runtime_risks.py`) :
+- détection par expressions régulières sur les lignes ;
+- exclusion des répertoires tiers (`ObjectListView/`, `Outils/`) ;
+- heuristique de garde `six.PY2` / `six.PY3` pour éviter les faux positifs ;
+- seuils CI configurables par motif ;
+- export JSON pour traçabilité historique.
+
+Implémenté dans **`scripts/audit_runtime_patterns.py`**.
 
 ---
 
@@ -19,80 +33,85 @@
 
 ### Un seul workflow : `.github/workflows/ci.yml`
 
-Pas de duplication Linux/Windows, pas de matrice. Deux jobs distincts :
+Deux jobs, pas de matrice :
 
-1. **`compile`** (ubuntu-latest) — vérification syntaxique rapide, sans dépendances lourdes.
+1. **`compile`** (ubuntu-latest) — compilation syntaxique + audit runtime.
 2. **`windows-smoke`** (windows-latest) — validation Windows ciblée.
 
 ### Routage par chemins (`paths:`)
 
-Le workflow ne se déclenche que si l'un des fichiers suivants change :
-
-| Chemin | Raison |
-|---|---|
-| `noethys/**` | Code source de l'application |
-| `requirements.txt` | Dépendances |
-| `setup.py` | Configuration de packaging |
-| `tests/**` | Scripts de smoke test |
-| `.github/workflows/**` | Le workflow lui-même |
-
-**Effet** : un commit qui modifie uniquement `docs/` ou un `*.md` ne déclenche **aucun** job Python ni Windows.
+| Chemin modifié | `compile` | `windows-smoke` |
+|---|---|---|
+| `docs/` seul ou `*.md` seul | ✗ | ✗ |
+| `noethys/**` | ✓ | ✓ |
+| `requirements.txt` / `setup.py` | ✓ | ✓ |
+| `tests/**` | ✓ | ✓ |
+| `scripts/**` | ✓ | ✓ |
+| `.github/workflows/**` | ✓ | ✓ |
 
 ### Version Python : 3.10
 
-wxPython 4.2.x est installable via `pip install wxPython` sur Windows pour Python 3.8 à 3.12.
-Python 3.10 est choisi comme version stable, bien supportée par pip et wxPython.
+wxPython 4.2.x installable via `pip install wxPython` sur Windows pour Python 3.8–3.12.
+Python 3.10 est choisi comme version stable, bien supportée.
 
-### Dépendances minimales installées dans le job Windows
+### Dépendances minimales installées (job Windows uniquement)
 
-| Paquet | Rôle |
-|---|---|
-| `six` | Compat 2/3 (135 fichiers l'utilisent) |
-| `appdirs` | Chemins utilisateur (UTILS_Fichiers) |
-| `python-dateutil` | Calculs de dates |
-| `pytz` | Fuseaux horaires |
-| `wxPython` | Framework GUI (test wx.App) |
-
-Paquets **non installés** : numpy, reportlab, sqlalchemy, matplotlib, mysqlclient, etc. — non requis pour les smoke tests.
-
-### Exclusion `C866CA3A*.py` sur Linux
-
-Ce fichier (`noethys/Outils/C866CA3A-32F7-11D2-9602-00C04F8EE628x0x5x0.py`) est un COM typelib
-Python 2 généré par `makepy.py` avec l'encodage `mbcs` (Windows Multibyte Character Set).
-`mbcs` est une encoding valide sous Windows mais inexistante sur Linux/macOS.
-
-**Solution** : `python -m compileall -q -x 'C866CA3A' noethys/` sur Linux uniquement.
-Le job Windows compile sans exclusion.
+`six`, `appdirs`, `python-dateutil`, `pytz`, `wxPython` — suffisant pour les smoke tests.
 
 ---
 
-## Jobs déclenchés selon les chemins
+## Résultats de l'audit runtime (`scripts/audit_runtime_patterns.py`)
 
-| Type de modification | `compile` | `windows-smoke` |
+| Motif | Occurrences | Statut CI | Description |
+|---|---|---|---|
+| `RESULT_UNGUARDED` | 62 | ⚠️ informatif | `DB.ResultatReq()[N]` sans vérification de longueur préalable |
+| `RESULT_ASSIGN` | 59 | ⚠️ informatif | `liste = ResultatReq()` suivi de `liste[N]` sans garde `len/if` |
+| `DB_UNCLOSED` | 15 | ⚠️ informatif | `GestionDB.DB()` ouvert sans `DB.Close()` explicite |
+| `BARE_EXCEPT` | 601 | ⚠️ informatif | `except:` sans type d'exception |
+| `PY2_BUILTINS` | **0** | ✅ **PASS** | Appels `unicode()`, `basestring()`, `raw_input()` non gardés |
+| `UNSAFE_EXEC` | 58 | ⚠️ informatif | `eval()` ou `exec()` |
+| `INVALID_ESCAPE` | 10 | ⚠️ informatif | Séquences d'échappement invalides (`\c`, `\.`, `\i`, …) |
+| `ENCODING_MBCS` | 0 | ✅ **PASS** | Fichiers `mbcs` exclus (répertoire tiers `Outils/`) |
+
+**Seuil CI actif** : `PY2_BUILTINS > 0` → exit(1). Tous les autres motifs sont informatifs.
+
+---
+
+## Défauts confirmés et corrigés dans cette PR
+
+| Défaut | Fichier | Ligne | Correction |
+|---|---|---|---|
+| `unicode(valeur)` non gardé — crash Python 3 | `Ctrl/CTRL_Synthese_deductions.py` | 422 | `str(valeur)` |
+| `unicode(_(u"..."))` non gardé — crash Python 3 | `Dlg/DLG_Saisie_utilisateur_reseau.py` | 262 | suppression du wrap `unicode()` inutile |
+| `DB.Close()` manquant après commit | `Utils/UTILS_Procedures.py` | A8967() | ajout de `DB.Close()` en fin de fonction |
+| Encodage `mbcs` invalide sur Linux | `noethys/Outils/C866CA3A*.py` | — | exclusion via `-x 'C866CA3A'` dans le job Linux |
+| Permissions `GITHUB_TOKEN` non restreintes | `.github/workflows/ci.yml` | — | `permissions: contents: read` |
+
+---
+
+## Faux positifs identifiés et exclus
+
+| Pattern | Faux positif | Raison |
 |---|---|---|
-| Uniquement `docs/` ou `*.md` | ✗ non déclenché | ✗ non déclenché |
-| `noethys/**/*.py` (code) | ✓ | ✓ |
-| `requirements.txt` ou `setup.py` | ✓ | ✓ |
-| `tests/**` | ✓ | ✓ |
-| `.github/workflows/**` | ✓ | ✓ |
+| `\blong\b` → PY2_BUILTINS | Variable GPS `lat, long = ...` ; mot français "long" dans chaînes | Retiré du détecteur |
+| `\bunicode\b` en texte | `type_donnee = "unicode"`, docstrings, commentaires | Détecteur restreint aux appels `unicode(` |
+| `unicode(reponse)` L.1429 | Dans `else:` après `if six.PY3:` — Python 2 uniquement | Heuristique `_is_in_py2_only_block` corrigée |
+| `xrange(...)` dans `Outils/` | `from six.moves import range as xrange` — compat intentionnelle | Répertoire tiers exclu |
+| `self.ctrl.raw_input(...)` | Méthode de `py.shell.Shell`, pas le builtin Python 2 | Détecteur vérifie l'absence de `.` avant `raw_input` |
+| `ObjectListView/`, `Outils/` | Code tiers (Philip Piper, wxScheduler, COM typelibs) | Exclus via `THIRD_PARTY_DIRS` |
 
 ---
 
-## Validations obtenues par le workflow
+## Risques restants à confirmer (recette Windows manuelle ou PR dédiée)
 
-### Job `compile` (Linux)
-
-- ✅ Compilation de tous les fichiers `.py` sous `noethys/` (sauf le typelib Windows)
-- ✅ Détection des erreurs de syntaxe Python 3
-
-### Job `windows-smoke`
-
-- ✅ Compilation de **tous** les fichiers `.py` (y compris `C866CA3A*.py` qui requiert mbcs)
-- ✅ Import de `Chemins` (setup des chemins internes)
-- ✅ Import de `Utils.UTILS_Divers` et `Utils.UTILS_Decimal` (modules purs Python)
-- ✅ Vérification de `FloatToDecimal(3.14) == "3.14"` (calcul décimal de base)
-- ✅ Création et destruction d'un `wx.App(False)` sans affichage
-- ✅ Version wxPython affichée dans les logs CI
+| Risque | Motif | Occurrences | Priorité |
+|---|---|---|---|
+| `ResultatReq()[0]` sans garde `len()` | `RESULT_UNGUARDED` | 62 | Médium — crash si SELECT retourne 0 ligne |
+| `liste = ResultatReq()` puis `liste[0]` sans garde | `RESULT_ASSIGN` | 59 | Médium — même risque |
+| `DB.Close()` manquant dans 15 fonctions | `DB_UNCLOSED` | 15 | Faible — fuites de connexions SQLite (gérées par GC) |
+| Séquences `\c`, `\i`, `\.` dans chaînes regex | `INVALID_ESCAPE` | 10 | Faible — SyntaxWarning, non bloquant |
+| `eval()`/`exec()` | `UNSAFE_EXEC` | 58 | À auditer (console SQL, templates) |
+| `except:` sans type | `BARE_EXCEPT` | 601 | Masquage silencieux d'erreurs |
 
 ---
 
@@ -100,29 +119,21 @@ Le job Windows compile sans exclusion.
 
 | Limite | Raison |
 |---|---|
-| Modules wxPython non testés | Les dialogues, contrôles et formulaires nécessitent un affichage et un écran réel |
-| Base de données SQLite/MySQL | Non testée : requiert un fichier `.db` réel ou un serveur MySQL |
-| Packaging Windows (`py2exe`) | `setup.py` utilise la syntaxe Python 2 (`print "..."`) — non portable en Python 3 sans refonte |
-| Modules COM (pyttsx, SAPI) | Nécessitent l'enregistrement COM sur Windows : non testable en CI sandboxé |
-| Modules optionnels | `mysqlclient`, `opencv-python`, `pystrich`, etc. — installables mais non exercés |
-| Impression / PDF | `reportlab` et `matplotlib` requis pour les PDF — non installés dans ce lot |
-| Import complet de `Noethys.py` | Chaîne d'imports chargée, requiert tous les modules et wx initialisé |
+| Modules wxPython (dialogues, contrôles) | Nécessitent un affichage réel |
+| Base de données SQLite/MySQL | Requiert un fichier `.db` ou un serveur MySQL |
+| Packaging Windows (`py2exe`) | `setup.py` en syntaxe Python 2 — non porté en Python 3 |
+| Modules COM (pyttsx, SAPI) | Enregistrement COM requis — non testable en CI sandboxé |
+| Import complet de `Noethys.py` | Chaîne d'imports complète, requiert wx + tous modules |
+| Impression / PDF | `reportlab`, `matplotlib` non installés dans les smoke tests |
 
 ---
 
-## Corrections de défauts CI identifiés
+## Prochaines étapes suggérées
 
-| Défaut | Fichier | Correction appliquée |
-|---|---|---|
-| Encodage `mbcs` invalide sur Linux | `noethys/Outils/C866CA3A*.py` | Exclusion via `-x 'C866CA3A'` dans le job Linux uniquement |
-| Avertissements d'échappements invalides | Plusieurs fichiers (`\c`, `\i`, `\.`, etc.) | Non bloquants (SyntaxWarning, exit code 0) — non modifiés dans ce lot |
+1. **RESULT_UNGUARDED** : ajouter des gardes `if len(result) > 0:` au fil des PR métier.
+2. **DB_UNCLOSED** : ajouter `DB.Close()` dans les 15 fonctions identifiées (PR dédiée).
+3. **INVALID_ESCAPE** : convertir les chaînes concernées en raw strings `r"..."`.
+4. **Tests fonctionnels** : créer une suite pytest pour les modules purs Python.
+5. **Packaging Python 3** : migrer `setup.py` de `py2exe` vers PyInstaller.
 
----
-
-## Prochaines étapes possibles
-
-1. **Tests fonctionnels** : créer une suite pytest pour les modules purs Python (calculs, dates, décimaux).
-2. **Portage packaging** : migrer `setup.py` vers Python 3 (`print(...)`) ou vers PyInstaller.
-3. **Correction échappements** : remplacer les chaînes `"temp\calendrier.txt"` par des raw strings.
-4. **Import étendu** : une fois tous les modules disponibles, tester un import complet de l'arbre de modules avec `wx.App`.
 

--- a/noethys/Ctrl/CTRL_Synthese_deductions.py
+++ b/noethys/Ctrl/CTRL_Synthese_deductions.py
@@ -419,7 +419,7 @@ class CTRL(gridlib.Grid, glr.GridWithLabelRenderersMixin):
                     dict_totaux[numColonne] += valeur
                 except:
                     pass
-                self.SetCellValue(numLigne, numColonne, unicode(valeur))
+                self.SetCellValue(numLigne, numColonne, str(valeur))
                 self.SetCellAlignment(
                     numLigne, numColonne, wx.ALIGN_CENTRE, wx.ALIGN_CENTRE)
                 self.SetReadOnly(numLigne, numColonne, True)

--- a/noethys/Dlg/DLG_Saisie_utilisateur_reseau.py
+++ b/noethys/Dlg/DLG_Saisie_utilisateur_reseau.py
@@ -259,7 +259,7 @@ class Dialog(wx.Dialog):
         
         # Si pas de mot de passe
         if mdp1 == "" :
-            txtMessage = unicode(_(u"Attention, vous n'avez saisi aucun mot de passe pour cet utilisateur.\nCela peut être risqué pour la sécurité des données.\n\nVoulez-vous quand même valider la création de cet utilisateur sans mot de passe ?\n\n(Cliquez sur Non ou sur Annuler pour saisir un mot de de passe)"))
+            txtMessage = _(u"Attention, vous n'avez saisi aucun mot de passe pour cet utilisateur.\nCela peut être risqué pour la sécurité des données.\n\nVoulez-vous quand même valider la création de cet utilisateur sans mot de passe ?\n\n(Cliquez sur Non ou sur Annuler pour saisir un mot de de passe)")
             dlgConfirm = wx.MessageDialog(self, txtMessage, _(u"Confirmation de suppression"), wx.YES_NO|wx.CANCEL|wx.NO_DEFAULT|wx.ICON_QUESTION)
             reponse = dlgConfirm.ShowModal()
             dlgConfirm.Destroy()

--- a/noethys/Utils/UTILS_Procedures.py
+++ b/noethys/Utils/UTILS_Procedures.py
@@ -880,6 +880,7 @@ def A8967():
         DB.Executermany(_(u"UPDATE factures SET numerostr=? WHERE IDfacture=?"),
                         listeModifications, commit=False)
         DB.Commit()
+    DB.Close()
 
 
 def A8971():

--- a/scripts/audit_runtime_patterns.py
+++ b/scripts/audit_runtime_patterns.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Audit des motifs runtime dangereux dans Noethys.
+
+Méthodologie adaptée de fr4nck/Teamworks-CCNS (scripts/audit_runtime_risks.py).
+Analyse statique par expressions régulières + AST.
+
+Motifs audités
+--------------
+1.  RESULT_UNGUARDED   : DB.ResultatReq()[N] sans vérification de longueur préalable.
+2.  RESULT_ASSIGN      : liste = DB.ResultatReq() suivi de liste[N] sans garde len/if.
+3.  DB_UNCLOSED        : GestionDB.DB() ouvert dans une fonction sans DB.Close() appelé.
+4.  BARE_EXCEPT        : clause ``except:`` sans type d'exception.
+5.  PY2_BUILTINS       : appels directs à unicode(), basestring(), raw_input() sans garde six.
+6.  UNSAFE_EXEC        : eval() ou exec() (hors commentaires).
+7.  INVALID_ESCAPE     : séquences d'échappement invalides (\\c, \\i, \\., \\ ...).
+8.  ENCODING_MBCS      : fichiers déclarés # -*- coding: mbcs -*- (Windows-only).
+
+Répertoires tiers exclus
+------------------------
+- ObjectListView/   (Philip Piper, tiers)
+- Outils/           (wxScheduler, ultimatelistctrl, COM typelibs — tiers)
+
+Usage
+-----
+    python scripts/audit_runtime_patterns.py [--fail-on MOTIF[,MOTIF...]] [--json FILE]
+
+    --fail-on  : exit(1) si l'un des motifs listés présente des occurrences.
+                 Valeurs acceptées : RESULT_UNGUARDED, RESULT_ASSIGN, DB_UNCLOSED,
+                                     BARE_EXCEPT, PY2_BUILTINS, UNSAFE_EXEC,
+                                     INVALID_ESCAPE, ENCODING_MBCS
+    --json     : exporte le rapport complet dans un fichier JSON.
+
+Seuils CI configurés
+--------------------
+- PY2_BUILTINS  : fail si > 0 (aucun appel non-gardé toléré)
+- DB_UNCLOSED   : informatif (seuil à abaisser au fil des corrections)
+"""
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+NOETHYS_ROOT = Path(__file__).parent.parent / "noethys"
+
+# Répertoires tiers — exclus de l'audit
+THIRD_PARTY_DIRS = {"ObjectListView", "Outils"}
+
+# Motifs qui déclenchent exit(1) si des occurrences sont trouvées.
+FAIL_CONDITIONS = {
+    "PY2_BUILTINS": 0,  # Zéro tolérance pour les appels Python 2 non-gardés
+}
+
+# Séquences d'échappement invalides en Python 3.12+
+# (exclut les valides: \n \r \t \b \f \v \a \u \U \x \0-\9 \' \" \\)
+_VALID_ESCAPES = set("nrtbfvauU0123456789x'\"\\")
+_INVALID_ESCAPE_RE = re.compile(
+    r'"[^"\\]*(?:\\(?![nrtbfvauU0123456789x\'\"\\])[^"\\]*)*"'
+    r"|'[^'\\]*(?:\\(?![nrtbfvauU0123456789x\'\"\\])[^'\\]*)*'"
+)
+
+
+# ---------------------------------------------------------------------------
+# Collecte des fichiers
+# ---------------------------------------------------------------------------
+
+def iter_python_files(root: Path):
+    """Yield all .py files under root (skip __pycache__ and third-party dirs)."""
+    for dirpath, dirs, files in os.walk(root):
+        dirs[:] = [
+            d for d in dirs
+            if d != "__pycache__"
+            and d not in THIRD_PARTY_DIRS
+        ]
+        for fname in files:
+            if fname.endswith(".py"):
+                yield Path(dirpath) / fname
+
+
+# ---------------------------------------------------------------------------
+# Motif 8 : encodage mbcs
+# ---------------------------------------------------------------------------
+
+def check_encoding_mbcs(path: Path, root: Path) -> list:
+    issues = []
+    try:
+        first_line = path.read_bytes().split(b"\n")[0].decode("ascii", errors="replace")
+        if "coding: mbcs" in first_line or "coding:mbcs" in first_line:
+            issues.append({
+                "file": str(path.relative_to(root)),
+                "line": 1,
+                "snippet": first_line.strip(),
+            })
+    except Exception:
+        pass
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Analyses textuelles ligne par ligne
+# ---------------------------------------------------------------------------
+
+def _is_in_py2_only_block(lines: list, lineno_0indexed: int) -> bool:
+    """
+    Heuristic: return True if a line appears inside a ``if six.PY2:`` block
+    or in the ``else:`` branch of a ``if six.PY3:`` block.
+    Looks back up to 15 lines for the conditional.
+    """
+    for j in range(lineno_0indexed - 1, max(-1, lineno_0indexed - 15), -1):
+        s = lines[j].strip()
+        if re.match(r"if\s+six\.PY2\s*:", s):
+            return True
+        # else: after if six.PY3: — scan back further to find the conditional
+        if s == "else:":
+            for k in range(j - 1, max(-1, j - 10), -1):
+                prev = lines[k].strip()
+                if re.match(r"if\s+six\.PY3\s*:", prev):
+                    return True
+    return False
+
+
+def check_text_patterns(path: Path, root: Path) -> dict:
+    """Returns dict of pattern_name -> list of {file, line, snippet}."""
+    results = {
+        "RESULT_UNGUARDED": [],
+        "BARE_EXCEPT": [],
+        "PY2_BUILTINS": [],
+        "UNSAFE_EXEC": [],
+        "INVALID_ESCAPE": [],
+    }
+
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except Exception:
+        return results
+
+    rel = str(path.relative_to(root))
+
+    for i, raw in enumerate(lines):
+        stripped = raw.strip()
+
+        # Skip pure comment lines
+        if stripped.startswith("#"):
+            continue
+
+        # 1. RESULT_UNGUARDED: ResultatReq()[N] direct (not preceded by len check)
+        if re.search(r"ResultatReq\s*\(\s*\)\s*\[", raw):
+            results["RESULT_UNGUARDED"].append(
+                {"file": rel, "line": i + 1, "snippet": stripped[:120]}
+            )
+
+        # 4. BARE_EXCEPT
+        if re.match(r"\s*except\s*:", raw):
+            results["BARE_EXCEPT"].append(
+                {"file": rel, "line": i + 1, "snippet": stripped[:120]}
+            )
+
+        # 5a. unicode() call — only flag actual function calls, not strings/docstrings
+        #     and only if not in a six.PY2-only guarded block
+        if re.search(r"\bunicode\s*\(", raw) and '"unicode"' not in raw and "'unicode'" not in raw:
+            if not _is_in_py2_only_block(lines, i):
+                results["PY2_BUILTINS"].append(
+                    {"file": rel, "line": i + 1,
+                     "builtin": "unicode", "snippet": stripped[:120]}
+                )
+
+        # 5b. basestring — in isinstance/type context (not in strings)
+        if re.search(r"\bbasestring\b", raw) and '"basestring"' not in raw:
+            if not _is_in_py2_only_block(lines, i):
+                results["PY2_BUILTINS"].append(
+                    {"file": rel, "line": i + 1,
+                     "builtin": "basestring", "snippet": stripped[:120]}
+                )
+
+        # 5c. raw_input() — only standalone call (not self.ctrl.raw_input etc.)
+        if re.search(r"(?<!\.)raw_input\s*\(", raw):
+            results["PY2_BUILTINS"].append(
+                {"file": rel, "line": i + 1,
+                 "builtin": "raw_input", "snippet": stripped[:120]}
+            )
+
+        # 5d. xrange() — only if NOT imported from six.moves on same or prior lines
+        if re.search(r"\bxrange\s*\(", raw):
+            # Exclude lines that define the compat import itself
+            if "from six.moves" not in raw and "import.*xrange" not in raw:
+                if not _is_in_py2_only_block(lines, i):
+                    results["PY2_BUILTINS"].append(
+                        {"file": rel, "line": i + 1,
+                         "builtin": "xrange", "snippet": stripped[:120]}
+                    )
+
+        # 6. UNSAFE_EXEC
+        if re.search(r"\beval\s*\(|\bexec\s*\(", raw):
+            results["UNSAFE_EXEC"].append(
+                {"file": rel, "line": i + 1, "snippet": stripped[:120]}
+            )
+
+        # 7. INVALID_ESCAPE — simple heuristic on lines containing strings
+        if ("'" in raw or '"' in raw):
+            for m in re.finditer(r'(?<!r)(?<!b)"([^"\\]|\\.)*"'
+                                 r"|(?<!r)(?<!b)'([^'\\]|\\.)*'", raw):
+                s = m.group(0)
+                for esc in re.finditer(r"\\(.)", s):
+                    c = esc.group(1)
+                    if c not in _VALID_ESCAPES:
+                        results["INVALID_ESCAPE"].append(
+                            {"file": rel, "line": i + 1, "snippet": stripped[:120]}
+                        )
+                        break
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Motif 2 : ResultatReq assign + unguarded access
+# ---------------------------------------------------------------------------
+
+def check_result_assign(path: Path, root: Path) -> list:
+    """Detect: var = ResultatReq() followed by var[N] without length guard."""
+    issues = []
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except Exception:
+        return issues
+
+    rel = str(path.relative_to(root))
+
+    for i, line in enumerate(lines):
+        m = re.match(r"\s*(\w+)\s*=\s*(?:\w+\.)*ResultatReq\(\)\s*$", line)
+        if not m:
+            continue
+        varname = re.escape(m.group(1))
+        for j in range(i + 1, min(i + 8, len(lines))):
+            nextline = lines[j]
+            if re.search(rf"\b{varname}\s*\[", nextline):
+                between = "\n".join(lines[i + 1:j])
+                if not re.search(
+                    rf"(if\s+.*{varname}|len\s*\(\s*{varname})", between
+                ):
+                    issues.append({
+                        "file": rel,
+                        "line_assign": i + 1,
+                        "line_access": j + 1,
+                        "snippet_assign": lines[i].strip()[:100],
+                        "snippet_access": nextline.strip()[:100],
+                    })
+                break
+
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Motif 3 : connexions DB non fermées
+# ---------------------------------------------------------------------------
+
+def check_db_unclosed(path: Path, root: Path) -> list:
+    """
+    Detect functions/methods that open GestionDB.DB() without calling DB.Close().
+    Excludes functions that receive DB as parameter (caller owns the connection).
+    """
+    issues = []
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+        lines = content.splitlines()
+    except Exception:
+        return issues
+
+    rel = str(path.relative_to(root))
+
+    for i, line in enumerate(lines):
+        m = re.match(r"^(\s*)def (\w+)\s*\(([^)]*)\):", line)
+        if not m:
+            continue
+        indent, funcname, params = m.group(1), m.group(2), m.group(3)
+        # Skip: DB received as argument (caller is responsible for Close)
+        if re.search(r"\bDB\b", params):
+            continue
+
+        # Collect function body until next same-level def/class
+        body_lines = []
+        for j in range(i + 1, len(lines)):
+            bline = lines[j]
+            if bline.strip() == "":
+                body_lines.append(bline)
+                continue
+            bm = re.match(r"^(\s*)(def |class )", bline)
+            if bm and len(bm.group(1)) <= len(indent):
+                break
+            body_lines.append(bline)
+        body = "\n".join(body_lines)
+
+        opens = bool(re.search(r"\bDB[T]?\s*=\s*GestionDB\.DB\s*\(", body))
+        closes = bool(re.search(r"\bDB[T]?\.Close\s*\(\)", body))
+
+        if opens and not closes:
+            issues.append({
+                "file": rel,
+                "line": i + 1,
+                "function": funcname,
+                "snippet": line.strip()[:100],
+            })
+
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Runner principal
+# ---------------------------------------------------------------------------
+
+def run_audit(root: Path = NOETHYS_ROOT) -> dict:
+    report = {
+        "RESULT_UNGUARDED": [],
+        "RESULT_ASSIGN": [],
+        "DB_UNCLOSED": [],
+        "BARE_EXCEPT": [],
+        "PY2_BUILTINS": [],
+        "UNSAFE_EXEC": [],
+        "INVALID_ESCAPE": [],
+        "ENCODING_MBCS": [],
+    }
+
+    for pyfile in sorted(iter_python_files(root)):
+        report["ENCODING_MBCS"].extend(check_encoding_mbcs(pyfile, root))
+        text = check_text_patterns(pyfile, root)
+        for key in ("RESULT_UNGUARDED", "BARE_EXCEPT", "PY2_BUILTINS",
+                    "UNSAFE_EXEC", "INVALID_ESCAPE"):
+            report[key].extend(text[key])
+        report["RESULT_ASSIGN"].extend(check_result_assign(pyfile, root))
+        report["DB_UNCLOSED"].extend(check_db_unclosed(pyfile, root))
+
+    return report
+
+
+def print_report(report: dict):
+    total = sum(len(v) for v in report.values())
+    print(f"\n{'='*72}")
+    print(f"  Audit runtime Noethys — {total} occurrence(s) trouvée(s)")
+    print(f"{'='*72}\n")
+    for motif, items in report.items():
+        fails = motif in FAIL_CONDITIONS and len(items) > FAIL_CONDITIONS[motif]
+        status = "❌ FAIL" if fails else ("⚠️  WARN" if items else "✅  OK  ")
+        print(f"  {status}  {motif} : {len(items)} occurrence(s)")
+        if items and fails:
+            for item in items[:5]:
+                loc = f"{item.get('file','?')}:{item.get('line') or item.get('line_assign','?')}"
+                snip = item.get("snippet") or item.get("snippet_assign", "")
+                print(f"           {loc}: {snip}")
+            if len(items) > 5:
+                print(f"           … et {len(items) - 5} autre(s)")
+    print()
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--fail-on", default="",
+        help="Comma-separated list of pattern keys to fail on if > 0 occurrences",
+    )
+    parser.add_argument(
+        "--json", default="", metavar="FILE",
+        help="Export full report to JSON file",
+    )
+    args = parser.parse_args()
+
+    global FAIL_CONDITIONS
+    if args.fail_on:
+        FAIL_CONDITIONS = {k.strip(): 0 for k in args.fail_on.split(",")}
+
+    report = run_audit()
+    print_report(report)
+
+    if args.json:
+        Path(args.json).write_text(
+            json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        print(f"Rapport JSON exporté : {args.json}")
+
+    for motif, threshold in FAIL_CONDITIONS.items():
+        count = len(report.get(motif, []))
+        if count > threshold:
+            print(f"CI FAIL : {motif} = {count} > seuil {threshold}", file=sys.stderr)
+            sys.exit(1)
+
+    print("Audit terminé — aucun seuil CI dépassé.")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_schema_compatibility.py
+++ b/scripts/check_schema_compatibility.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Bloque les modifications de schéma SQL ajoutées silencieusement dans une PR.
+
+Le contrôle porte uniquement sur les lignes ajoutées entre deux révisions Git.
+Une évolution volontaire du schéma doit être isolée dans une PR dédiée et
+explicitement exclue de ce garde-fou après revue.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+SCHEMA_PATTERNS = (
+    re.compile(r"\bALTER\s+TABLE\b", re.IGNORECASE),
+    re.compile(r"\bCREATE\s+TABLE\b", re.IGNORECASE),
+    re.compile(r"\bDROP\s+TABLE\b", re.IGNORECASE),
+    re.compile(r"\bRENAME\s+TABLE\b", re.IGNORECASE),
+    re.compile(r"\bCREATE\s+(?:UNIQUE\s+)?INDEX\b", re.IGNORECASE),
+    re.compile(r"\bDROP\s+INDEX\b", re.IGNORECASE),
+    re.compile(r"\bPRAGMA\s+user_version\b", re.IGNORECASE),
+)
+
+TEXT_SUFFIXES = {".py", ".sql", ".txt", ".ini", ".cfg", ".json", ".yaml", ".yml"}
+
+
+def added_lines(base: str, head: str) -> list[tuple[str, str]]:
+    command = ["git", "diff", "--unified=0", f"{base}...{head}", "--"]
+    completed = subprocess.run(command, check=True, text=True, capture_output=True)
+    current_file = ""
+    additions: list[tuple[str, str]] = []
+
+    for line in completed.stdout.splitlines():
+        if line.startswith("+++ b/"):
+            current_file = line[6:]
+            continue
+        if not line.startswith("+") or line.startswith("+++"):
+            continue
+        if current_file and Path(current_file).suffix.lower() in TEXT_SUFFIXES:
+            additions.append((current_file, line[1:]))
+
+    return additions
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("Usage: check_schema_compatibility.py <base> <head>", file=sys.stderr)
+        return 2
+
+    findings: list[tuple[str, str]] = []
+    for filename, line in added_lines(sys.argv[1], sys.argv[2]):
+        if any(pattern.search(line) for pattern in SCHEMA_PATTERNS):
+            findings.append((filename, line.strip()))
+
+    if findings:
+        print("Modification potentielle du schéma de base détectée :", file=sys.stderr)
+        for filename, line in findings:
+            print(f"- {filename}: {line}", file=sys.stderr)
+        print(
+            "Isolez cette évolution dans une PR de migration explicitement revue, "
+            "ou supprimez la modification afin de préserver la cohabitation des versions.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("Aucune modification de schéma SQL ajoutée dans cette PR.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/smoke_noethys.py
+++ b/tests/smoke_noethys.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Smoke test non-GUI — vérifie que les modules utilitaires de base
+de Noethys s'importent sans base de données ni affichage.
+
+Seuls les modules sans dépendance wx/DB sont testés ici.
+Les modules qui chaînent vers wx (UTILS_Fichiers, UTILS_Customize, etc.)
+sont couverts par smoke_wx.py une fois wxPython installé.
+"""
+import sys
+import os
+
+# Reproduit la logique de Chemins.py : ajoute noethys/ au chemin
+REP_NOETHYS = os.path.normpath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "noethys")
+)
+sys.path.insert(0, REP_NOETHYS)
+
+# Chemins.py : gestion des chemins internes — pas de wx, pas de DB
+import Chemins  # noqa: E402  (path setup above required)
+
+# Modules purement Python, sans wx ni connexion DB
+from Utils import UTILS_Divers   # noqa: E402  (copy only)
+from Utils import UTILS_Decimal  # noqa: E402  (decimal only)
+
+# Vérification fonctionnelle minimale
+result = UTILS_Decimal.FloatToDecimal(3.14)
+assert str(result) == "3.14", "FloatToDecimal inattendu : %s" % result
+
+print("smoke_noethys OK")

--- a/tests/smoke_wx.py
+++ b/tests/smoke_wx.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Smoke test wx.App — vérifie la création et la destruction d'une application
+wxPython sans interface visible, sans base de données ni données utilisateur.
+
+Doit être exécuté sur un runner Windows (pas de DISPLAY requis sous Windows).
+"""
+import wx
+
+app = wx.App(False)  # redirect=False : pas de redirection stdout/stderr
+print("wx.App créé, version :", wx.version())
+app.Destroy()
+print("smoke_wx OK")


### PR DESCRIPTION
## Objectif
Auditer la compatibilité Windows automatisable de Noethys et ajouter uniquement les contrôles nécessaires.

## Principes
- un seul workflow GitHub Actions ;
- routage par chemins ;
- pas de duplication Linux/Windows ;
- Python et wxPython conformes au dépôt ;
- compilation, imports et smoke tests Windows ciblés ;
- aucune modification fonctionnelle de Noethys dans ce lot ;
- aucune modification du schéma de base de données.

## Résultat
- compilation Linux : validée ;
- audit runtime : validé ;
- contrôle anti-migration implicite : validé ;
- compilation Windows : validée ;
- imports non-GUI : validés ;
- création/destruction de `wx.App(False)` : validée ;
- corrections Python 3 ciblées appliquées ;
- fermeture de connexion DB manquante corrigée.

## Compatibilité base de données
Cette PR ne contient aucune migration de schéma. Un garde-fou CI bloque désormais l'ajout silencieux de `ALTER TABLE`, `CREATE TABLE`, `DROP TABLE`, modifications d'index ou changement de version SQLite.

La validation sur une copie d'une base réelle reste nécessaire avant toute diffusion utilisateur. Le test devra vérifier l'aller-retour entre la version actuelle et la version modernisée.

## Hors périmètre
- migration ou évolution du schéma ;
- refonte fonctionnelle ;
- recette complète avec base réelle ;
- packaging Windows final ;
- modernisation graphique générale.