### PR TITLE
CI: keep Python 3.11/3.12 deep qualifications on demand

### DIFF
--- a/.github/workflows/python311-compat.yml
+++ b/.github/workflows/python311-compat.yml
@@ -1,16 +1,10 @@
 name: Python 3.11 qualification
 
+# Qualification profonde volontairement déclenchée à la demande (par exemple
+# avant une RC). La CI courante reste centrée sur la baseline Python 3.10 afin
+# de ne pas reconstruire un portable complet 3.11 à chaque PR.
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - '.github/workflows/python311-compat.yml'
-      - 'requirements.txt'
-      - 'requirements-build.txt'
-      - 'packaging/**'
-      - 'scripts/**'
-      - 'tests/**'
-      - 'noethys/**'
 
 permissions:
   contents: read
@@ -46,10 +40,6 @@ jobs:
       - name: Tester le migrateur DB vers DB
         run: python tests/test_migration_base.py
 
-      - name: Vérifier l'absence de migration implicite
-        run: python scripts/check_schema_compatibility.py '${{ github.event.pull_request.base.sha }}' HEAD
-        if: github.event_name == 'pull_request'
-
   windows-full:
     name: Windows portable Python 3.11
     runs-on: windows-latest
@@ -79,6 +69,9 @@ jobs:
 
       - name: Smoke test wx.App
         run: python tests/smoke_wx.py
+
+      - name: Smoke test layout wx
+        run: python tests/smoke_wx_layout.py
 
       - name: Valider les piles fonctionnelles optionnelles
         run: python scripts/smoke_optional_feature_stacks.py
@@ -115,6 +108,9 @@ jobs:
       - name: Compiler les sources
         run: python -m compileall -q -x 'C866CA3A' noethys/
 
+      - name: Audit compatibilité wxPython Phoenix
+        run: python scripts/audit_wxphoenix_compat.py --runtime --fail-missing
+
       - name: Smoke test imports non-GUI
         run: python tests/smoke_noethys.py
 
@@ -126,3 +122,6 @@ jobs:
 
       - name: Smoke test wx.App
         run: python tests/smoke_wx.py
+
+      - name: Smoke test layout wx
+        run: python tests/smoke_wx_layout.py

--- a/.github/workflows/python312-study.yml
+++ b/.github/workflows/python312-study.yml
@@ -1,16 +1,10 @@
 name: Python 3.12 study
 
+# Étude prospective déclenchée à la demande. Python 3.12 n'est pas la baseline
+# de production ; il est requalifié ponctuellement avant les jalons importants
+# sans consommer trois runners à chaque PR courante.
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - '.github/workflows/python312-study.yml'
-      - 'requirements.txt'
-      - 'requirements-build.txt'
-      - 'packaging/**'
-      - 'scripts/**'
-      - 'tests/**'
-      - 'noethys/**'
 
 permissions:
   contents: read
@@ -45,9 +39,6 @@ jobs:
         run: python scripts/audit_critical_business_modules.py
       - name: Tester le migrateur DB vers DB
         run: python tests/test_migration_base.py
-      - name: Vérifier l'absence de migration implicite
-        run: python scripts/check_schema_compatibility.py '${{ github.event.pull_request.base.sha }}' HEAD
-        if: github.event_name == 'pull_request'
 
   windows-dependencies:
     name: Windows dependencies Python 3.12
@@ -66,12 +57,16 @@ jobs:
         run: python -m pip install --upgrade pip wheel && python -m pip install -r requirements-build.txt
       - name: Compiler les sources
         run: python -m compileall -q noethys/
+      - name: Audit compatibilité wxPython Phoenix
+        run: python scripts/audit_wxphoenix_compat.py --runtime --fail-missing
       - name: Smoke test imports non-GUI
         run: python tests/smoke_noethys.py
       - name: Smoke test configuration UTF-8 et récupération
         run: python scripts/smoke_config_utf8_recovery.py
       - name: Smoke test wx.App
         run: python tests/smoke_wx.py
+      - name: Smoke test layout wx
+        run: python tests/smoke_wx_layout.py
       - name: Valider les piles fonctionnelles optionnelles
         run: python scripts/smoke_optional_feature_stacks.py
       - name: Vérifier PyInstaller sans construire le portable
@@ -89,9 +84,13 @@ jobs:
         run: python -m pip install --upgrade pip && python -m pip install six appdirs python-dateutil pytz wxPython pyttsx3
       - name: Compiler les sources
         run: python -m compileall -q -x 'C866CA3A' noethys/
+      - name: Audit compatibilité wxPython Phoenix
+        run: python scripts/audit_wxphoenix_compat.py --runtime --fail-missing
       - name: Smoke test imports non-GUI
         run: python tests/smoke_noethys.py
       - name: Smoke test configuration UTF-8 et récupération
         run: python scripts/smoke_config_utf8_recovery.py
       - name: Smoke test wx.App
         run: python tests/smoke_wx.py
+      - name: Smoke test layout wx
+        run: python tests/smoke_wx_layout.py


### PR DESCRIPTION
Réduit le bruit et le coût de CI maintenant que Python 3.11 et 3.12 ont été qualifiés :
- la CI courante reste la baseline Python 3.10 sur Windows/macOS/Linux GTK3 ;
- les qualifications profondes 3.11 et 3.12 restent disponibles via `workflow_dispatch`, notamment avant une RC ;
- leurs smoke tests sont alignés sur les contrôles Phoenix/layout récents.

Cela évite les builds complets 3.11/3.12 à chaque PR sans supprimer la capacité de requalification.