### PR TITLE
Noe-042: prepare RC readiness and release notes

### DIFF
--- a/docs/NOE-042-RC-READINESS.md
+++ b/docs/NOE-042-RC-READINESS.md
@@ -1,0 +1,78 @@
+# Noe-042 — État de préparation de la Release Candidate
+
+## Position actuelle
+
+La modernisation technique critique est désormais largement qualifiée. Une RC ne doit toutefois **pas** être publiée tant que la recette humaine sur une copie de base réellement utilisée n'a pas été effectuée.
+
+## Portes techniques franchies
+
+- **SQL / bases** : audit SQL strict, `OL_Reglements`, export comptable et audit d'index traités ;
+- **Python** : baseline Python 3.10 qualifiée, études 3.11 et 3.12 vertes et conservées en requalification à la demande ;
+- **wxPython** : audit Phoenix intégré à la CI, incompatibilité réelle `SystemSettings_GetFont` corrigée ;
+- **plateformes** : smoke tests Windows, macOS et Linux GTK3 ;
+- **non-régression métier** : découverte complète `tests/test_*.py` intégrée à la CI ;
+- **bases existantes** : préflight Noe-030 en lecture seule, empreinte de schéma et contrôle SHA-256 SQLite ;
+- **sauvegarde/restauration** : contrôle de flux réparé et tests de restauration ajoutés ;
+- **packaging Windows** : PyInstaller `onedir` qualifié par exécution réelle de l'archive extraite sans Python externe ;
+- **layout PyInstaller 6** : disposition `_internal` refusée, layout plat historique restauré afin de rester compatible avec `Chemins.py` ;
+- **traçabilité** : `BUILD-INFO.txt` identifie commit, Python, run et date de fabrication.
+
+## Porte technique encore en cours
+
+- **Noe-041 — mode portable** : activation explicite du dossier historique `Portable/`, isolation de la configuration et des données, tests de chemins et validation du marqueur dans l'archive finale.
+
+Cette porte doit être fusionnée avant de figer le commit candidat RC.
+
+## Portes humaines obligatoires avant publication d'une RC
+
+### 1. Noe-030 — recette sur une copie de base réelle
+
+Utiliser exclusivement une **copie** d'une base Noethys réellement utilisée.
+
+Minimum attendu :
+
+- préflight lecture seule avant ouverture ;
+- démarrage du portable Windows ;
+- familles / individus ;
+- activités / groupes / inscriptions ;
+- consommations / réservations ;
+- prestations / facturation ;
+- règlements et ventilation ;
+- comptabilité / export réellement utilisé ;
+- génération d'un PDF ;
+- fermeture et réouverture ;
+- second préflight et confirmation que le `schema_digest` n'a pas changé de façon inattendue.
+
+### 2. Validation visuelle Windows
+
+La CI lance le véritable EXE en mode smoke mais s'arrête volontairement avant `Noethys.py`. Un humain doit donc encore confirmer :
+
+- ouverture réelle de la fenêtre principale ;
+- absence de dialogue ou ressource manquante ;
+- comportement normal des écrans critiques utilisés pendant la recette ;
+- fermeture propre de l'application.
+
+## Ce qui n'est pas bloquant pour cette première RC
+
+- installateur Windows système ;
+- signature de code ;
+- paquet macOS signé/notarisé ;
+- paquet Linux ;
+- migration Python 3.11 ou 3.12 comme baseline ;
+- migration de la base vers une version MySQL/MariaDB plus récente.
+
+Ces sujets peuvent être traités après stabilisation sans retarder une RC Windows portable compatible avec l'existant.
+
+## Décision RC
+
+La RC est **prête à être figée** lorsque :
+
+1. Noe-041 est fusionné ;
+2. la CI du SHA candidat est verte ;
+3. `Package Windows` est vert sur ce même SHA ;
+4. l'artefact est identifié par `BUILD-INFO.txt` ;
+5. Noe-030 a été exécuté sur une copie de base réelle ;
+6. la recette Windows manuelle ne révèle aucun blocage ;
+7. les anomalies éventuelles sont corrigées puis les contrôles concernés relancés.
+
+Tant que les points 5 et 6 ne sont pas réalisés, le projet peut produire un **candidat technique**, mais il ne doit pas être présenté comme une RC validée.

--- a/docs/NOE-042-RC-READINESS.md
+++ b/docs/NOE-042-RC-READINESS.md
@@ -2,7 +2,9 @@
 
 ## Position actuelle
 
-La modernisation technique critique est désormais largement qualifiée. Une RC ne doit toutefois **pas** être publiée tant que la recette humaine sur une copie de base réellement utilisée n'a pas été effectuée.
+Les **portes techniques critiques sont franchies**. Le dépôt peut désormais produire un candidat Windows portable techniquement qualifié.
+
+Une RC ne doit toutefois **pas** être publiée comme validée tant que la recette humaine sur une copie de base réellement utilisée n'a pas été effectuée.
 
 ## Portes techniques franchies
 
@@ -15,13 +17,8 @@ La modernisation technique critique est désormais largement qualifiée. Une RC 
 - **sauvegarde/restauration** : contrôle de flux réparé et tests de restauration ajoutés ;
 - **packaging Windows** : PyInstaller `onedir` qualifié par exécution réelle de l'archive extraite sans Python externe ;
 - **layout PyInstaller 6** : disposition `_internal` refusée, layout plat historique restauré afin de rester compatible avec `Chemins.py` ;
-- **traçabilité** : `BUILD-INFO.txt` identifie commit, Python, run et date de fabrication.
-
-## Porte technique encore en cours
-
-- **Noe-041 — mode portable** : activation explicite du dossier historique `Portable/`, isolation de la configuration et des données, tests de chemins et validation du marqueur dans l'archive finale.
-
-Cette porte doit être fusionnée avant de figer le commit candidat RC.
+- **mode portable** : dossier historique `Portable/` livré dans l'archive, isolation config/données testée et marqueur vérifié après extraction ;
+- **traçabilité** : `BUILD-INFO.txt` identifie commit, Python, run, date de fabrication et activation du mode portable.
 
 ## Portes humaines obligatoires avant publication d'une RC
 
@@ -40,6 +37,7 @@ Minimum attendu :
 - règlements et ventilation ;
 - comptabilité / export réellement utilisé ;
 - génération d'un PDF ;
+- sauvegarde et restauration sur la copie si le contexte le permet ;
 - fermeture et réouverture ;
 - second préflight et confirmation que le `schema_digest` n'a pas changé de façon inattendue.
 
@@ -65,14 +63,13 @@ Ces sujets peuvent être traités après stabilisation sans retarder une RC Wind
 
 ## Décision RC
 
-La RC est **prête à être figée** lorsque :
+La partie **technique automatisée est prête**. Pour figer puis publier une RC validée :
 
-1. Noe-041 est fusionné ;
-2. la CI du SHA candidat est verte ;
-3. `Package Windows` est vert sur ce même SHA ;
-4. l'artefact est identifié par `BUILD-INFO.txt` ;
-5. Noe-030 a été exécuté sur une copie de base réelle ;
-6. la recette Windows manuelle ne révèle aucun blocage ;
-7. les anomalies éventuelles sont corrigées puis les contrôles concernés relancés.
+1. sélectionner le SHA candidat sur `master` ;
+2. confirmer CI + `Package Windows` verts sur ce SHA ;
+3. vérifier `BUILD-INFO.txt` dans l'artefact ;
+4. exécuter Noe-030 sur une copie de base réelle ;
+5. effectuer la recette Windows manuelle ;
+6. corriger tout défaut bloquant éventuel et relancer les contrôles concernés.
 
-Tant que les points 5 et 6 ne sont pas réalisés, le projet peut produire un **candidat technique**, mais il ne doit pas être présenté comme une RC validée.
+Tant que les points 4 et 5 ne sont pas réalisés, le projet dispose d'un **candidat technique RC**, mais la validation finale reste volontairement en attente.

--- a/docs/RC-CHECKLIST.md
+++ b/docs/RC-CHECKLIST.md
@@ -7,23 +7,31 @@ Cette checklist sépare les garanties déjà apportées par la CI des vérificat
 - compilation Python 3 ;
 - audits runtime, encodages, dates, CSV et compatibilités wxPython ;
 - absence de migration implicite du schéma dans les contrôles prévus ;
+- suite complète de non-régression métier `tests/test_*.py` ;
 - imports des piles fonctionnelles critiques ;
 - génération PDF Unicode avec ReportLab ;
-- ressources essentielles du packaging ;
+- sauvegarde/restauration sur scénarios synthétiques ;
 - construction PyInstaller Windows `onedir` ;
-- présence de `Noethys.exe` ;
-- génération d'un `BUILD-INFO.txt` traçant commit, version Python, run et date ;
+- layout plat des ressources compatible avec `Chemins.py` ;
+- présence de `Noethys.exe`, `Static`, `Versions.txt`, `Licence.txt` et `Icone.ico` ;
+- extraction de l'archive dans un dossier neuf ;
+- exécution réelle de l'EXE extrait sans Python externe ;
+- imports des dépendances critiques depuis le bundle ;
+- absence d'écriture dans le profil Windows pendant le smoke ;
+- présence du dossier `Portable/` et tests d'isolation config/données ;
+- génération d'un `BUILD-INFO.txt` traçant commit, version Python, run, mode portable et date ;
 - création et publication de l'artefact `Noethys-Windows-portable`.
 
-## Avant de déclarer une RC testable
+## Avant de déclarer une RC validée
 
-1. utiliser le dernier artefact construit depuis `master` ;
+1. utiliser le dernier artefact construit depuis le SHA candidat sur `master` ;
 2. vérifier que le SHA dans `BUILD-INFO.txt` correspond au commit attendu ;
-3. extraire l'archive dans un chemin comportant si possible espaces et accents ;
-4. lancer `Noethys.exe` sans base de production ;
-5. vérifier le démarrage complet, l'affichage de l'accueil et l'absence d'erreur de module, DLL ou ressource ;
+3. conserver une sauvegarde indépendante de la base utilisée pour la recette ;
+4. lancer `Noethys.exe` manuellement sans toucher à l'unique base de production ;
+5. vérifier le démarrage complet et l'affichage réel de l'accueil ;
 6. ouvrir uniquement une copie d'une base existante ;
-7. vérifier qu'aucune migration de schéma inattendue n'est proposée ou exécutée.
+7. exécuter le préflight Noe-030 avant et après la recette ;
+8. vérifier qu'aucune migration de schéma inattendue n'est proposée ou exécutée.
 
 ## Recette métier minimale
 
@@ -33,11 +41,10 @@ Tester au moins les parcours suivants :
 - activités, groupes et inscriptions ;
 - consommations/réservations ;
 - facturation ;
-- règlements ;
-- comptabilité ;
+- règlements et ventilation ;
+- comptabilité et export réellement utilisé ;
 - génération d'au moins un PDF ;
-- export CSV/XLSX utile ;
-- formules et filtres ayant été modernisés ;
+- sauvegarde/restauration sur la copie si pertinent ;
 - fermeture puis réouverture propre de l'application.
 
 ## Compatibilité des données historiques
@@ -45,6 +52,7 @@ Tester au moins les parcours suivants :
 Après la recette sur la copie :
 
 - fermer Noethys modernisé ;
+- comparer le `schema_digest` au rapport Noe-030 initial ;
 - conserver une seconde copie de sauvegarde intacte ;
 - rouvrir la base de recette avec la version historique lorsqu'il est pertinent de vérifier la compatibilité descendante ;
 - contrôler qu'aucune altération incompatible n'a été introduite.
@@ -53,7 +61,7 @@ Après la recette sur la copie :
 
 À tester uniquement si utilisées dans l'installation concernée :
 
-- MySQL distant ;
+- MySQL/MariaDB distant ;
 - portail/Connecthys ;
 - SFTP avec mémorisation de clé hôte ;
 - FTPS si activé ;
@@ -69,7 +77,7 @@ Une RC peut être publiée comme version de test lorsque :
 
 - la CI du commit candidat est verte ;
 - le packaging du même code est vert ;
-- le démarrage réel sous Windows est confirmé ;
+- le démarrage réel de l'interface sous Windows est confirmé ;
 - une copie de base existante s'ouvre et les parcours métier minimaux fonctionnent ;
 - aucune migration implicite ou corruption n'est observée ;
 - les limites connues sont documentées.

--- a/docs/RC-RELEASE-NOTES-DRAFT.md
+++ b/docs/RC-RELEASE-NOTES-DRAFT.md
@@ -43,7 +43,9 @@ La priorité est la compatibilité et la fiabilité ; il ne s'agit pas d'une ré
 - archive Windows identifiable par `BUILD-INFO.txt` ;
 - extraction et exécution réelle de `Noethys.exe` en CI sans environnement Python externe ;
 - contrôle des ressources et dépendances embarquées ;
-- isolation portable historique via le dossier `Portable/` dès validation de Noe-041.
+- mode portable historique activé explicitement via `Portable/` ;
+- configuration et bases locales isolées sous le dossier portable ;
+- création à la demande des sous-dossiers `Data`, `Temp`, `Updates`, `Lang`, `Sync` et `Extensions`.
 
 ### Compatibilité multi-plateforme du code source
 
@@ -77,12 +79,12 @@ Ne sont pas inclus comme exigences de cette première RC :
 
 ## Validation encore requise avant publication
 
-Avant de transformer ce brouillon en notes de RC publiables :
+La partie technique automatisée est prête. Avant de transformer ce brouillon en notes de RC publiables :
 
-1. fusionner Noe-041 ;
-2. sélectionner le SHA candidat sur `master` ;
-3. obtenir CI + packaging verts sur ce SHA ;
-4. tester le portable sur Windows ;
+1. sélectionner le SHA candidat sur `master` ;
+2. obtenir CI + packaging verts sur ce SHA ;
+3. vérifier le SHA dans `BUILD-INFO.txt` ;
+4. tester visuellement le portable sur Windows ;
 5. ouvrir une **copie** d'une base Noethys réellement utilisée ;
 6. exécuter la recette métier Noe-030 ;
 7. vérifier l'absence de changement de schéma inattendu ;

--- a/docs/RC-RELEASE-NOTES-DRAFT.md
+++ b/docs/RC-RELEASE-NOTES-DRAFT.md
@@ -1,0 +1,89 @@
+# Noethys Upgrade — notes de Release Candidate (brouillon)
+
+> Brouillon préparatoire. Ne pas publier comme RC validée avant la recette Noe-030 sur une copie de base réelle.
+
+## Objectif de cette RC
+
+Cette Release Candidate vise à rendre Noethys Desktop exploitable sur un environnement Python/wxPython moderne tout en conservant au maximum les bases, configurations et usages historiques.
+
+La priorité est la compatibilité et la fiabilité ; il ne s'agit pas d'une réécriture fonctionnelle de Noethys.
+
+## Principales évolutions
+
+### Runtime moderne
+
+- Python 3.10 comme baseline de production ;
+- qualification prospective Python 3.11 et 3.12 ;
+- wxPython Phoenix ;
+- corrections ciblées des incompatibilités Python/wx réellement confirmées ;
+- modernisation des frontières encodage, dates, fichiers et dépendances nécessaires.
+
+### Bases de données
+
+- maintien de SQLite ;
+- stratégie conservatrice pour les installations MySQL/MariaDB historiques ;
+- aucune migration implicite de schéma introduite par le chantier ;
+- audit SQL strict et correction des requêtes concernées ;
+- préflight lecture seule pour qualifier une copie de base existante ;
+- contrôle d'empreinte de schéma avant/après recette.
+
+### Fiabilité métier
+
+- tests de non-régression exécutés automatiquement en CI ;
+- couverture des migrations/copies de base ;
+- couverture des règlements et de leurs ventilations ;
+- couverture des exports comptables concernés par SQL strict ;
+- couverture des échanges PMSL ajoutés au fork ;
+- réparation de chemins historiques de restauration qui pouvaient échouer systématiquement.
+
+### Windows portable
+
+- build PyInstaller `onedir` reproductible ;
+- layout plat compatible avec la résolution historique des ressources Noethys ;
+- archive Windows identifiable par `BUILD-INFO.txt` ;
+- extraction et exécution réelle de `Noethys.exe` en CI sans environnement Python externe ;
+- contrôle des ressources et dépendances embarquées ;
+- isolation portable historique via le dossier `Portable/` dès validation de Noe-041.
+
+### Compatibilité multi-plateforme du code source
+
+- smoke tests Windows ;
+- smoke tests macOS ;
+- smoke tests Linux GTK3 sous X virtuel ;
+- tests de layout wxPython représentatifs.
+
+La distribution utilisateur prioritaire de cette RC reste Windows. macOS et Linux sont qualifiés au niveau du code source, sans promesse de paquet utilisateur équivalent au portable Windows.
+
+## Compatibilité
+
+Cette RC est conçue pour rester compatible avec les données et configurations historiques autant que possible. La règle du projet reste :
+
+- pas de migration de base silencieuse ;
+- pas de remplacement automatique de la base ;
+- pas de recette sur l'unique base de production ;
+- test préalable sur une copie réelle avant adoption.
+
+## Limites connues de la RC
+
+Ne sont pas inclus comme exigences de cette première RC :
+
+- installateur Windows système ;
+- signature de code ;
+- package macOS signé/notarisé ;
+- package Linux ;
+- bascule de la baseline vers Python 3.11/3.12 ;
+- migration imposée vers une version MySQL/MariaDB récente ;
+- transformation de Noethys Desktop en application web.
+
+## Validation encore requise avant publication
+
+Avant de transformer ce brouillon en notes de RC publiables :
+
+1. fusionner Noe-041 ;
+2. sélectionner le SHA candidat sur `master` ;
+3. obtenir CI + packaging verts sur ce SHA ;
+4. tester le portable sur Windows ;
+5. ouvrir une **copie** d'une base Noethys réellement utilisée ;
+6. exécuter la recette métier Noe-030 ;
+7. vérifier l'absence de changement de schéma inattendu ;
+8. consigner et corriger tout défaut bloquant.


### PR DESCRIPTION
Prépare la phase Release Candidate sans déclarer prématurément la RC validée :
- état de préparation avec toutes les portes techniques franchies ;
- checklist RC mise à jour avec le véritable EXE et le mode Portable ;
- brouillon de notes de version ;
- séparation explicite entre validation automatisée et recette humaine.

Après fusion, les seuls verrous RC restants sont Noe-030 sur une copie de base réellement utilisée et la validation visuelle/métier Windows correspondante.

Issue #19 reste donc ouverte après cette PR.