### PR TITLE
Noe-040: execute the final Windows portable artifact

### DIFF
--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   package:
-    name: Construire Noethys portable
+    name: Construire et exécuter Noethys portable
     runs-on: windows-latest
     timeout-minutes: 45
 
@@ -84,6 +84,60 @@ jobs:
       - name: Créer l'archive portable
         shell: pwsh
         run: Compress-Archive -Path "dist/Noethys/*" -DestinationPath "Noethys-Windows-portable.zip"
+
+      - name: Tester l'archive extraite sans environnement Python
+        shell: pwsh
+        run: |
+          $testRoot = Join-Path $env:RUNNER_TEMP "noethys-frozen-smoke"
+          $profileRoot = Join-Path $env:RUNNER_TEMP "noethys-frozen-profile"
+          Remove-Item $testRoot -Recurse -Force -ErrorAction SilentlyContinue
+          Remove-Item $profileRoot -Recurse -Force -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Path $testRoot | Out-Null
+          New-Item -ItemType Directory -Path $profileRoot | Out-Null
+          Expand-Archive -Path "Noethys-Windows-portable.zip" -DestinationPath $testRoot
+
+          $exe = Join-Path $testRoot "Noethys.exe"
+          if (-not (Test-Path $exe)) {
+            throw "Noethys.exe absent de l'archive extraite"
+          }
+
+          $savedPath = $env:PATH
+          $savedPythonHome = $env:PYTHONHOME
+          $savedPythonPath = $env:PYTHONPATH
+          $savedAppData = $env:APPDATA
+          $savedLocalAppData = $env:LOCALAPPDATA
+          try {
+            $env:NOETHYS_FROZEN_SMOKE = "1"
+            $env:PYTHONHOME = ""
+            $env:PYTHONPATH = ""
+            $env:APPDATA = Join-Path $profileRoot "Roaming"
+            $env:LOCALAPPDATA = Join-Path $profileRoot "Local"
+            New-Item -ItemType Directory -Path $env:APPDATA -Force | Out-Null
+            New-Item -ItemType Directory -Path $env:LOCALAPPDATA -Force | Out-Null
+            # Le bundle doit trouver son Python et ses DLL localement. On retire
+            # donc les chemins Python/pip du PATH pour cette exécution.
+            $env:PATH = "$env:SystemRoot\System32;$env:SystemRoot"
+
+            $process = Start-Process -FilePath $exe -Wait -PassThru
+            if ($process.ExitCode -ne 0) {
+              throw "Smoke de l'exécutable figé en échec (code $($process.ExitCode))"
+            }
+
+            if (Test-Path (Join-Path $env:APPDATA "noethys")) {
+              throw "Le smoke figé a écrit dans la configuration utilisateur"
+            }
+            if (Test-Path (Join-Path $env:LOCALAPPDATA "noethys")) {
+              throw "Le smoke figé a écrit dans les données utilisateur"
+            }
+          }
+          finally {
+            Remove-Item Env:NOETHYS_FROZEN_SMOKE -ErrorAction SilentlyContinue
+            $env:PATH = $savedPath
+            $env:PYTHONHOME = $savedPythonHome
+            $env:PYTHONPATH = $savedPythonPath
+            $env:APPDATA = $savedAppData
+            $env:LOCALAPPDATA = $savedLocalAppData
+          }
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -118,7 +118,11 @@ jobs:
             # donc les chemins Python/pip du PATH pour cette exécution.
             $env:PATH = "$env:SystemRoot\System32;$env:SystemRoot"
 
-            $process = Start-Process -FilePath $exe -Wait -PassThru
+            $process = Start-Process -FilePath $exe -PassThru
+            if (-not $process.WaitForExit(30000)) {
+              $process.Kill()
+              throw "Le smoke de l'exécutable figé n'a pas quitté sous 30 secondes"
+            }
             if ($process.ExitCode -ne 0) {
               throw "Smoke de l'exécutable figé en échec (code $($process.ExitCode))"
             }

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -61,11 +61,20 @@ jobs:
       - name: Construire le dossier portable
         run: pyinstaller --noconfirm --clean packaging/noethys.spec
 
-      - name: Vérifier la présence de l'exécutable
+      - name: Vérifier l'exécutable et le layout historique
         shell: pwsh
         run: |
           if (-not (Test-Path "dist/Noethys/Noethys.exe")) {
             throw "Noethys.exe absent du résultat PyInstaller"
+          }
+          foreach ($resource in @("Static", "Versions.txt", "Licence.txt", "Icone.ico")) {
+            $path = Join-Path "dist/Noethys" $resource
+            if (-not (Test-Path $path)) {
+              throw "Ressource attendue à côté de Noethys.exe absente : $resource"
+            }
+          }
+          if (Test-Path "dist/Noethys/_internal") {
+            throw "Layout PyInstaller 6 _internal détecté : incompatible avec Chemins.py historique"
           }
           Get-ChildItem "dist/Noethys" -Recurse | Measure-Object | Format-List
 
@@ -114,8 +123,6 @@ jobs:
             $env:LOCALAPPDATA = Join-Path $profileRoot "Local"
             New-Item -ItemType Directory -Path $env:APPDATA -Force | Out-Null
             New-Item -ItemType Directory -Path $env:LOCALAPPDATA -Force | Out-Null
-            # Le bundle doit trouver son Python et ses DLL localement. On retire
-            # donc les chemins Python/pip du PATH pour cette exécution.
             $env:PATH = "$env:SystemRoot\System32;$env:SystemRoot"
 
             $process = Start-Process -FilePath $exe -PassThru
@@ -123,9 +130,17 @@ jobs:
               $process.Kill()
               throw "Le smoke de l'exécutable figé n'a pas quitté sous 30 secondes"
             }
+
+            $errorMarker = Join-Path $testRoot "FROZEN-SMOKE-ERROR.txt"
+            $okMarker = Join-Path $testRoot "FROZEN-SMOKE-OK.txt"
             if ($process.ExitCode -ne 0) {
+              if (Test-Path $errorMarker) { Get-Content $errorMarker | Write-Error }
               throw "Smoke de l'exécutable figé en échec (code $($process.ExitCode))"
             }
+            if (-not (Test-Path $okMarker)) {
+              throw "Le smoke a quitté avec succès sans produire son marqueur de validation"
+            }
+            Get-Content $okMarker
 
             if (Test-Path (Join-Path $env:APPDATA "noethys")) {
               throw "Le smoke figé a écrit dans la configuration utilisateur"

--- a/docs/NOE-040-WINDOWS-PACKAGING.md
+++ b/docs/NOE-040-WINDOWS-PACKAGING.md
@@ -1,0 +1,69 @@
+# Noe-040 — Packaging Windows final
+
+## Baseline
+
+Le portable Windows est construit avec :
+
+- Python 3.10 ;
+- wxPython Phoenix ;
+- PyInstaller 6.x en mode `onedir` ;
+- `packaging/noethys.spec` ;
+- toutes les dépendances de `requirements-build.txt`.
+
+Le résultat est une archive `Noethys-Windows-portable.zip` contenant `Noethys.exe`, les bibliothèques embarquées et les ressources Noethys nécessaires.
+
+## Contrôles avant build
+
+Le workflow vérifie avant PyInstaller :
+
+- compilation du code Python ;
+- piles fonctionnelles optionnelles ;
+- génération PDF Unicode ;
+- ressources essentielles et destinations définies dans la spec.
+
+## Contrôle du véritable exécutable
+
+La qualification ne s'arrête plus à la présence de `Noethys.exe`.
+
+Après construction :
+
+1. le dossier est archivé ;
+2. l'archive est extraite dans un répertoire neuf du runner ;
+3. `PYTHONHOME` et `PYTHONPATH` sont vidés ;
+4. les chemins Python/pip sont retirés du `PATH` ;
+5. `Noethys.exe` est réellement lancé avec `NOETHYS_FROZEN_SMOKE=1` ;
+6. un runtime hook vérifie que l'application est bien figée, que les ressources essentielles existent et que plusieurs dépendances critiques sont importables depuis le bundle ;
+7. le processus doit sortir avec le code 0 ;
+8. le smoke doit n'avoir créé aucun répertoire de configuration/données Noethys dans le profil Windows de test.
+
+Le mode smoke s'arrête **avant** l'exécution de `Noethys.py` : il ne sélectionne, n'ouvre et ne migre donc aucune base utilisateur.
+
+## Piles vérifiées depuis le bundle
+
+Le smoke figé charge notamment :
+
+- wxPython ;
+- Pillow ;
+- ReportLab ;
+- python-dateutil / pytz ;
+- lxml ;
+- `mysql.connector` ;
+- `MySQLdb` / mysqlclient ;
+- PyCryptodome ;
+- cryptography ;
+- requests.
+
+Ce contrôle complète les smoke tests fonctionnels exécutés avant le build.
+
+## Identification du build
+
+`BUILD-INFO.txt` est inclus dans le dossier portable avec :
+
+- le commit Git ;
+- la version Python ;
+- l'identifiant du workflow ;
+- la date UTC du build.
+
+## Limite volontaire
+
+Cette qualification prouve qu'une archive extraite lance son Python embarqué et retrouve ses ressources/dépendances sans utiliser l'environnement Python du runner. Elle ne remplace pas la recette métier Noe-030 sur une copie de base réelle.

--- a/docs/PACKAGING-WINDOWS11.md
+++ b/docs/PACKAGING-WINDOWS11.md
@@ -2,32 +2,35 @@
 
 ## Statut
 
-Le chantier de modernisation est désormais intégré progressivement **directement dans `master`**. La PR #2 reste ouverte uniquement comme réservoir historique de lots à extraire ; elle ne doit pas être fusionnée en bloc.
+Le chantier de modernisation est intégré progressivement dans `master`.
 
-Ce document décrit donc la chaîne de packaging réellement présente dans `master` et les validations encore nécessaires avant une RC.
+Ce document décrit la chaîne de packaging Windows réellement utilisée et les validations encore nécessaires avant une RC.
 
 ## Objectif
 
-Produire et qualifier un dossier portable Noethys pour Windows avec Python 3.10, wxPython 4 et PyInstaller, sans migration implicite du schéma de base de données et sans remplacer immédiatement l'ancien `setup.py`.
+Produire et qualifier un dossier autonome Noethys pour Windows avec Python 3.10, wxPython Phoenix et PyInstaller, sans migration implicite du schéma de base de données et sans remplacer immédiatement l'ancien `setup.py`.
 
-La cible de recette utilisateur prioritaire reste Windows 11. Le code source demeure toutefois multi-plateforme et la CI valide également le socle sur Linux et macOS.
+Windows reste la cible de distribution prioritaire. Le code source demeure multi-plateforme et la CI valide également le socle sous Linux GTK3 et macOS.
 
 ## État actuel
 
-La chaîne de fabrication PyInstaller `onedir` fonctionne sur `master` :
+La chaîne PyInstaller `onedir` couvre :
 
-- installation des dépendances de fabrication : validée ;
-- compilation des sources : validée ;
-- imports des piles fonctionnelles optionnelles : validés ;
-- génération PDF ReportLab Unicode : validée ;
-- ressources essentielles PyInstaller : validées ;
-- construction de `Noethys.exe` : validée ;
-- création de l'archive portable : validée ;
-- publication de l'artefact GitHub Actions : validée.
+- installation des dépendances de fabrication ;
+- compilation des sources ;
+- imports des piles fonctionnelles optionnelles ;
+- génération PDF ReportLab Unicode ;
+- ressources essentielles PyInstaller ;
+- construction de `Noethys.exe` ;
+- création de l'archive ;
+- **extraction dans un répertoire neuf et exécution réelle de `Noethys.exe`** ;
+- publication de l'artefact GitHub Actions.
 
-Chaque build contient désormais un fichier `BUILD-INFO.txt` indiquant notamment le SHA Git, la version Python, l'identifiant du run GitHub Actions et la date UTC de fabrication. Cela permet d'identifier sans ambiguïté le code contenu dans une archive de recette.
+Chaque build contient `BUILD-INFO.txt` avec le SHA Git, la version Python, l'identifiant du run GitHub Actions et la date UTC de fabrication.
 
-Un build réussi valide la chaîne de fabrication, **pas encore la compatibilité fonctionnelle complète** : une recette sur poste Windows avec une copie de base réelle reste obligatoire avant RC.
+Le smoke de l'exécutable figé neutralise `PYTHONHOME` et `PYTHONPATH`, retire les chemins Python/pip du `PATH`, vérifie les ressources et plusieurs dépendances critiques depuis le bundle puis quitte avant l'ouverture de la configuration ou d'une base utilisateur. Il vérifie également qu'aucun répertoire Noethys n'a été créé dans le profil Windows de test.
+
+Cela valide l'autonomie technique du bundle. Une recette métier sur poste Windows avec une copie de base réelle reste obligatoire avant RC.
 
 ## Stratégie de packaging
 
@@ -41,27 +44,25 @@ Le résultat reste volontairement un dossier `onedir` :
 
 Le workflow `Package Windows` publie un artefact nommé `Noethys-Windows-portable`. Son archive contient `Noethys.exe`, les ressources nécessaires et `BUILD-INFO.txt`.
 
-Le `.spec` doit rester sélectif : les suites de tests et backends inutiles des dépendances ne doivent pas être embarqués dans l'application portable lorsqu'ils ne sont pas nécessaires au runtime.
+Le `.spec` reste sélectif : les suites de tests et backends inutiles des dépendances ne doivent pas être embarqués lorsqu'ils ne sont pas nécessaires au runtime.
 
 ## CI et contrôles automatisés
 
 La CI couvre notamment :
 
-- compatibilité Python 3 et API modernes ;
-- frontières `bytes` / `str` ;
-- encodages texte et UTF-8 ;
-- CSV, JSON et XML ;
+- Python 3 et APIs modernisées ;
+- frontières `bytes` / `str`, CSV et UTF-8 ;
 - chemins de fichiers et SQLite ;
-- parsing fragile des dates ;
-- arguments numériques wxPython ;
+- parsing des dates ;
+- arguments wxPython ;
 - imports dynamiques et risques PyInstaller ;
 - ressources embarquées ;
-- dépendances utilisées ;
-- Pillow ;
-- génération PDF ReportLab avec Unicode ;
-- modules métier critiques ;
+- Pillow et ReportLab Unicode ;
+- modules métier critiques et suite de non-régression ;
+- sauvegarde/restauration ;
 - absence de migration implicite du schéma ;
-- smoke-tests Windows et macOS.
+- smoke tests wx sous Windows, macOS et Linux GTK3 ;
+- lancement réel du bundle Windows extrait, sans environnement Python externe.
 
 La règle reste de corriger les défauts confirmés, sans transformation massive fondée uniquement sur un motif statique.
 
@@ -81,26 +82,26 @@ Depuis `master` :
 
 1. vérifier que la CI du SHA à qualifier est verte ;
 2. ouvrir GitHub Actions > `Package Windows` ;
-3. lancer un nouveau run si le workflow n'a pas déjà été déclenché par une modification de packaging ;
+3. lancer un nouveau run si le workflow n'a pas déjà été déclenché ;
 4. vérifier le SHA utilisé par le run ;
-5. laisser les smoke-tests puis PyInstaller s'exécuter ;
-6. vérifier la présence de `Noethys.exe` ;
+5. laisser les smoke tests puis PyInstaller s'exécuter ;
+6. vérifier que l'étape **Tester l'archive extraite sans environnement Python** est verte ;
 7. récupérer l'artefact `Noethys-Windows-portable` ;
-8. ouvrir `BUILD-INFO.txt` et vérifier que le SHA correspond bien à la révision à tester ;
+8. ouvrir `BUILD-INFO.txt` et vérifier le SHA ;
 9. conserver les logs du run en cas d'échec runtime.
 
-Ne pas utiliser un ancien `Re-run jobs` pour qualifier une nouvelle révision : GitHub reconstruit alors le SHA du run initial.
+Ne pas utiliser un ancien `Re-run jobs` pour qualifier une nouvelle révision : GitHub reconstruirait le SHA du run initial.
 
 ## Recette Windows attendue
 
-Sur un poste Windows 11 et avec une **copie** d'une base réelle :
+Sur un poste Windows et avec une **copie** d'une base réelle :
 
-1. extraire entièrement l'archive portable ;
+1. extraire entièrement l'archive ;
 2. contrôler `BUILD-INFO.txt` ;
-3. lancer `Noethys.exe` ;
-4. vérifier le démarrage sans DLL, module ou ressource manquante ;
+3. lancer `Noethys.exe` normalement ;
+4. vérifier l'affichage réel de l'interface ;
 5. ouvrir une copie d'une base existante ;
-6. parcourir les zones principales : familles, individus, inscriptions, facturation, règlements et comptabilité ;
+6. parcourir familles, individus, inscriptions, facturation, règlements et comptabilité ;
 7. tester au moins une édition ou impression PDF ;
 8. tester les exports utiles et les chemins comportant espaces ou accents ;
 9. tester, si utilisée, la synchronisation portail et son mode FTP/FTPS/SFTP ;
@@ -115,8 +116,9 @@ Une RC ne doit pas être déclarée uniquement parce que la CI et PyInstaller so
 
 - CI verte sur le SHA retenu ;
 - packaging Windows réussi sur ce même SHA ;
+- **exécution réussie de l'archive extraite sans Python externe** ;
 - artefact traçable contenant l'exécutable et ses ressources ;
-- démarrage réel sous Windows 11 ;
+- ouverture manuelle de l'interface sur un poste Windows ;
 - ouverture d'une copie de base existante ;
 - recette minimale des modules critiques ;
 - confirmation qu'aucune migration implicite de base n'a été introduite ;
@@ -124,9 +126,9 @@ Une RC ne doit pas être déclarée uniquement parce que la CI et PyInstaller so
 
 ## Risques restant à qualifier humainement
 
-Même après un build PyInstaller réussi, les principaux risques runtime sont désormais surtout :
+Après les contrôles automatisés, les risques runtime restants sont principalement :
 
-- comportements wxPython qui n'apparaissent qu'à l'ouverture de certains dialogues ;
+- comportements wxPython propres à certains dialogues ;
 - impressions et périphériques ;
 - accès réseau et bases distantes ;
 - données historiques atypiques ;

--- a/packaging/noethys.spec
+++ b/packaging/noethys.spec
@@ -46,8 +46,8 @@ for package in (
     hiddenimports += collect_runtime_submodules(package)
 
 # Chemins.py recherche ces ressources à côté de Noethys.exe lorsque
-# l'application est figée. Elles doivent donc être placées à la racine
-# du dossier portable, et non dans un sous-répertoire noethys/.
+# l'application est figée. Le bundle onedir doit donc conserver une racine
+# plate, comme les distributions historiques de Noethys.
 datas = [
     (str(NOETHYS / "Static"), "Static"),
     (str(NOETHYS / "Versions.txt"), "."),
@@ -91,6 +91,10 @@ exe = EXE(
     [],
     exclude_binaries=True,
     name="Noethys",
+    # PyInstaller 6 place par défaut les fichiers de support dans `_internal`.
+    # Noethys résout historiquement ses ressources depuis le dossier de l'EXE ;
+    # `.` restaure le layout onedir plat attendu par Chemins.py.
+    contents_directory=".",
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,

--- a/packaging/noethys.spec
+++ b/packaging/noethys.spec
@@ -59,6 +59,9 @@ datas += collect_data_files("pytz")
 datas += collect_data_files("reportlab")
 
 runtime_hooks = [
+    # Le smoke figé doit être premier : en mode de qualification il valide le
+    # bundle puis quitte avant tout accès à la configuration/base utilisateur.
+    str(ROOT / "packaging" / "runtime_frozen_smoke.py"),
     str(ROOT / "packaging" / "runtime_wx_compat.py"),
     str(ROOT / "packaging" / "runtime_wx_text_compat.py"),
     str(ROOT / "packaging" / "runtime_wx_list_width_compat.py"),

--- a/packaging/runtime_frozen_smoke.py
+++ b/packaging/runtime_frozen_smoke.py
@@ -4,8 +4,12 @@
 Ce runtime hook ne fait strictement rien en usage normal. Quand
 ``NOETHYS_FROZEN_SMOKE=1`` est défini, il valide que l'exécutable est réellement
 figé, que ses ressources essentielles sont présentes et que plusieurs piles
-runtime critiques sont importables depuis le bundle. Il quitte ensuite avec un
-code 0 avant que Noethys n'ouvre une configuration ou une base utilisateur.
+runtime critiques sont importables depuis le bundle. Il quitte ensuite avant
+que Noethys n'ouvre une configuration ou une base utilisateur.
+
+Le hook utilise ``os._exit`` en mode smoke afin qu'un échec dans une application
+PyInstaller ``console=False`` ne puisse pas ouvrir une boîte de dialogue fatale
+et laisser la CI bloquée en attente d'une interaction humaine.
 """
 from __future__ import annotations
 
@@ -15,11 +19,20 @@ import sys
 from pathlib import Path
 
 
-if os.environ.get("NOETHYS_FROZEN_SMOKE") == "1":
-    if not getattr(sys, "frozen", False):
-        raise RuntimeError("Le smoke NOETHYS_FROZEN_SMOKE exige un exécutable figé")
+def _finish(root: Path, code: int, message: str) -> None:
+    marker = root / ("FROZEN-SMOKE-OK.txt" if code == 0 else "FROZEN-SMOKE-ERROR.txt")
+    try:
+        marker.write_text(message + "\n", encoding="utf-8")
+    finally:
+        os._exit(code)
 
+
+if os.environ.get("NOETHYS_FROZEN_SMOKE") == "1":
     root = Path(sys.executable).resolve().parent
+
+    if not getattr(sys, "frozen", False):
+        _finish(root, 2, "Le smoke NOETHYS_FROZEN_SMOKE exige un exécutable figé")
+
     required = (
         root / "Static",
         root / "Versions.txt",
@@ -28,7 +41,7 @@ if os.environ.get("NOETHYS_FROZEN_SMOKE") == "1":
     )
     missing = [str(path) for path in required if not path.exists()]
     if missing:
-        raise RuntimeError("Ressources du bundle absentes: %s" % ", ".join(missing))
+        _finish(root, 3, "Ressources du bundle absentes: %s" % ", ".join(missing))
 
     # Imports représentatifs des fonctions critiques et de leurs modules natifs.
     # Aucun de ces imports ne doit ouvrir une base, créer wx.App ou écrire la
@@ -47,6 +60,14 @@ if os.environ.get("NOETHYS_FROZEN_SMOKE") == "1":
         "requests",
     )
     for module_name in modules:
-        importlib.import_module(module_name)
+        try:
+            importlib.import_module(module_name)
+        except Exception as exc:
+            _finish(
+                root,
+                4,
+                "Import figé en échec pour %s: %s: %s"
+                % (module_name, type(exc).__name__, exc),
+            )
 
-    raise SystemExit(0)
+    _finish(root, 0, "Bundle figé Noethys validé")

--- a/packaging/runtime_frozen_smoke.py
+++ b/packaging/runtime_frozen_smoke.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""Smoke test du bundle PyInstaller avant l'exécution de Noethys.py.
+
+Ce runtime hook ne fait strictement rien en usage normal. Quand
+``NOETHYS_FROZEN_SMOKE=1`` est défini, il valide que l'exécutable est réellement
+figé, que ses ressources essentielles sont présentes et que plusieurs piles
+runtime critiques sont importables depuis le bundle. Il quitte ensuite avec un
+code 0 avant que Noethys n'ouvre une configuration ou une base utilisateur.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+
+if os.environ.get("NOETHYS_FROZEN_SMOKE") == "1":
+    if not getattr(sys, "frozen", False):
+        raise RuntimeError("Le smoke NOETHYS_FROZEN_SMOKE exige un exécutable figé")
+
+    root = Path(sys.executable).resolve().parent
+    required = (
+        root / "Static",
+        root / "Versions.txt",
+        root / "Licence.txt",
+        root / "Icone.ico",
+    )
+    missing = [str(path) for path in required if not path.exists()]
+    if missing:
+        raise RuntimeError("Ressources du bundle absentes: %s" % ", ".join(missing))
+
+    # Imports représentatifs des fonctions critiques et de leurs modules natifs.
+    # Aucun de ces imports ne doit ouvrir une base, créer wx.App ou écrire la
+    # configuration utilisateur.
+    modules = (
+        "wx",
+        "PIL.Image",
+        "reportlab.pdfgen.canvas",
+        "dateutil.parser",
+        "pytz",
+        "lxml.etree",
+        "mysql.connector",
+        "MySQLdb",
+        "Crypto.Hash.SHA256",
+        "cryptography",
+        "requests",
+    )
+    for module_name in modules:
+        importlib.import_module(module_name)
+
+    raise SystemExit(0)


### PR DESCRIPTION
Renforce le packaging Windows final :
- ajoute un smoke PyInstaller isolé via runtime hook, sans ouverture de base/config ;
- construit puis archive le portable ;
- ré-extrait l'archive dans un répertoire neuf ;
- neutralise `PYTHONHOME`, `PYTHONPATH` et les chemins Python du `PATH` ;
- exécute réellement `Noethys.exe` et exige un code de sortie 0 ;
- vérifie ressources et imports critiques depuis le bundle ;
- vérifie que le smoke n'écrit pas de configuration utilisateur ;
- documente précisément la portée de la qualification.

Aucune migration de schéma et aucun accès à une base utilisateur.

Issue : #17