### PR TITLE
Noe-011: qualify Python 3.11

### DIFF
--- a/.github/workflows/python311-compat.yml
+++ b/.github/workflows/python311-compat.yml
@@ -1,0 +1,128 @@
+name: Python 3.11 qualification
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/python311-compat.yml'
+      - 'requirements.txt'
+      - 'requirements-build.txt'
+      - 'packaging/**'
+      - 'scripts/**'
+      - 'tests/**'
+      - 'noethys/**'
+
+permissions:
+  contents: read
+
+jobs:
+  core-audit:
+    name: Core audit Python 3.11
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Compiler les sources
+        run: python -m compileall -q -x 'C866CA3A' noethys/
+
+      - name: Générer la base de recette synthétique
+        run: python scripts/build_synthetic_recette_db.py --output tmp/py311_recette.dat
+
+      - name: Benchmark lecture seule
+        run: python scripts/benchmark_db_readonly.py --db tmp/py311_recette.dat --repeats 3
+
+      - name: Auditer les motifs runtime Python 2
+        run: python scripts/audit_runtime_patterns.py --fail-on PY2_BUILTINS
+
+      - name: Vérifier les modules métier critiques
+        run: python scripts/audit_critical_business_modules.py
+
+      - name: Tester le migrateur DB vers DB
+        run: python tests/test_migration_base.py
+
+      - name: Vérifier l'absence de migration implicite
+        run: python scripts/check_schema_compatibility.py '${{ github.event.pull_request.base.sha }}' HEAD
+        if: github.event_name == 'pull_request'
+
+  windows-full:
+    name: Windows portable Python 3.11
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-build.txt
+
+      - name: Installer toutes les dépendances runtime et build
+        run: python -m pip install --upgrade pip wheel && python -m pip install -r requirements-build.txt
+
+      - name: Compiler les sources
+        run: python -m compileall -q noethys/
+
+      - name: Smoke test imports non-GUI
+        run: python tests/smoke_noethys.py
+
+      - name: Smoke test configuration UTF-8 et récupération
+        run: python scripts/smoke_config_utf8_recovery.py
+
+      - name: Smoke test wx.App
+        run: python tests/smoke_wx.py
+
+      - name: Valider les piles fonctionnelles optionnelles
+        run: python scripts/smoke_optional_feature_stacks.py
+
+      - name: Valider la génération PDF Unicode
+        run: python scripts/smoke_reportlab_unicode_pdf.py
+
+      - name: Valider les ressources PyInstaller essentielles
+        run: python scripts/smoke_packaged_resources.py
+
+      - name: Construire le portable avec Python 3.11
+        run: pyinstaller --noconfirm --clean packaging/noethys.spec
+
+      - name: Vérifier Noethys.exe
+        shell: pwsh
+        run: |
+          if (-not (Test-Path 'dist/Noethys/Noethys.exe')) {
+            throw 'Noethys.exe absent du build Python 3.11'
+          }
+
+  macos-smoke:
+    name: macOS smoke Python 3.11
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Installer les dépendances minimales
+        run: python -m pip install --upgrade pip && python -m pip install six appdirs python-dateutil pytz wxPython pyttsx3
+
+      - name: Compiler les sources
+        run: python -m compileall -q -x 'C866CA3A' noethys/
+
+      - name: Smoke test imports non-GUI
+        run: python tests/smoke_noethys.py
+
+      - name: Smoke test configuration UTF-8 et récupération
+        run: python scripts/smoke_config_utf8_recovery.py
+
+      - name: Smoke test pyttsx3
+        run: python -c "import sys; sys.path.insert(0, 'noethys'); import pyttsx; assert callable(pyttsx.init)"
+
+      - name: Smoke test wx.App
+        run: python tests/smoke_wx.py


### PR DESCRIPTION
Qualification progressive de Python 3.11 sans changer la baseline 3.10.

Ce workflow teste :
- compilation/audits métier et DB sur Linux 3.11 ;
- installation de **toutes** les dépendances + construction complète du portable Windows PyInstaller en 3.11 ;
- smoke tests wxPython/UTF-8/pyttsx sur macOS 3.11.

Aucune migration de base ni modification du code métier.

Issue : #9