### PR TITLE
Noe-041: make the Windows artifact truly portable

### DIFF
--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -78,6 +78,12 @@ jobs:
           }
           Get-ChildItem "dist/Noethys" -Recurse | Measure-Object | Format-List
 
+      - name: Activer l'isolation portable
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path "dist/Noethys/Portable" -Force | Out-Null
+          Copy-Item "packaging/portable/README.txt" "dist/Noethys/Portable/README.txt"
+
       - name: Écrire les informations de build
         shell: pwsh
         run: |
@@ -87,6 +93,7 @@ jobs:
             "Commit: $env:GITHUB_SHA"
             "Python: $pythonVersion"
             "Workflow run: $env:GITHUB_RUN_ID"
+            "Portable mode: enabled (Portable/)"
             "Build UTC: $([DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ'))"
           ) | Set-Content -Path "dist/Noethys/BUILD-INFO.txt" -Encoding UTF8
 
@@ -108,6 +115,9 @@ jobs:
           $exe = Join-Path $testRoot "Noethys.exe"
           if (-not (Test-Path $exe)) {
             throw "Noethys.exe absent de l'archive extraite"
+          }
+          if (-not (Test-Path (Join-Path $testRoot "Portable/README.txt"))) {
+            throw "Marqueur Portable absent de l'archive extraite"
           }
 
           $savedPath = $env:PATH

--- a/docs/NOE-041-MODE-PORTABLE.md
+++ b/docs/NOE-041-MODE-PORTABLE.md
@@ -1,0 +1,75 @@
+# Noe-041 — Mode portable Noethys
+
+## Fonctionnement historique conservé
+
+Noethys possède déjà un mécanisme de mode portable : lorsque le dossier `Portable` existe à côté de `Noethys.exe`, `UTILS_Fichiers` redirige la configuration et les données vers ce dossier au lieu d'utiliser les emplacements du profil utilisateur Windows.
+
+Le packaging moderne active désormais explicitement ce mécanisme dans l'archive `Noethys-Windows-portable.zip`.
+
+## Arborescence
+
+Une archive fraîche contient notamment :
+
+```text
+Noethys.exe
+BUILD-INFO.txt
+Static/
+Portable/
+  README.txt
+```
+
+À l'utilisation, les sous-dossiers nécessaires sont créés à la demande :
+
+```text
+Portable/
+  Config.json
+  Customize.ini
+  journal.log
+  Data/
+  Temp/
+  Updates/
+  Lang/
+  Sync/
+  Extensions/
+```
+
+## Isolation
+
+En mode portable :
+
+- `GetRepUtilisateur()` pointe dans `Portable/` ;
+- `GetRepData()` pointe dans `Portable/Data/` ;
+- les répertoires temporaires, mises à jour, langues, synchronisation et extensions sont créés sous `Portable/` ;
+- le mécanisme `appdirs` normal n'est pas utilisé pour ces chemins.
+
+La présence du dossier `Portable` reste le déclencheur historique. Les installations classiques sans ce dossier conservent donc leur comportement habituel.
+
+## Mise à jour d'un portable existant
+
+Ne jamais supprimer le dossier `Portable` lors d'une mise à jour : il peut contenir la configuration et les bases locales.
+
+La méthode prudente est :
+
+1. sauvegarder le dossier portable existant ;
+2. extraire la nouvelle version dans un nouveau dossier ;
+3. pour une recette, copier uniquement une **copie** des données nécessaires ;
+4. valider la nouvelle version avant de remplacer l'ancien dossier applicatif.
+
+## Recette avec base réelle
+
+Pour Noe-030 et la future RC :
+
+- travailler sur une copie de la base ;
+- placer cette copie dans `Portable/Data/` si la recette est locale ;
+- conserver l'original hors du portable de test ;
+- après recette, vérifier l'absence de changement de schéma inattendu avec l'outil Noe-030.
+
+## Couverture automatisée
+
+`tests/test_noe_041_portable_paths.py` vérifie que :
+
+- la présence de `Portable/` redirige bien configuration et données ;
+- `Data`, `Temp`, `Updates`, `Lang`, `Sync` et `Extensions` sont créés à la demande ;
+- les chemins `appdirs` ne sont pas utilisés en mode portable.
+
+Le workflow Windows vérifie également que le marqueur portable est présent après extraction de l'archive finale.

--- a/noethys/Utils/UTILS_Fichiers.py
+++ b/noethys/Utils/UTILS_Fichiers.py
@@ -19,87 +19,92 @@ import appdirs
 import six
 
 
-def GetRepData(fichier=""):
-    # Vérifie si un répertoire 'Portable' existe
+def _GetRepPortable():
+    """Retourne le répertoire portable historique lorsqu'il est activé."""
     chemin = Chemins.GetMainPath("Portable")
     if os.path.isdir(chemin):
-        chemin = os.path.join(chemin, "Data")
-        if not os.path.isdir(chemin):
-            os.mkdir(chemin)
+        return chemin
+    return None
+
+
+def _GetRepPortableSousDossier(nom):
+    """Crée à la demande un sous-dossier du mode portable déjà activé."""
+    racine = _GetRepPortable()
+    if racine is None:
+        return None
+    chemin = os.path.join(racine, nom)
+    if not os.path.isdir(chemin):
+        os.mkdir(chemin)
+    return chemin
+
+
+def GetRepData(fichier=""):
+    # Le mode portable historique est activé par la présence du dossier
+    # "Portable" à côté de Noethys.exe (ou de Noethys.py en mode source).
+    chemin = _GetRepPortableSousDossier("Data")
+    if chemin is not None:
         return os.path.join(chemin, fichier)
 
     # Recherche s'il existe un chemin personnalisé dans le Customize.ini
     chemin = UTILS_Customize.GetValeur("repertoire_donnees", "chemin", "")
-    #chemin = chemin.decode("utf8")
     if chemin != "" and os.path.isdir(chemin):
         return os.path.join(chemin, fichier)
 
     # Recherche le chemin du répertoire des données
     if sys.platform == "win32" and platform.release() != "Vista" :
-
         chemin = appdirs.site_data_dir(appname=None, appauthor=False)
-        #chemin = chemin.decode("utf8")
-
         chemin = os.path.join(chemin, "noethys")
         if not os.path.isdir(chemin):
             os.mkdir(chemin)
-
     else :
-
         chemin = appdirs.user_data_dir(appname=None, appauthor=False)
-        #chemin = chemin.decode("utf8")
-
         chemin = os.path.join(chemin, "noethys")
         if not os.path.isdir(chemin):
             os.mkdir(chemin)
-
         chemin = os.path.join(chemin, "Data")
         if not os.path.isdir(chemin):
             os.mkdir(chemin)
 
-    # Ajoute le dirname si besoin
+    return os.path.join(chemin, fichier)
+
+
+def _GetRepUtilisateurSousDossier(nom, fichier=""):
+    chemin = _GetRepPortableSousDossier(nom)
+    if chemin is None:
+        chemin = GetRepUtilisateur(nom)
     return os.path.join(chemin, fichier)
 
 
 def GetRepTemp(fichier=""):
-    chemin = GetRepUtilisateur("Temp")
-    return os.path.join(chemin, fichier)
+    return _GetRepUtilisateurSousDossier("Temp", fichier)
+
 
 def GetRepUpdates(fichier=""):
-    chemin = GetRepUtilisateur("Updates")
-    return os.path.join(chemin, fichier)
+    return _GetRepUtilisateurSousDossier("Updates", fichier)
+
 
 def GetRepLang(fichier=""):
-    chemin = GetRepUtilisateur("Lang")
-    return os.path.join(chemin, fichier)
+    return _GetRepUtilisateurSousDossier("Lang", fichier)
+
 
 def GetRepSync(fichier=""):
-    chemin = GetRepUtilisateur("Sync")
-    return os.path.join(chemin, fichier)
+    return _GetRepUtilisateurSousDossier("Sync", fichier)
+
 
 def GetRepExtensions(fichier=""):
-    chemin = GetRepUtilisateur("Extensions")
-    return os.path.join(chemin, fichier)
+    return _GetRepUtilisateurSousDossier("Extensions", fichier)
+
 
 def GetRepUtilisateur(fichier=""):
     """ Recherche le répertoire Utilisateur pour stockage des fichiers de config et provisoires """
-    chemin = None
-
-    # Vérifie si un répertoire 'Portable' existe
-    chemin = Chemins.GetMainPath("Portable")
-    if os.path.isdir(chemin):
+    chemin = _GetRepPortable()
+    if chemin is not None:
         return os.path.join(chemin, fichier)
 
-    # Recherche le chemin du répertoire de l'utilisateur
     chemin = appdirs.user_config_dir(appname=None, appauthor=False, roaming=True)
-    #chemin = chemin.decode("utf8")
-
-    # Ajoute 'noethys' dans le chemin et création du répertoire
     chemin = os.path.join(chemin, "noethys")
     if not os.path.isdir(chemin):
         os.mkdir(chemin)
-
-    # Ajoute le dirname si besoin
     return os.path.join(chemin, fichier)
 
 def DeplaceFichiers():
@@ -131,10 +136,8 @@ def DeplaceFichiers():
             if six.PY2:
                 nomFichier = nomFichier.decode("utf8")
             if nomFichier.endswith(".dat") and "_" in nomFichier and "EXEMPLE_" not in nomFichier and "_archive.dat" not in nomFichier :
-                # Déplace le fichier vers le répertoire des fichiers de données
                 print(["copie base de donnees :", nomFichier, " > ", GetRepData(nomFichier)])
                 shutil.copy(Chemins.GetMainPath(u"Data/%s" % nomFichier), GetRepData(nomFichier))
-                # Renomme le fichier de données en archive (par sécurité)
                 try :
                     os.rename(Chemins.GetMainPath(u"Data/%s" % nomFichier), Chemins.GetMainPath(u"Data/%s" % nomFichier.replace(".dat", "_archive.dat")))
                 except :
@@ -146,7 +149,6 @@ def DeplaceExemples():
         chemin = Chemins.GetStaticPath("Exemples")
         for nomFichier in os.listdir(chemin) :
             if nomFichier.endswith(".dat") and "EXEMPLE_" in nomFichier :
-                # Déplace le fichier vers le répertoire des fichiers de données
                 shutil.copy(os.path.join(chemin, nomFichier), GetRepData(nomFichier))
 
 def OuvrirRepertoire(rep):
@@ -158,15 +160,8 @@ def OuvrirRepertoire(rep):
         subprocess.Popen(["xdg-open", rep])
 
 
-
 if __name__ == "__main__":
-    # Teste les déplacements de fichiers
-    # DeplaceFichiers()
-
-    # Répertoire utilisateur
     print(GetRepUtilisateur())
-
-    # Répertoire des données
     chemin = GetRepData()
     print(1, os.path.join(chemin, u"Testé.pdf"))
     print(2, os.path.join(chemin, "Test.pdf"))

--- a/packaging/portable/README.txt
+++ b/packaging/portable/README.txt
@@ -1,0 +1,15 @@
+NOETHYS - MODE PORTABLE
+=======================
+
+La présence de ce dossier active le mode portable historique de Noethys.
+
+Dans ce mode :
+- Config.json, Customize.ini et journal.log restent dans ce dossier Portable ;
+- les bases locales sont stockées dans Portable\Data ;
+- les dossiers Temp, Updates, Lang, Sync et Extensions sont créés ici à la demande ;
+- le profil Windows (AppData) n'est pas utilisé pour ces données Noethys.
+
+Pour une recette avec une base existante : travaillez uniquement sur une COPIE de la base.
+Ne déplacez jamais ici votre unique base de production pour tester une RC.
+
+Pour revenir au comportement utilisateur classique, utilisez une distribution sans dossier Portable ; ne supprimez pas ce dossier d'une installation qui contient déjà sa configuration ou ses bases sans les sauvegarder auparavant.

--- a/tests/test_noe_041_portable_paths.py
+++ b/tests/test_noe_041_portable_paths.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+
+def _load_utils_files(root):
+    chemins = types.ModuleType("Chemins")
+    chemins.GetMainPath = lambda fichier="": str(Path(root) / fichier)
+    chemins.GetStaticPath = lambda fichier="": str(Path(root) / "Static" / fichier)
+    sys.modules["Chemins"] = chemins
+
+    utils_pkg = types.ModuleType("Utils")
+    utils_pkg.__path__ = []
+    sys.modules["Utils"] = utils_pkg
+
+    customize = types.ModuleType("Utils.UTILS_Customize")
+    customize.GetValeur = lambda *args, **kwargs: ""
+    sys.modules["Utils.UTILS_Customize"] = customize
+    utils_pkg.UTILS_Customize = customize
+
+    appdirs = types.ModuleType("appdirs")
+    appdirs.site_data_dir = lambda **kwargs: str(Path(root) / "outside-site-data")
+    appdirs.user_data_dir = lambda **kwargs: str(Path(root) / "outside-user-data")
+    appdirs.user_config_dir = lambda **kwargs: str(Path(root) / "outside-user-config")
+    sys.modules["appdirs"] = appdirs
+
+    six = types.ModuleType("six")
+    six.PY2 = False
+    six.PY3 = True
+    sys.modules["six"] = six
+
+    path = Path(__file__).resolve().parents[1] / "noethys" / "Utils" / "UTILS_Fichiers.py"
+    spec = importlib.util.spec_from_file_location("noe041_utils_fichiers", str(path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class PortablePathsTests(unittest.TestCase):
+    def test_portable_marker_isolates_config_and_data(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            portable = root / "Portable"
+            portable.mkdir()
+            module = _load_utils_files(root)
+
+            self.assertEqual(Path(module.GetRepUtilisateur("Config.json")), portable / "Config.json")
+            self.assertEqual(Path(module.GetRepData("demo_DATA.dat")), portable / "Data" / "demo_DATA.dat")
+            self.assertTrue((portable / "Data").is_dir())
+
+    def test_portable_runtime_subdirectories_are_created_on_demand(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            portable = root / "Portable"
+            portable.mkdir()
+            module = _load_utils_files(root)
+
+            expected = {
+                "Temp": module.GetRepTemp("journal.tmp"),
+                "Updates": module.GetRepUpdates("update.bin"),
+                "Lang": module.GetRepLang("fr.xlang"),
+                "Sync": module.GetRepSync("sync.json"),
+                "Extensions": module.GetRepExtensions("plugin.py"),
+            }
+            for dirname, path in expected.items():
+                self.assertEqual(Path(path).parent, portable / dirname)
+                self.assertTrue((portable / dirname).is_dir())
+
+    def test_portable_mode_does_not_use_appdirs(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "Portable").mkdir()
+            module = _load_utils_files(root)
+
+            config = Path(module.GetRepUtilisateur("Config.json"))
+            data = Path(module.GetRepData("demo.dat"))
+            self.assertNotIn("outside-", str(config))
+            self.assertNotIn("outside-", str(data))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
PR propre recréée depuis `master` après fusion de Noe-040.

Active explicitement le mode portable historique :
- ajoute le dossier marqueur `Portable/` dans la distribution ;
- redirige configuration et bases locales sous `Portable/` ;
- crée à la demande `Data`, `Temp`, `Updates`, `Lang`, `Sync` et `Extensions` ;
- ajoute des tests de chemins et d'isolement vis-à-vis d'AppData/appdirs ;
- vérifie la présence du marqueur dans l'archive Windows réellement extraite ;
- documente la mise à jour prudente et la recette sur copie de base.

Le comportement des installations classiques sans dossier `Portable` reste inchangé.

Issue : #18