### PR TITLE
Noe-041: make the Windows artifact truly portable

### DIFF
--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   package:
-    name: Construire Noethys portable
+    name: Construire et exécuter Noethys portable
     runs-on: windows-latest
     timeout-minutes: 45
 
@@ -84,6 +84,60 @@ jobs:
       - name: Créer l'archive portable
         shell: pwsh
         run: Compress-Archive -Path "dist/Noethys/*" -DestinationPath "Noethys-Windows-portable.zip"
+
+      - name: Tester l'archive extraite sans environnement Python
+        shell: pwsh
+        run: |
+          $testRoot = Join-Path $env:RUNNER_TEMP "noethys-frozen-smoke"
+          $profileRoot = Join-Path $env:RUNNER_TEMP "noethys-frozen-profile"
+          Remove-Item $testRoot -Recurse -Force -ErrorAction SilentlyContinue
+          Remove-Item $profileRoot -Recurse -Force -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Path $testRoot | Out-Null
+          New-Item -ItemType Directory -Path $profileRoot | Out-Null
+          Expand-Archive -Path "Noethys-Windows-portable.zip" -DestinationPath $testRoot
+
+          $exe = Join-Path $testRoot "Noethys.exe"
+          if (-not (Test-Path $exe)) {
+            throw "Noethys.exe absent de l'archive extraite"
+          }
+
+          $savedPath = $env:PATH
+          $savedPythonHome = $env:PYTHONHOME
+          $savedPythonPath = $env:PYTHONPATH
+          $savedAppData = $env:APPDATA
+          $savedLocalAppData = $env:LOCALAPPDATA
+          try {
+            $env:NOETHYS_FROZEN_SMOKE = "1"
+            $env:PYTHONHOME = ""
+            $env:PYTHONPATH = ""
+            $env:APPDATA = Join-Path $profileRoot "Roaming"
+            $env:LOCALAPPDATA = Join-Path $profileRoot "Local"
+            New-Item -ItemType Directory -Path $env:APPDATA -Force | Out-Null
+            New-Item -ItemType Directory -Path $env:LOCALAPPDATA -Force | Out-Null
+            # Le bundle doit trouver son Python et ses DLL localement. On retire
+            # donc les chemins Python/pip du PATH pour cette exécution.
+            $env:PATH = "$env:SystemRoot\System32;$env:SystemRoot"
+
+            $process = Start-Process -FilePath $exe -Wait -PassThru
+            if ($process.ExitCode -ne 0) {
+              throw "Smoke de l'exécutable figé en échec (code $($process.ExitCode))"
+            }
+
+            if (Test-Path (Join-Path $env:APPDATA "noethys")) {
+              throw "Le smoke figé a écrit dans la configuration utilisateur"
+            }
+            if (Test-Path (Join-Path $env:LOCALAPPDATA "noethys")) {
+              throw "Le smoke figé a écrit dans les données utilisateur"
+            }
+          }
+          finally {
+            Remove-Item Env:NOETHYS_FROZEN_SMOKE -ErrorAction SilentlyContinue
+            $env:PATH = $savedPath
+            $env:PYTHONHOME = $savedPythonHome
+            $env:PYTHONPATH = $savedPythonPath
+            $env:APPDATA = $savedAppData
+            $env:LOCALAPPDATA = $savedLocalAppData
+          }
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -118,7 +118,11 @@ jobs:
             # donc les chemins Python/pip du PATH pour cette exécution.
             $env:PATH = "$env:SystemRoot\System32;$env:SystemRoot"
 
-            $process = Start-Process -FilePath $exe -Wait -PassThru
+            $process = Start-Process -FilePath $exe -PassThru
+            if (-not $process.WaitForExit(30000)) {
+              $process.Kill()
+              throw "Le smoke de l'exécutable figé n'a pas quitté sous 30 secondes"
+            }
             if ($process.ExitCode -ne 0) {
               throw "Smoke de l'exécutable figé en échec (code $($process.ExitCode))"
             }

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -61,11 +61,20 @@ jobs:
       - name: Construire le dossier portable
         run: pyinstaller --noconfirm --clean packaging/noethys.spec
 
-      - name: Vérifier la présence de l'exécutable
+      - name: Vérifier l'exécutable et le layout historique
         shell: pwsh
         run: |
           if (-not (Test-Path "dist/Noethys/Noethys.exe")) {
             throw "Noethys.exe absent du résultat PyInstaller"
+          }
+          foreach ($resource in @("Static", "Versions.txt", "Licence.txt", "Icone.ico")) {
+            $path = Join-Path "dist/Noethys" $resource
+            if (-not (Test-Path $path)) {
+              throw "Ressource attendue à côté de Noethys.exe absente : $resource"
+            }
+          }
+          if (Test-Path "dist/Noethys/_internal") {
+            throw "Layout PyInstaller 6 _internal détecté : incompatible avec Chemins.py historique"
           }
           Get-ChildItem "dist/Noethys" -Recurse | Measure-Object | Format-List
 
@@ -124,8 +133,6 @@ jobs:
             $env:LOCALAPPDATA = Join-Path $profileRoot "Local"
             New-Item -ItemType Directory -Path $env:APPDATA -Force | Out-Null
             New-Item -ItemType Directory -Path $env:LOCALAPPDATA -Force | Out-Null
-            # Le bundle doit trouver son Python et ses DLL localement. On retire
-            # donc les chemins Python/pip du PATH pour cette exécution.
             $env:PATH = "$env:SystemRoot\System32;$env:SystemRoot"
 
             $process = Start-Process -FilePath $exe -PassThru
@@ -133,9 +140,17 @@ jobs:
               $process.Kill()
               throw "Le smoke de l'exécutable figé n'a pas quitté sous 30 secondes"
             }
+
+            $errorMarker = Join-Path $testRoot "FROZEN-SMOKE-ERROR.txt"
+            $okMarker = Join-Path $testRoot "FROZEN-SMOKE-OK.txt"
             if ($process.ExitCode -ne 0) {
+              if (Test-Path $errorMarker) { Get-Content $errorMarker | Write-Error }
               throw "Smoke de l'exécutable figé en échec (code $($process.ExitCode))"
             }
+            if (-not (Test-Path $okMarker)) {
+              throw "Le smoke a quitté avec succès sans produire son marqueur de validation"
+            }
+            Get-Content $okMarker
 
             if (Test-Path (Join-Path $env:APPDATA "noethys")) {
               throw "Le smoke figé a écrit dans la configuration utilisateur"

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -69,6 +69,12 @@ jobs:
           }
           Get-ChildItem "dist/Noethys" -Recurse | Measure-Object | Format-List
 
+      - name: Activer l'isolation portable
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path "dist/Noethys/Portable" -Force | Out-Null
+          Copy-Item "packaging/portable/README.txt" "dist/Noethys/Portable/README.txt"
+
       - name: Écrire les informations de build
         shell: pwsh
         run: |
@@ -78,6 +84,7 @@ jobs:
             "Commit: $env:GITHUB_SHA"
             "Python: $pythonVersion"
             "Workflow run: $env:GITHUB_RUN_ID"
+            "Portable mode: enabled (Portable/)"
             "Build UTC: $([DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ'))"
           ) | Set-Content -Path "dist/Noethys/BUILD-INFO.txt" -Encoding UTF8
 
@@ -99,6 +106,9 @@ jobs:
           $exe = Join-Path $testRoot "Noethys.exe"
           if (-not (Test-Path $exe)) {
             throw "Noethys.exe absent de l'archive extraite"
+          }
+          if (-not (Test-Path (Join-Path $testRoot "Portable/README.txt"))) {
+            throw "Marqueur Portable absent de l'archive extraite"
           }
 
           $savedPath = $env:PATH

--- a/docs/NOE-040-WINDOWS-PACKAGING.md
+++ b/docs/NOE-040-WINDOWS-PACKAGING.md
@@ -1,0 +1,69 @@
+# Noe-040 — Packaging Windows final
+
+## Baseline
+
+Le portable Windows est construit avec :
+
+- Python 3.10 ;
+- wxPython Phoenix ;
+- PyInstaller 6.x en mode `onedir` ;
+- `packaging/noethys.spec` ;
+- toutes les dépendances de `requirements-build.txt`.
+
+Le résultat est une archive `Noethys-Windows-portable.zip` contenant `Noethys.exe`, les bibliothèques embarquées et les ressources Noethys nécessaires.
+
+## Contrôles avant build
+
+Le workflow vérifie avant PyInstaller :
+
+- compilation du code Python ;
+- piles fonctionnelles optionnelles ;
+- génération PDF Unicode ;
+- ressources essentielles et destinations définies dans la spec.
+
+## Contrôle du véritable exécutable
+
+La qualification ne s'arrête plus à la présence de `Noethys.exe`.
+
+Après construction :
+
+1. le dossier est archivé ;
+2. l'archive est extraite dans un répertoire neuf du runner ;
+3. `PYTHONHOME` et `PYTHONPATH` sont vidés ;
+4. les chemins Python/pip sont retirés du `PATH` ;
+5. `Noethys.exe` est réellement lancé avec `NOETHYS_FROZEN_SMOKE=1` ;
+6. un runtime hook vérifie que l'application est bien figée, que les ressources essentielles existent et que plusieurs dépendances critiques sont importables depuis le bundle ;
+7. le processus doit sortir avec le code 0 ;
+8. le smoke doit n'avoir créé aucun répertoire de configuration/données Noethys dans le profil Windows de test.
+
+Le mode smoke s'arrête **avant** l'exécution de `Noethys.py` : il ne sélectionne, n'ouvre et ne migre donc aucune base utilisateur.
+
+## Piles vérifiées depuis le bundle
+
+Le smoke figé charge notamment :
+
+- wxPython ;
+- Pillow ;
+- ReportLab ;
+- python-dateutil / pytz ;
+- lxml ;
+- `mysql.connector` ;
+- `MySQLdb` / mysqlclient ;
+- PyCryptodome ;
+- cryptography ;
+- requests.
+
+Ce contrôle complète les smoke tests fonctionnels exécutés avant le build.
+
+## Identification du build
+
+`BUILD-INFO.txt` est inclus dans le dossier portable avec :
+
+- le commit Git ;
+- la version Python ;
+- l'identifiant du workflow ;
+- la date UTC du build.
+
+## Limite volontaire
+
+Cette qualification prouve qu'une archive extraite lance son Python embarqué et retrouve ses ressources/dépendances sans utiliser l'environnement Python du runner. Elle ne remplace pas la recette métier Noe-030 sur une copie de base réelle.

--- a/docs/NOE-041-MODE-PORTABLE.md
+++ b/docs/NOE-041-MODE-PORTABLE.md
@@ -1,0 +1,75 @@
+# Noe-041 — Mode portable Noethys
+
+## Fonctionnement historique conservé
+
+Noethys possède déjà un mécanisme de mode portable : lorsque le dossier `Portable` existe à côté de `Noethys.exe`, `UTILS_Fichiers` redirige la configuration et les données vers ce dossier au lieu d'utiliser les emplacements du profil utilisateur Windows.
+
+Le packaging moderne active désormais explicitement ce mécanisme dans l'archive `Noethys-Windows-portable.zip`.
+
+## Arborescence
+
+Une archive fraîche contient notamment :
+
+```text
+Noethys.exe
+BUILD-INFO.txt
+Static/
+Portable/
+  README.txt
+```
+
+À l'utilisation, les sous-dossiers nécessaires sont créés à la demande :
+
+```text
+Portable/
+  Config.json
+  Customize.ini
+  journal.log
+  Data/
+  Temp/
+  Updates/
+  Lang/
+  Sync/
+  Extensions/
+```
+
+## Isolation
+
+En mode portable :
+
+- `GetRepUtilisateur()` pointe dans `Portable/` ;
+- `GetRepData()` pointe dans `Portable/Data/` ;
+- les répertoires temporaires, mises à jour, langues, synchronisation et extensions sont créés sous `Portable/` ;
+- le mécanisme `appdirs` normal n'est pas utilisé pour ces chemins.
+
+La présence du dossier `Portable` reste le déclencheur historique. Les installations classiques sans ce dossier conservent donc leur comportement habituel.
+
+## Mise à jour d'un portable existant
+
+Ne jamais supprimer le dossier `Portable` lors d'une mise à jour : il peut contenir la configuration et les bases locales.
+
+La méthode prudente est :
+
+1. sauvegarder le dossier portable existant ;
+2. extraire la nouvelle version dans un nouveau dossier ;
+3. pour une recette, copier uniquement une **copie** des données nécessaires ;
+4. valider la nouvelle version avant de remplacer l'ancien dossier applicatif.
+
+## Recette avec base réelle
+
+Pour Noe-030 et la future RC :
+
+- travailler sur une copie de la base ;
+- placer cette copie dans `Portable/Data/` si la recette est locale ;
+- conserver l'original hors du portable de test ;
+- après recette, vérifier l'absence de changement de schéma inattendu avec l'outil Noe-030.
+
+## Couverture automatisée
+
+`tests/test_noe_041_portable_paths.py` vérifie que :
+
+- la présence de `Portable/` redirige bien configuration et données ;
+- `Data`, `Temp`, `Updates`, `Lang`, `Sync` et `Extensions` sont créés à la demande ;
+- les chemins `appdirs` ne sont pas utilisés en mode portable.
+
+Le workflow Windows vérifie également que le marqueur portable est présent après extraction de l'archive finale.

--- a/docs/PACKAGING-WINDOWS11.md
+++ b/docs/PACKAGING-WINDOWS11.md
@@ -2,32 +2,35 @@
 
 ## Statut
 
-Le chantier de modernisation est désormais intégré progressivement **directement dans `master`**. La PR #2 reste ouverte uniquement comme réservoir historique de lots à extraire ; elle ne doit pas être fusionnée en bloc.
+Le chantier de modernisation est intégré progressivement dans `master`.
 
-Ce document décrit donc la chaîne de packaging réellement présente dans `master` et les validations encore nécessaires avant une RC.
+Ce document décrit la chaîne de packaging Windows réellement utilisée et les validations encore nécessaires avant une RC.
 
 ## Objectif
 
-Produire et qualifier un dossier portable Noethys pour Windows avec Python 3.10, wxPython 4 et PyInstaller, sans migration implicite du schéma de base de données et sans remplacer immédiatement l'ancien `setup.py`.
+Produire et qualifier un dossier autonome Noethys pour Windows avec Python 3.10, wxPython Phoenix et PyInstaller, sans migration implicite du schéma de base de données et sans remplacer immédiatement l'ancien `setup.py`.
 
-La cible de recette utilisateur prioritaire reste Windows 11. Le code source demeure toutefois multi-plateforme et la CI valide également le socle sur Linux et macOS.
+Windows reste la cible de distribution prioritaire. Le code source demeure multi-plateforme et la CI valide également le socle sous Linux GTK3 et macOS.
 
 ## État actuel
 
-La chaîne de fabrication PyInstaller `onedir` fonctionne sur `master` :
+La chaîne PyInstaller `onedir` couvre :
 
-- installation des dépendances de fabrication : validée ;
-- compilation des sources : validée ;
-- imports des piles fonctionnelles optionnelles : validés ;
-- génération PDF ReportLab Unicode : validée ;
-- ressources essentielles PyInstaller : validées ;
-- construction de `Noethys.exe` : validée ;
-- création de l'archive portable : validée ;
-- publication de l'artefact GitHub Actions : validée.
+- installation des dépendances de fabrication ;
+- compilation des sources ;
+- imports des piles fonctionnelles optionnelles ;
+- génération PDF ReportLab Unicode ;
+- ressources essentielles PyInstaller ;
+- construction de `Noethys.exe` ;
+- création de l'archive ;
+- **extraction dans un répertoire neuf et exécution réelle de `Noethys.exe`** ;
+- publication de l'artefact GitHub Actions.
 
-Chaque build contient désormais un fichier `BUILD-INFO.txt` indiquant notamment le SHA Git, la version Python, l'identifiant du run GitHub Actions et la date UTC de fabrication. Cela permet d'identifier sans ambiguïté le code contenu dans une archive de recette.
+Chaque build contient `BUILD-INFO.txt` avec le SHA Git, la version Python, l'identifiant du run GitHub Actions et la date UTC de fabrication.
 
-Un build réussi valide la chaîne de fabrication, **pas encore la compatibilité fonctionnelle complète** : une recette sur poste Windows avec une copie de base réelle reste obligatoire avant RC.
+Le smoke de l'exécutable figé neutralise `PYTHONHOME` et `PYTHONPATH`, retire les chemins Python/pip du `PATH`, vérifie les ressources et plusieurs dépendances critiques depuis le bundle puis quitte avant l'ouverture de la configuration ou d'une base utilisateur. Il vérifie également qu'aucun répertoire Noethys n'a été créé dans le profil Windows de test.
+
+Cela valide l'autonomie technique du bundle. Une recette métier sur poste Windows avec une copie de base réelle reste obligatoire avant RC.
 
 ## Stratégie de packaging
 
@@ -41,27 +44,25 @@ Le résultat reste volontairement un dossier `onedir` :
 
 Le workflow `Package Windows` publie un artefact nommé `Noethys-Windows-portable`. Son archive contient `Noethys.exe`, les ressources nécessaires et `BUILD-INFO.txt`.
 
-Le `.spec` doit rester sélectif : les suites de tests et backends inutiles des dépendances ne doivent pas être embarqués dans l'application portable lorsqu'ils ne sont pas nécessaires au runtime.
+Le `.spec` reste sélectif : les suites de tests et backends inutiles des dépendances ne doivent pas être embarqués lorsqu'ils ne sont pas nécessaires au runtime.
 
 ## CI et contrôles automatisés
 
 La CI couvre notamment :
 
-- compatibilité Python 3 et API modernes ;
-- frontières `bytes` / `str` ;
-- encodages texte et UTF-8 ;
-- CSV, JSON et XML ;
+- Python 3 et APIs modernisées ;
+- frontières `bytes` / `str`, CSV et UTF-8 ;
 - chemins de fichiers et SQLite ;
-- parsing fragile des dates ;
-- arguments numériques wxPython ;
+- parsing des dates ;
+- arguments wxPython ;
 - imports dynamiques et risques PyInstaller ;
 - ressources embarquées ;
-- dépendances utilisées ;
-- Pillow ;
-- génération PDF ReportLab avec Unicode ;
-- modules métier critiques ;
+- Pillow et ReportLab Unicode ;
+- modules métier critiques et suite de non-régression ;
+- sauvegarde/restauration ;
 - absence de migration implicite du schéma ;
-- smoke-tests Windows et macOS.
+- smoke tests wx sous Windows, macOS et Linux GTK3 ;
+- lancement réel du bundle Windows extrait, sans environnement Python externe.
 
 La règle reste de corriger les défauts confirmés, sans transformation massive fondée uniquement sur un motif statique.
 
@@ -81,26 +82,26 @@ Depuis `master` :
 
 1. vérifier que la CI du SHA à qualifier est verte ;
 2. ouvrir GitHub Actions > `Package Windows` ;
-3. lancer un nouveau run si le workflow n'a pas déjà été déclenché par une modification de packaging ;
+3. lancer un nouveau run si le workflow n'a pas déjà été déclenché ;
 4. vérifier le SHA utilisé par le run ;
-5. laisser les smoke-tests puis PyInstaller s'exécuter ;
-6. vérifier la présence de `Noethys.exe` ;
+5. laisser les smoke tests puis PyInstaller s'exécuter ;
+6. vérifier que l'étape **Tester l'archive extraite sans environnement Python** est verte ;
 7. récupérer l'artefact `Noethys-Windows-portable` ;
-8. ouvrir `BUILD-INFO.txt` et vérifier que le SHA correspond bien à la révision à tester ;
+8. ouvrir `BUILD-INFO.txt` et vérifier le SHA ;
 9. conserver les logs du run en cas d'échec runtime.
 
-Ne pas utiliser un ancien `Re-run jobs` pour qualifier une nouvelle révision : GitHub reconstruit alors le SHA du run initial.
+Ne pas utiliser un ancien `Re-run jobs` pour qualifier une nouvelle révision : GitHub reconstruirait le SHA du run initial.
 
 ## Recette Windows attendue
 
-Sur un poste Windows 11 et avec une **copie** d'une base réelle :
+Sur un poste Windows et avec une **copie** d'une base réelle :
 
-1. extraire entièrement l'archive portable ;
+1. extraire entièrement l'archive ;
 2. contrôler `BUILD-INFO.txt` ;
-3. lancer `Noethys.exe` ;
-4. vérifier le démarrage sans DLL, module ou ressource manquante ;
+3. lancer `Noethys.exe` normalement ;
+4. vérifier l'affichage réel de l'interface ;
 5. ouvrir une copie d'une base existante ;
-6. parcourir les zones principales : familles, individus, inscriptions, facturation, règlements et comptabilité ;
+6. parcourir familles, individus, inscriptions, facturation, règlements et comptabilité ;
 7. tester au moins une édition ou impression PDF ;
 8. tester les exports utiles et les chemins comportant espaces ou accents ;
 9. tester, si utilisée, la synchronisation portail et son mode FTP/FTPS/SFTP ;
@@ -115,8 +116,9 @@ Une RC ne doit pas être déclarée uniquement parce que la CI et PyInstaller so
 
 - CI verte sur le SHA retenu ;
 - packaging Windows réussi sur ce même SHA ;
+- **exécution réussie de l'archive extraite sans Python externe** ;
 - artefact traçable contenant l'exécutable et ses ressources ;
-- démarrage réel sous Windows 11 ;
+- ouverture manuelle de l'interface sur un poste Windows ;
 - ouverture d'une copie de base existante ;
 - recette minimale des modules critiques ;
 - confirmation qu'aucune migration implicite de base n'a été introduite ;
@@ -124,9 +126,9 @@ Une RC ne doit pas être déclarée uniquement parce que la CI et PyInstaller so
 
 ## Risques restant à qualifier humainement
 
-Même après un build PyInstaller réussi, les principaux risques runtime sont désormais surtout :
+Après les contrôles automatisés, les risques runtime restants sont principalement :
 
-- comportements wxPython qui n'apparaissent qu'à l'ouverture de certains dialogues ;
+- comportements wxPython propres à certains dialogues ;
 - impressions et périphériques ;
 - accès réseau et bases distantes ;
 - données historiques atypiques ;

--- a/noethys/Utils/UTILS_Fichiers.py
+++ b/noethys/Utils/UTILS_Fichiers.py
@@ -19,13 +19,30 @@ import appdirs
 import six
 
 
-def GetRepData(fichier=""):
-    # Vérifie si un répertoire 'Portable' existe
+def _GetRepPortable():
+    """Retourne le répertoire portable historique lorsqu'il est activé."""
     chemin = Chemins.GetMainPath("Portable")
     if os.path.isdir(chemin):
-        chemin = os.path.join(chemin, "Data")
-        if not os.path.isdir(chemin):
-            os.mkdir(chemin)
+        return chemin
+    return None
+
+
+def _GetRepPortableSousDossier(nom):
+    """Crée à la demande un sous-dossier du mode portable déjà activé."""
+    racine = _GetRepPortable()
+    if racine is None:
+        return None
+    chemin = os.path.join(racine, nom)
+    if not os.path.isdir(chemin):
+        os.mkdir(chemin)
+    return chemin
+
+
+def GetRepData(fichier=""):
+    # Le mode portable historique est activé par la présence du dossier
+    # "Portable" à côté de Noethys.exe (ou de Noethys.py en mode source).
+    chemin = _GetRepPortableSousDossier("Data")
+    if chemin is not None:
         return os.path.join(chemin, fichier)
 
     # Recherche s'il existe un chemin personnalisé dans le Customize.ini
@@ -61,33 +78,40 @@ def GetRepData(fichier=""):
     return os.path.join(chemin, fichier)
 
 
-def GetRepTemp(fichier=""):
-    chemin = GetRepUtilisateur("Temp")
+def _GetRepUtilisateurSousDossier(nom, fichier=""):
+    chemin = _GetRepPortableSousDossier(nom)
+    if chemin is None:
+        chemin = GetRepUtilisateur(nom)
     return os.path.join(chemin, fichier)
+
+
+def GetRepTemp(fichier=""):
+    return _GetRepUtilisateurSousDossier("Temp", fichier)
+
 
 def GetRepUpdates(fichier=""):
-    chemin = GetRepUtilisateur("Updates")
-    return os.path.join(chemin, fichier)
+    return _GetRepUtilisateurSousDossier("Updates", fichier)
+
 
 def GetRepLang(fichier=""):
-    chemin = GetRepUtilisateur("Lang")
-    return os.path.join(chemin, fichier)
+    return _GetRepUtilisateurSousDossier("Lang", fichier)
+
 
 def GetRepSync(fichier=""):
-    chemin = GetRepUtilisateur("Sync")
-    return os.path.join(chemin, fichier)
+    return _GetRepUtilisateurSousDossier("Sync", fichier)
+
 
 def GetRepExtensions(fichier=""):
-    chemin = GetRepUtilisateur("Extensions")
-    return os.path.join(chemin, fichier)
+    return _GetRepUtilisateurSousDossier("Extensions", fichier)
+
 
 def GetRepUtilisateur(fichier=""):
     """ Recherche le répertoire Utilisateur pour stockage des fichiers de config et provisoires """
     chemin = None
 
     # Vérifie si un répertoire 'Portable' existe
-    chemin = Chemins.GetMainPath("Portable")
-    if os.path.isdir(chemin):
+    chemin = _GetRepPortable()
+    if chemin is not None:
         return os.path.join(chemin, fichier)
 
     # Recherche le chemin du répertoire de l'utilisateur
@@ -146,7 +170,7 @@ def DeplaceExemples():
         chemin = Chemins.GetStaticPath("Exemples")
         for nomFichier in os.listdir(chemin) :
             if nomFichier.endswith(".dat") and "EXEMPLE_" in nomFichier :
-                # Déplace le fichier vers le répertoire des fichiers de données
+                # Déplace le fichier exemple vers le répertoire des fichiers de données
                 shutil.copy(os.path.join(chemin, nomFichier), GetRepData(nomFichier))
 
 def OuvrirRepertoire(rep):

--- a/packaging/noethys.spec
+++ b/packaging/noethys.spec
@@ -59,6 +59,9 @@ datas += collect_data_files("pytz")
 datas += collect_data_files("reportlab")
 
 runtime_hooks = [
+    # Le smoke figé doit être premier : en mode de qualification il valide le
+    # bundle puis quitte avant tout accès à la configuration/base utilisateur.
+    str(ROOT / "packaging" / "runtime_frozen_smoke.py"),
     str(ROOT / "packaging" / "runtime_wx_compat.py"),
     str(ROOT / "packaging" / "runtime_wx_text_compat.py"),
     str(ROOT / "packaging" / "runtime_wx_list_width_compat.py"),

--- a/packaging/noethys.spec
+++ b/packaging/noethys.spec
@@ -25,8 +25,6 @@ def collect_runtime_submodules(package):
 
 
 hiddenimports = [
-    # Les backends réellement utilisés par Noethys. Le hook Matplotlib les
-    # détecte également via les appels matplotlib.use('Agg'/'wxagg').
     "matplotlib.backends.backend_agg",
     "matplotlib.backends.backend_wxagg",
 ]
@@ -46,8 +44,7 @@ for package in (
     hiddenimports += collect_runtime_submodules(package)
 
 # Chemins.py recherche ces ressources à côté de Noethys.exe lorsque
-# l'application est figée. Elles doivent donc être placées à la racine
-# du dossier portable, et non dans un sous-répertoire noethys/.
+# l'application est figée. Le bundle onedir conserve donc une racine plate.
 datas = [
     (str(NOETHYS / "Static"), "Static"),
     (str(NOETHYS / "Versions.txt"), "."),
@@ -59,8 +56,6 @@ datas += collect_data_files("pytz")
 datas += collect_data_files("reportlab")
 
 runtime_hooks = [
-    # Le smoke figé doit être premier : en mode de qualification il valide le
-    # bundle puis quitte avant tout accès à la configuration/base utilisateur.
     str(ROOT / "packaging" / "runtime_frozen_smoke.py"),
     str(ROOT / "packaging" / "runtime_wx_compat.py"),
     str(ROOT / "packaging" / "runtime_wx_text_compat.py"),
@@ -91,6 +86,7 @@ exe = EXE(
     [],
     exclude_binaries=True,
     name="Noethys",
+    contents_directory=".",
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,

--- a/packaging/portable/README.txt
+++ b/packaging/portable/README.txt
@@ -1,0 +1,15 @@
+NOETHYS - MODE PORTABLE
+=======================
+
+La présence de ce dossier active le mode portable historique de Noethys.
+
+Dans ce mode :
+- Config.json, Customize.ini et journal.log restent dans ce dossier Portable ;
+- les bases locales sont stockées dans Portable\Data ;
+- les dossiers Temp, Updates, Lang, Sync et Extensions sont créés ici à la demande ;
+- le profil Windows (AppData) n'est pas utilisé pour ces données Noethys.
+
+Pour une recette avec une base existante : travaillez uniquement sur une COPIE de la base.
+Ne déplacez jamais ici votre unique base de production pour tester une RC.
+
+Pour revenir au comportement utilisateur classique, utilisez une distribution sans dossier Portable ; ne supprimez pas ce dossier d'une installation qui contient déjà sa configuration ou ses bases sans les sauvegarder auparavant.

--- a/packaging/runtime_frozen_smoke.py
+++ b/packaging/runtime_frozen_smoke.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""Smoke test du bundle PyInstaller avant l'exécution de Noethys.py.
+
+Ce runtime hook ne fait strictement rien en usage normal. Quand
+``NOETHYS_FROZEN_SMOKE=1`` est défini, il valide que l'exécutable est réellement
+figé, que ses ressources essentielles sont présentes et que plusieurs piles
+runtime critiques sont importables depuis le bundle. Il quitte ensuite avec un
+code 0 avant que Noethys n'ouvre une configuration ou une base utilisateur.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+
+if os.environ.get("NOETHYS_FROZEN_SMOKE") == "1":
+    if not getattr(sys, "frozen", False):
+        raise RuntimeError("Le smoke NOETHYS_FROZEN_SMOKE exige un exécutable figé")
+
+    root = Path(sys.executable).resolve().parent
+    required = (
+        root / "Static",
+        root / "Versions.txt",
+        root / "Licence.txt",
+        root / "Icone.ico",
+    )
+    missing = [str(path) for path in required if not path.exists()]
+    if missing:
+        raise RuntimeError("Ressources du bundle absentes: %s" % ", ".join(missing))
+
+    # Imports représentatifs des fonctions critiques et de leurs modules natifs.
+    # Aucun de ces imports ne doit ouvrir une base, créer wx.App ou écrire la
+    # configuration utilisateur.
+    modules = (
+        "wx",
+        "PIL.Image",
+        "reportlab.pdfgen.canvas",
+        "dateutil.parser",
+        "pytz",
+        "lxml.etree",
+        "mysql.connector",
+        "MySQLdb",
+        "Crypto.Hash.SHA256",
+        "cryptography",
+        "requests",
+    )
+    for module_name in modules:
+        importlib.import_module(module_name)
+
+    raise SystemExit(0)

--- a/packaging/runtime_frozen_smoke.py
+++ b/packaging/runtime_frozen_smoke.py
@@ -1,12 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Smoke test du bundle PyInstaller avant l'exécution de Noethys.py.
-
-Ce runtime hook ne fait strictement rien en usage normal. Quand
-``NOETHYS_FROZEN_SMOKE=1`` est défini, il valide que l'exécutable est réellement
-figé, que ses ressources essentielles sont présentes et que plusieurs piles
-runtime critiques sont importables depuis le bundle. Il quitte ensuite avec un
-code 0 avant que Noethys n'ouvre une configuration ou une base utilisateur.
-"""
+"""Smoke test du bundle PyInstaller avant l'exécution de Noethys.py."""
 from __future__ import annotations
 
 import importlib
@@ -15,11 +8,19 @@ import sys
 from pathlib import Path
 
 
-if os.environ.get("NOETHYS_FROZEN_SMOKE") == "1":
-    if not getattr(sys, "frozen", False):
-        raise RuntimeError("Le smoke NOETHYS_FROZEN_SMOKE exige un exécutable figé")
+def _finish(root: Path, code: int, message: str) -> None:
+    marker = root / ("FROZEN-SMOKE-OK.txt" if code == 0 else "FROZEN-SMOKE-ERROR.txt")
+    try:
+        marker.write_text(message + "\n", encoding="utf-8")
+    finally:
+        os._exit(code)
 
+
+if os.environ.get("NOETHYS_FROZEN_SMOKE") == "1":
     root = Path(sys.executable).resolve().parent
+    if not getattr(sys, "frozen", False):
+        _finish(root, 2, "Le smoke NOETHYS_FROZEN_SMOKE exige un exécutable figé")
+
     required = (
         root / "Static",
         root / "Versions.txt",
@@ -28,11 +29,8 @@ if os.environ.get("NOETHYS_FROZEN_SMOKE") == "1":
     )
     missing = [str(path) for path in required if not path.exists()]
     if missing:
-        raise RuntimeError("Ressources du bundle absentes: %s" % ", ".join(missing))
+        _finish(root, 3, "Ressources du bundle absentes: %s" % ", ".join(missing))
 
-    # Imports représentatifs des fonctions critiques et de leurs modules natifs.
-    # Aucun de ces imports ne doit ouvrir une base, créer wx.App ou écrire la
-    # configuration utilisateur.
     modules = (
         "wx",
         "PIL.Image",
@@ -47,6 +45,14 @@ if os.environ.get("NOETHYS_FROZEN_SMOKE") == "1":
         "requests",
     )
     for module_name in modules:
-        importlib.import_module(module_name)
+        try:
+            importlib.import_module(module_name)
+        except Exception as exc:
+            _finish(
+                root,
+                4,
+                "Import figé en échec pour %s: %s: %s"
+                % (module_name, type(exc).__name__, exc),
+            )
 
-    raise SystemExit(0)
+    _finish(root, 0, "Bundle figé Noethys validé")

--- a/tests/test_noe_041_portable_paths.py
+++ b/tests/test_noe_041_portable_paths.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+
+def _load_utils_files(root):
+    chemins = types.ModuleType("Chemins")
+    chemins.GetMainPath = lambda fichier="": str(Path(root) / fichier)
+    chemins.GetStaticPath = lambda fichier="": str(Path(root) / "Static" / fichier)
+    sys.modules["Chemins"] = chemins
+
+    utils_pkg = types.ModuleType("Utils")
+    utils_pkg.__path__ = []
+    sys.modules["Utils"] = utils_pkg
+
+    customize = types.ModuleType("Utils.UTILS_Customize")
+    customize.GetValeur = lambda *args, **kwargs: ""
+    sys.modules["Utils.UTILS_Customize"] = customize
+    utils_pkg.UTILS_Customize = customize
+
+    appdirs = types.ModuleType("appdirs")
+    appdirs.site_data_dir = lambda **kwargs: str(Path(root) / "outside-site-data")
+    appdirs.user_data_dir = lambda **kwargs: str(Path(root) / "outside-user-data")
+    appdirs.user_config_dir = lambda **kwargs: str(Path(root) / "outside-user-config")
+    sys.modules["appdirs"] = appdirs
+
+    six = types.ModuleType("six")
+    six.PY2 = False
+    six.PY3 = True
+    sys.modules["six"] = six
+
+    path = Path(__file__).resolve().parents[1] / "noethys" / "Utils" / "UTILS_Fichiers.py"
+    spec = importlib.util.spec_from_file_location("noe041_utils_fichiers", str(path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class PortablePathsTests(unittest.TestCase):
+    def test_portable_marker_isolates_config_and_data(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            portable = root / "Portable"
+            portable.mkdir()
+            module = _load_utils_files(root)
+
+            self.assertEqual(Path(module.GetRepUtilisateur("Config.json")), portable / "Config.json")
+            self.assertEqual(Path(module.GetRepData("demo_DATA.dat")), portable / "Data" / "demo_DATA.dat")
+            self.assertTrue((portable / "Data").is_dir())
+
+    def test_portable_runtime_subdirectories_are_created_on_demand(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            portable = root / "Portable"
+            portable.mkdir()
+            module = _load_utils_files(root)
+
+            expected = {
+                "Temp": module.GetRepTemp("journal.tmp"),
+                "Updates": module.GetRepUpdates("update.bin"),
+                "Lang": module.GetRepLang("fr.xlang"),
+                "Sync": module.GetRepSync("sync.json"),
+                "Extensions": module.GetRepExtensions("plugin.py"),
+            }
+            for dirname, path in expected.items():
+                self.assertEqual(Path(path).parent, portable / dirname)
+                self.assertTrue((portable / dirname).is_dir())
+
+    def test_portable_mode_does_not_use_appdirs(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "Portable").mkdir()
+            module = _load_utils_files(root)
+
+            config = Path(module.GetRepUtilisateur("Config.json"))
+            data = Path(module.GetRepData("demo.dat"))
+            self.assertNotIn("outside-", str(config))
+            self.assertNotIn("outside-", str(data))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Remplacée par une PR propre créée depuis `master` après fusion de Noe-040. Cette PR empilait historiquement Noe-040 et conservait un historique artificiel après le squash de #34 ; aucun changement fonctionnel n'est abandonné.