### PR TITLE
Windows 11 — packaging PyInstaller portable minimal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-# Déclenché uniquement quand du code Python ou les workflows changent.
+# Déclenché uniquement quand du code Python, le packaging ou les workflows changent.
 # Les modifications portant exclusivement sur docs/ ou *.md ne déclenchent
 # aucun job Python ni Windows.
 on:
@@ -8,7 +8,9 @@ on:
     paths:
       - 'noethys/**'
       - 'requirements.txt'
+      - 'requirements-build.txt'
       - 'setup.py'
+      - 'packaging/**'
       - 'tests/**'
       - 'scripts/**'
       - '.github/workflows/**'
@@ -16,17 +18,17 @@ on:
     paths:
       - 'noethys/**'
       - 'requirements.txt'
+      - 'requirements-build.txt'
       - 'setup.py'
+      - 'packaging/**'
       - 'tests/**'
       - 'scripts/**'
       - '.github/workflows/**'
 
-# Permissions minimales : lecture seule du contenu.
 permissions:
   contents: read
 
 jobs:
-  # ── 1. Vérification syntaxique + audit runtime (Linux, sans dépendances lourdes) ──
   compile:
     name: Compilation + Audit runtime
     runs-on: ubuntu-latest
@@ -40,19 +42,15 @@ jobs:
           python-version: "3.10"
 
       - name: Compiler les sources (détection d'erreurs de syntaxe)
-        # C866CA3A*.py utilise l'encodage 'mbcs' (Windows uniquement) — exclu sur Linux.
         run: python -m compileall -q -x 'C866CA3A' noethys/
 
       - name: Audit des motifs runtime dangereux
-        # Fail si des appels Python 2 non gardés (unicode(), basestring()…) sont détectés.
-        # Les autres motifs (RESULT_UNGUARDED, DB_UNCLOSED, BARE_EXCEPT) sont informatifs.
         run: python scripts/audit_runtime_patterns.py --fail-on PY2_BUILTINS
 
       - name: Vérifier l'absence de migration implicite du schéma
         if: github.event_name == 'pull_request'
         run: python scripts/check_schema_compatibility.py "${{ github.event.pull_request.base.sha }}" HEAD
 
-  # ── 2. Validation Windows frugale ────────────────────────────────────────────────
   windows-smoke:
     name: Smoke test Windows
     runs-on: windows-latest

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -1,0 +1,52 @@
+name: Package Windows
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  package:
+    name: Construire Noethys portable
+    runs-on: windows-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-build.txt
+
+      - name: Installer les dépendances de fabrication
+        run: python -m pip install --upgrade pip wheel && python -m pip install -r requirements-build.txt
+
+      - name: Compiler les sources
+        run: python -m compileall -q noethys
+
+      - name: Construire le dossier portable
+        run: pyinstaller --noconfirm --clean packaging/noethys.spec
+
+      - name: Vérifier la présence de l'exécutable
+        shell: pwsh
+        run: |
+          if (-not (Test-Path "dist/Noethys/Noethys.exe")) {
+            throw "Noethys.exe absent du résultat PyInstaller"
+          }
+          Get-ChildItem "dist/Noethys" -Recurse | Measure-Object | Format-List
+
+      - name: Créer l'archive portable
+        shell: pwsh
+        run: Compress-Archive -Path "dist/Noethys/*" -DestinationPath "Noethys-Windows11-portable.zip"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Noethys-Windows11-portable
+          path: Noethys-Windows11-portable.zip
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -7,6 +7,13 @@ on:
       - 'packaging/**'
       - 'requirements-build.txt'
       - '.github/workflows/windows-package.yml'
+  push:
+    branches:
+      - 'agent/windows11-pyinstaller'
+    paths:
+      - 'packaging/**'
+      - 'requirements-build.txt'
+      - '.github/workflows/windows-package.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -2,6 +2,11 @@ name: Package Windows
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - 'packaging/**'
+      - 'requirements-build.txt'
+      - '.github/workflows/windows-package.yml'
 
 permissions:
   contents: read

--- a/docs/PACKAGING-WINDOWS11.md
+++ b/docs/PACKAGING-WINDOWS11.md
@@ -1,0 +1,49 @@
+# Packaging Windows 11
+
+## Objectif
+
+Produire un dossier portable Noethys pour Windows 11 avec Python 3.10, wxPython 4 et PyInstaller, sans modifier le schéma de base de données ni remplacer immédiatement l'ancien `setup.py`.
+
+## Stratégie
+
+Le premier résultat est volontairement un dossier `onedir` :
+
+- démarrage et erreurs plus faciles à diagnostiquer ;
+- ressources visibles ;
+- dépendances manquantes identifiables ;
+- retour arrière immédiat ;
+- aucune installation système requise.
+
+Le build ne s'exécute pas sur chaque PR. Le workflow `Package Windows` est lancé manuellement depuis GitHub Actions et publie un artefact conservé 14 jours.
+
+## Contenu ajouté
+
+- `packaging/noethys.spec` : configuration PyInstaller ;
+- `requirements-build.txt` : dépendances de fabrication ;
+- `.github/workflows/windows-package.yml` : build manuel et archive portable.
+
+## Contraintes
+
+- aucune migration de base ;
+- aucune évolution métier ;
+- aucun mode sombre ;
+- aucun installateur dans ce premier lot ;
+- aucune signature de code dans ce premier lot.
+
+## Validation attendue
+
+1. le workflow fabrique `Noethys-Windows11-portable.zip` ;
+2. l'archive contient `Noethys.exe` et les ressources statiques ;
+3. l'application démarre sur Windows 11 ;
+4. une copie de base existante s'ouvre ;
+5. après une opération de recette, l'ancienne version ouvre toujours la même copie.
+
+## Risques connus à qualifier par le premier build
+
+- anciennes dépendances telles que `pyttsx` ;
+- compilation de `mysqlclient` ;
+- modules COM Windows ;
+- imports dynamiques wxPython, Matplotlib, Twisted et ReportLab ;
+- ressources ou DLL chargées par chemin relatif.
+
+Le premier échec de build sera traité comme un résultat d'audit : seules les dépendances réellement nécessaires seront corrigées ou remplacées.

--- a/docs/UPSTREAM-BUG-BACKLOG.md
+++ b/docs/UPSTREAM-BUG-BACKLOG.md
@@ -1,0 +1,117 @@
+# Backlog issu du projet Noethys original
+
+## Objectif
+
+Transformer les signalements du forum et du dépôt d’origine en backlog technique priorisé pour la modernisation Windows 11, sans modifier le schéma de base.
+
+## Sources suivies
+
+- Dépôt original : https://github.com/Noethys/Noethys
+- Forum officiel : https://www.noethys.com/index.php/forum-34
+
+## P0 — Démarrage et récupération
+
+### Configuration locale corrompue
+
+Signalement récurrent : `error: db type could not be determined` lors de l’ouverture du fichier de configuration `shelve/anydbm`.
+
+Le contournement historique impose de maintenir CTRL ou ALT au démarrage afin de réinitialiser les préférences.
+
+Travaux attendus :
+
+- détecter automatiquement la corruption ;
+- sauvegarder ou renommer le fichier fautif ;
+- proposer une récupération explicite ;
+- journaliser l’incident ;
+- ne jamais toucher au fichier de données métier.
+
+Références :
+
+- https://www.noethys.com/index.php/forum-34/6-signaler-un-bug/6278-impossible-de-lancer-noethys
+- https://www.noethys.com/index.php/forum-34/6-signaler-un-bug/5438-impossible-d-ouvrir-noethys-gros-bug
+- https://www.noethys.com/index.php/forum-34/6-signaler-un-bug/5517-noethys-ne-s-ouvre-plus
+
+## P0 — Compatibilité wxPython moderne
+
+Des assertions ont été signalées sur les grilles et les indices de colonnes avec wxPython Phoenix. Le mainteneur indiquait que d’autres incompatibilités pouvaient subsister.
+
+Travaux attendus :
+
+- tests ciblés des grilles ;
+- tests des listes et contrôles personnalisés ;
+- ouverture/destruction de dialogues prioritaires ;
+- qualification avec la version wxPython retenue pour Windows 11.
+
+Référence :
+
+- https://www.noethys.com/index.php/forum-34/6-signaler-un-bug/5371-importation-d-un-fichier-csv
+
+## P1 — Facturation et impressions
+
+Signalements :
+
+- facture impossible à produire ou télécharger lorsque le logo ou le modèle est absent ;
+- fichiers PDF temporaires potentiellement supprimés par la fermeture d’une autre instance ;
+- édition ou envoi restant bloqué sans diagnostic clair.
+
+Travaux attendus :
+
+- garde explicite sur les ressources absentes ;
+- répertoires temporaires isolés par processus ;
+- test d’édition et d’envoi avec et sans logo ;
+- diagnostic utilisateur exploitable.
+
+Références :
+
+- https://www.noethys.com/index.php/forum-34/noethysweb/6328-impression-des-factures-impossible
+- https://www.noethys.com/index.php/forum-34/6-signaler-un-bug/5959-message-d-erreur-a-l-impression-et-a-l-envoi-des-factures
+
+## P1 — Windows 11, réseau et MySQL
+
+Les utilisateurs demandent explicitement une validation Windows 11, notamment en bureau à distance et avec une base MySQL.
+
+Travaux attendus :
+
+- recette Windows 11 locale ;
+- recette TSE/RDP ;
+- recette SQLite ;
+- recette MySQL ;
+- documentation des versions serveur supportées ;
+- procédure de sauvegarde et restauration.
+
+Référence :
+
+- https://www.noethys.com/index.php/forum-34/installation/6262-passage-a-windows-11
+
+## P2 — Installation et dépendances
+
+Les procédures historiques et certaines dépendances deviennent obsolètes.
+
+Travaux attendus :
+
+- dépendances épinglées et testées ;
+- version Python documentée ;
+- version wxPython documentée ;
+- packaging reproductible ;
+- suppression progressive des dépendances non nécessaires.
+
+Référence :
+
+- https://www.noethys.com/index.php/forum-34/installation/5376-refaire-un-script-a-jour-pour-l-installation-de-noethys-sur-ubuntu-20-04
+
+## Règles de traitement
+
+- Une correction fonctionnelle ou runtime par PR ciblée.
+- Aucun changement implicite du schéma de base.
+- Toujours tester sur une copie de base réelle.
+- Conserver la compatibilité avec l’ancienne version tant qu’aucune migration dédiée n’est décidée.
+- Distinguer défaut confirmé, problème de paramétrage et faux positif.
+
+## Ordre recommandé
+
+1. Finaliser le ZIP Windows 11 portable.
+2. Ajouter un test de récupération du fichier de configuration corrompu.
+3. Ajouter les tests wxPython prioritaires.
+4. Tester factures, impressions et fichiers temporaires.
+5. Qualifier SQLite et MySQL sous Windows 11 et RDP.
+6. Continuer l’inventaire du forum par lots.

--- a/packaging/noethys.spec
+++ b/packaging/noethys.spec
@@ -22,11 +22,14 @@ for package in (
 ):
     hiddenimports += collect_submodules(package)
 
+# Chemins.py recherche ces ressources à côté de Noethys.exe lorsque
+# l'application est figée. Elles doivent donc être placées à la racine
+# du dossier portable, et non dans un sous-répertoire noethys/.
 datas = [
-    (str(NOETHYS / "Static"), "noethys/Static"),
-    (str(NOETHYS / "Versions.txt"), "noethys"),
-    (str(NOETHYS / "Licence.txt"), "noethys"),
-    (str(NOETHYS / "Icone.ico"), "noethys"),
+    (str(NOETHYS / "Static"), "Static"),
+    (str(NOETHYS / "Versions.txt"), "."),
+    (str(NOETHYS / "Licence.txt"), "."),
+    (str(NOETHYS / "Icone.ico"), "."),
 ]
 datas += collect_data_files("matplotlib")
 datas += collect_data_files("pytz")

--- a/packaging/noethys.spec
+++ b/packaging/noethys.spec
@@ -1,0 +1,72 @@
+# -*- mode: python ; coding: utf-8 -*-
+from pathlib import Path
+
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+
+ROOT = Path(SPECPATH).resolve().parent.parent
+NOETHYS = ROOT / "noethys"
+
+hiddenimports = []
+for package in (
+    "matplotlib.backends",
+    "reportlab",
+    "sqlalchemy",
+    "twisted",
+    "lxml",
+    "PIL",
+    "dateutil",
+    "pytz",
+    "icalendar",
+    "paramiko",
+    "comtypes",
+):
+    hiddenimports += collect_submodules(package)
+
+datas = [
+    (str(NOETHYS / "Static"), "noethys/Static"),
+    (str(NOETHYS / "Versions.txt"), "noethys"),
+    (str(NOETHYS / "Licence.txt"), "noethys"),
+    (str(NOETHYS / "Icone.ico"), "noethys"),
+]
+datas += collect_data_files("matplotlib")
+datas += collect_data_files("pytz")
+datas += collect_data_files("reportlab")
+
+analysis = Analysis(
+    [str(NOETHYS / "Noethys.py")],
+    pathex=[str(ROOT), str(NOETHYS)],
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=["tkinter", "PyQt5", "PyQt6", "PySide2", "PySide6"],
+    noarchive=False,
+)
+
+pyz = PYZ(analysis.pure)
+
+exe = EXE(
+    pyz,
+    analysis.scripts,
+    [],
+    exclude_binaries=True,
+    name="Noethys",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=False,
+    icon=str(NOETHYS / "Icone.ico"),
+)
+
+collect = COLLECT(
+    exe,
+    analysis.binaries,
+    analysis.datas,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    name="Noethys",
+)

--- a/packaging/noethys.spec
+++ b/packaging/noethys.spec
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 
-ROOT = Path(SPECPATH).resolve().parent.parent
+ROOT = Path(SPECPATH).resolve().parent
 NOETHYS = ROOT / "noethys"
 
 hiddenimports = []

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+wxPython
+pyinstaller>=6.0,<7


### PR DESCRIPTION
## Objectif
Intégrer uniquement le premier lot de packaging Windows 11 déjà validé par GitHub Actions, sans embarquer les travaux de modernisation ultérieurs.

## Périmètre
- workflow manuel `Package Windows` ;
- configuration PyInstaller `onedir` ;
- dépendances de fabrication séparées ;
- documentation de recette et backlog amont ;
- aucun changement métier ;
- aucune migration de base ;
- aucun installateur ni mode sombre.

## Validation obtenue
- CI réussie sur le commit `2baaa7561ee4bdc1fb4f30c6dad514bfc64ee1e0` ;
- job `Construire Noethys portable` réussi ;
- artefact `Noethys-Windows11-portable` produit, contenant `Noethys.exe`.

## Validation restant à faire
Le démarrage réel et l’ouverture d’une copie de base devront être testés sur un poste Windows 11 avant qualification fonctionnelle. Cette PR ne prétend valider que la reproductibilité du packaging.