### PR TITLE
Noe-050/051/052: consolidate developer, user and upgrade documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,71 +2,116 @@
 
 Noethys est un logiciel libre et gratuit de gestion multi-activités destiné notamment aux accueils de loisirs, crèches, garderies périscolaires, cantines, activités périscolaires, clubs sportifs et structures culturelles.
 
-Le projet d'origine, sa documentation fonctionnelle et les informations destinées aux utilisateurs restent disponibles sur le site officiel de Noethys et dans le dépôt amont `Noethys/Noethys`.
+Le projet d'origine, sa documentation fonctionnelle et les informations historiques restent disponibles sur le site officiel de Noethys et dans le dépôt amont `Noethys/Noethys`.
 
 ## À propos de ce fork
 
-Ce dépôt `fr4nck/Noethys` travaille à la **remise à niveau technique de Noethys** en conservant son fonctionnement métier et, autant que possible, sa compatibilité avec les données existantes et les plateformes historiquement visées.
+`fr4nck/Noethys` poursuit la **remise à niveau technique de Noethys Desktop** en conservant son fonctionnement métier et, autant que possible, sa compatibilité avec les données et configurations existantes.
 
-**Base fonctionnelle : Noethys 1.3.4.2 (1er février 2026), issue du `master` du dépôt amont `Noethys/Noethys`.** Cette base est plus récente que la version 1.3.3.9 encore distribuée sur le site officiel. Le fork conserve donc les évolutions fonctionnelles et correctifs intégrés en amont jusqu'à la 1.3.4.2, auxquels s'ajoute le chantier de modernisation technique décrit ci-dessous.
+**Base fonctionnelle : Noethys 1.3.4.2 (1er février 2026), issue du `master` du dépôt amont `Noethys/Noethys`.** Cette base est plus récente que la version 1.3.3.9 encore distribuée sur le site officiel.
 
-La modernisation concerne donc le **code source multi-plateforme** de Noethys : Windows, Linux et macOS. Windows est actuellement la plateforme la plus avancée dans la qualification du packaging, tandis que la CI valide également le socle technique sous Linux et macOS.
+Le chantier ne vise pas une réécriture de Noethys ni une migration forcée vers NoethysWeb. Il modernise le code desktop par lots ciblés : Python 3, wxPython Phoenix, SQL strict, encodages, fichiers, dépendances, tests, sauvegarde/restauration et packaging.
 
-Le chantier porte principalement sur :
+## État actuel
 
-- la compatibilité avec Python 3 et les API modernes ;
-- wxPython 4 et les écarts de comportement entre plateformes ;
-- les encodages UTF-8 et les frontières texte/binaire ;
-- les chemins de fichiers et les données historiques ;
-- Pillow, ReportLab, SQLite et les dépendances utilisées par Noethys ;
-- les imports dynamiques et anciennes compatibilités runtime ;
-- une CI GitHub Actions ciblée et frugale ;
-- la qualification progressive de Windows, Linux et macOS ;
-- la production d'artefacts adaptés à chaque plateforme lorsque leur chaîne de fabrication est suffisamment stabilisée.
+Les principales portes **techniques automatisées** de la première RC modernisée sont désormais franchies :
 
-L'objectif n'est pas de réécrire Noethys ni d'ajouter des évolutions métier dans ce lot. Les corrections sont progressives et doivent rester portables sauf lorsqu'un comportement est intrinsèquement spécifique à un système d'exploitation.
+- Python 3.10 comme baseline de production ;
+- Python 3.11 et 3.12 qualifiés pour revalidation ponctuelle ;
+- wxPython Phoenix ;
+- SQL strict et non-régressions des règlements/exports comptables ;
+- suite complète `tests/test_*.py` dans la CI ;
+- préflight lecture seule des bases existantes ;
+- sauvegarde/restauration auditée et réparée ;
+- smoke tests Windows, macOS et Linux GTK3 ;
+- build PyInstaller Windows `onedir` ;
+- exécution réelle en CI de l'archive Windows extraite sans Python externe ;
+- vrai mode portable via le dossier historique `Portable/` ;
+- traçabilité du build via `BUILD-INFO.txt`.
 
-La trajectoire et l'ordre de priorité du chantier sont figés dans [`docs/ROADMAP.md`](docs/ROADMAP.md).
-
-## État de la modernisation
-
-Le code modernisé doit rester compatible avec les trois familles de plateformes supportées par Noethys :
-
-- **Linux** : la CI compile et audite le code sous Ubuntu ;
-- **Windows** : la CI valide la compilation, les imports non-GUI et l'initialisation de `wx.App`, et le packaging PyInstaller produit un dossier portable ;
-- **macOS** : la CI valide la compilation, les imports non-GUI et l'initialisation de `wx.App` sur macOS.
-
-Ces validations automatisées confirment la compatibilité technique de base des trois plateformes, mais elles ne remplacent pas une recette fonctionnelle complète avec une base réelle, les principaux écrans, impressions, exports et périphériques.
-
-La modernisation active est désormais intégrée **par lots ciblés directement dans `master`**. La PR #2 reste ouverte uniquement comme réservoir historique de changements à examiner ; elle ne doit pas être fusionnée en bloc.
+Le projet dispose donc d'un **candidat technique RC**. La publication d'une RC validée reste volontairement bloquée jusqu'à une recette humaine sur une **copie d'une base réellement utilisée** et une validation visuelle/métier sous Windows.
 
 ## Windows
 
-Windows est aujourd'hui la plateforme de packaging la plus avancée. La chaîne Python 3.10 + wxPython 4 + PyInstaller produit un dossier `onedir`, un `Noethys.exe` et une archive GitHub Actions `Noethys-Windows-portable`.
+Windows est la plateforme de distribution prioritaire.
 
-Chaque archive contient également un `BUILD-INFO.txt` indiquant le commit exact, la version Python, l'identifiant du workflow et la date du build afin de rendre les essais reproductibles.
+Le workflow `Package Windows` produit l'artefact :
 
-La CI Windows valide également la compilation des sources, plusieurs imports non-GUI et la création/destruction d'un `wx.App`. Ces contrôles constituent une qualification technique reproductible, mais **ne constituent pas encore une version stable destinée à remplacer l'installation historique**.
+```text
+Noethys-Windows-portable
+```
 
-La procédure, les contrôles et les critères de qualification sont documentés dans [`docs/PACKAGING-WINDOWS11.md`](docs/PACKAGING-WINDOWS11.md).
+L'archive contient notamment :
 
-Les artefacts produits pendant la modernisation doivent être testés avec une **copie** d'une base existante, jamais directement avec une base de production.
+```text
+Noethys.exe
+BUILD-INFO.txt
+Static/
+Portable/
+```
+
+La chaîne de qualification :
+
+1. compile le code ;
+2. valide les piles fonctionnelles et PDF ;
+3. construit le bundle PyInstaller ;
+4. vérifie les ressources historiques à côté de l'EXE ;
+5. active le mode `Portable/` ;
+6. crée l'archive ;
+7. la ré-extrait dans un dossier neuf ;
+8. neutralise `PYTHONHOME`, `PYTHONPATH` et le Python externe du `PATH` ;
+9. exécute réellement `Noethys.exe` en mode smoke ;
+10. vérifie les dépendances embarquées ;
+11. publie l'artefact.
+
+Le smoke automatique s'arrête avant l'ouverture de la configuration ou d'une base utilisateur. Une recette réelle reste donc nécessaire avant RC.
+
+## Mode portable
+
+Noethys reconnaît historiquement un dossier `Portable` à côté de l'exécutable. Le fork réutilise ce mécanisme au lieu d'en créer un nouveau.
+
+Dans la distribution portable :
+
+- configuration : `Portable/` ;
+- bases locales : `Portable/Data/` ;
+- temporaires : `Portable/Temp/` ;
+- mises à jour : `Portable/Updates/` ;
+- langues : `Portable/Lang/` ;
+- synchronisation : `Portable/Sync/` ;
+- extensions : `Portable/Extensions/`.
+
+Les installations classiques sans dossier `Portable/` conservent leur comportement habituel.
 
 ## Linux
 
-Linux reste une cible du code source. La CI exécute déjà les contrôles de compilation et plusieurs audits sur `ubuntu-latest`.
+Le code source reste une cible Linux. La CI utilise Ubuntu avec wxPython GTK3 sous Xvfb et vérifie :
 
-Les anciennes instructions d'installation Linux du projet amont restent utiles pour comprendre les dépendances historiques, mais elles devront être réactualisées lorsque la cible Linux moderne aura été qualifiée de bout en bout avec les versions de Python, wxPython et des dépendances retenues pour ce fork.
+- le backend GTK/Phoenix ;
+- la création/destruction de `wx.App` ;
+- un layout wx représentatif avec sizers et `UltimateListCtrl`.
+
+Il n'existe pas encore de paquet Linux utilisateur final équivalent au portable Windows.
 
 ## macOS
 
-macOS reste également une cible du projet. Aucun choix d'architecture ne doit rendre le code Windows-only sans nécessité explicite.
+Le code source reste également une cible macOS. La CI valide compilation, imports, wxPython Phoenix, `wx.App` et layout représentatif.
 
-La CI macOS exécute désormais une validation récente de compilation, des imports non-GUI et un smoke-test `wx.App`. Cela confirme que le socle Python/wxPython démarre correctement dans l'environnement GitHub Actions macOS.
+Cette qualification confirme le socle technique du code source ; elle ne constitue pas encore une distribution macOS signée/notarisée ni une recette métier complète sur machine réelle.
 
-Cette validation ne vaut toutefois pas encore qualification fonctionnelle complète : il reste à tester l'application avec une copie de base réelle, les principaux parcours GUI, impressions, exports et éventuelles intégrations spécifiques à macOS avant d'annoncer une compatibilité utilisateur totalement garantie.
+## Compatibilité des bases
 
-## Développement depuis les sources
+La conservation des données existantes est un invariant du chantier :
+
+- aucune migration implicite de schéma ;
+- SQLite conservé ;
+- stratégie conservatrice pour les anciennes installations MySQL/MariaDB ;
+- recette sur copie de base réelle ;
+- possibilité de retour arrière ;
+- contrôles de non-régression sur les requêtes modernisées.
+
+Une CI verte ou un build réussi ne justifient jamais un premier essai sur l'unique base de production.
+
+## Développement
 
 Le point d'entrée historique reste :
 
@@ -74,32 +119,27 @@ Le point d'entrée historique reste :
 noethys/Noethys.py
 ```
 
-Les évolutions doivent privilégier les API Python et wxPython portables. Le code spécifique à Windows, Linux ou macOS doit rester isolé et explicitement conditionné lorsqu'il est réellement nécessaire.
+La baseline de développement/distribution est Python 3.10. Les changements doivent privilégier les API portables et isoler le code spécifique à une plateforme uniquement lorsque c'est nécessaire.
 
-## Compatibilité des bases
-
-La conservation des données existantes est un invariant du chantier :
-
-- aucune migration implicite de schéma ;
-- recette sur copie de base réelle ;
-- vérification des principaux modules métier ;
-- contrôle de la compatibilité avec la version historique lorsque cela fait partie du scénario de validation.
-
-Une CI verte ou un build réussi sur une plateforme ne suffisent pas à déclarer toutes les plateformes fonctionnellement qualifiées : chaque environnement doit disposer de ses propres contrôles adaptés et d'une recette réelle lorsque nécessaire.
+Voir [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) pour l'environnement, l'architecture du dépôt, les tests, les audits et le build.
 
 ## Documentation
 
-- [`docs/ROADMAP.md`](docs/ROADMAP.md) — feuille de route et priorités de la modernisation ;
-- [`docs/PACKAGING-WINDOWS11.md`](docs/PACKAGING-WINDOWS11.md) — packaging, CI, recette et critères de qualification Windows ;
+- [`docs/ROADMAP.md`](docs/ROADMAP.md) — feuille de route ;
+- [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) — documentation développeur ;
+- [`docs/USER-GUIDE-UPGRADE.md`](docs/USER-GUIDE-UPGRADE.md) — installation, mise à jour, sauvegarde et recette utilisateur ;
+- [`docs/UPGRADE-HISTORY.md`](docs/UPGRADE-HISTORY.md) — historique et décisions du chantier ;
+- [`docs/PACKAGING-WINDOWS11.md`](docs/PACKAGING-WINDOWS11.md) — packaging Windows ;
+- [`docs/RC-CHECKLIST.md`](docs/RC-CHECKLIST.md) — checklist avant RC ;
+- [`docs/NOE-030-RECETTE-BASE-EXISTANTE.md`](docs/NOE-030-RECETTE-BASE-EXISTANTE.md) — recette sur copie de base existante ;
+- [`docs/NOE-042-RC-READINESS.md`](docs/NOE-042-RC-READINESS.md) — état de préparation de la RC ;
 - `noethys/Doc/` — documentation historique embarquée dans Noethys.
-
-La documentation Linux et macOS sera complétée à mesure que leurs chaînes modernes de test et de distribution seront qualifiées.
 
 ## Principes de contribution
 
 Les changements doivent rester ciblés : pas de refactorisation cosmétique massive, pas de nouvelle fonctionnalité métier mêlée à la modernisation, pas de multiplication inutile des workflows et pas de modification globale des données ou encodages sans preuve de compatibilité.
 
-Lorsqu'un défaut apparaît, la priorité est de corriger sa cause racine et d'ajouter un garde-fou reproductible lorsqu'il apporte une réelle valeur. Une correction introduite pour une plateforme ne doit pas dégrader les autres sans justification documentée.
+Lorsqu'un défaut apparaît, la priorité est de corriger sa cause racine et d'ajouter un garde-fou reproductible lorsqu'il apporte une valeur réelle.
 
 ## Projet d'origine
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,182 @@
+# Développement — fork Upgrade Noethys
+
+## Positionnement
+
+Ce dépôt modernise Noethys Desktop sans réécriture métier. Les priorités de développement sont, dans l'ordre :
+
+1. conserver les bases et configurations existantes ;
+2. éviter toute migration implicite de schéma ;
+3. maintenir le comportement métier historique ;
+4. moderniser Python, wxPython et les dépendances par corrections ciblées ;
+5. conserver le code source compatible Windows, macOS et Linux lorsque c'est raisonnablement possible ;
+6. produire en priorité un portable Windows reproductible.
+
+## Runtime de référence
+
+La baseline de production reste **Python 3.10**.
+
+Python 3.11 et 3.12 ont été qualifiés par des workflows dédiés, conservés pour des requalifications ponctuelles avant des jalons importants. Ils ne sont pas encore la baseline de distribution.
+
+wxPython Phoenix est utilisé sur les plateformes modernes. La CI vérifie les API historiques réellement encore employées et évite les remplacements cosmétiques lorsqu'un alias reste supporté.
+
+## Installation de l'environnement
+
+Pour les audits et tests sans GUI, un Python 3.10 suffit avec les dépendances nécessaires au scénario concerné.
+
+Pour reproduire le build Windows complet :
+
+```bash
+python -m pip install --upgrade pip wheel
+python -m pip install -r requirements-build.txt
+```
+
+`requirements-build.txt` inclut la chaîne nécessaire à PyInstaller et aux piles fonctionnelles vérifiées pendant le packaging.
+
+## Organisation du dépôt
+
+- `noethys/` : application historique et code métier ;
+- `noethys/Ctrl/` : contrôles wxPython ;
+- `noethys/Dlg/` : dialogues et écrans métier ;
+- `noethys/Ol/` : listes/ObjectListView ;
+- `noethys/Utils/` : services, fichiers, sauvegarde, intégrations et utilitaires ;
+- `noethys/Data/` : descriptions et données structurelles ;
+- `tests/` : tests unitaires/non-régression ;
+- `scripts/` : audits, smoke tests et outils de recette ;
+- `packaging/` : spec PyInstaller et runtime hooks ;
+- `.github/workflows/` : CI multi-plateforme et packaging Windows ;
+- `docs/` : roadmap, décisions, procédures de qualification et documentation du fork.
+
+Le point d'entrée historique reste :
+
+```text
+noethys/Noethys.py
+```
+
+## Tests de non-régression
+
+La suite métier complète s'exécute avec :
+
+```bash
+python -m unittest discover -s tests -p 'test_*.py' -v
+```
+
+Elle couvre notamment :
+
+- migration/copie de bases ;
+- SQL strict des règlements ;
+- exports comptables concernés ;
+- passerelle PMSL ;
+- restauration ;
+- isolation du mode portable.
+
+Une correction d'un défaut métier reproductible doit ajouter ou renforcer un test lorsqu'il est raisonnablement automatisable.
+
+## Audits principaux
+
+La CI exécute notamment :
+
+- `scripts/audit_runtime_patterns.py` ;
+- `scripts/audit_critical_business_modules.py` ;
+- `scripts/audit_dynamic_import_risks.py` ;
+- `scripts/audit_wxphoenix_compat.py` ;
+- audits encodage, CSV, dates, bytes/texte et dépendances ;
+- `scripts/check_schema_compatibility.py` ;
+- base synthétique et benchmark lecture seule ;
+- préflight Noe-030.
+
+Ces outils sont des garde-fous. Un motif statique n'est pas automatiquement un bug : la règle reste de corriger les causes confirmées.
+
+## Bases de données
+
+### Invariants
+
+- aucune migration implicite ;
+- SQLite reste supporté ;
+- la compatibilité avec les anciennes installations MySQL/MariaDB est conservée autant que possible ;
+- ne pas introduire une fonctionnalité SQL nécessitant inutilement un serveur récent ;
+- toute modification touchant les requêtes doit préserver la forme et la sémantique des résultats métier.
+
+### Recette
+
+Pour une base existante, utiliser :
+
+```bash
+python scripts/recette_existing_db_readonly.py --sqlite copie.dat --json avant.json
+```
+
+Puis, après la recette sur la copie :
+
+```bash
+python scripts/recette_existing_db_readonly.py \
+  --sqlite copie.dat \
+  --expect-schema-from avant.json \
+  --json apres.json
+```
+
+Ne jamais utiliser l'unique base de production pour qualifier une branche ou une RC.
+
+## wxPython et plateformes
+
+La CI principale comporte :
+
+- Windows : compilation, Phoenix, imports, `wx.App` et layout wx ;
+- macOS : mêmes frontières techniques principales ;
+- Linux GTK3 : wxPython système sous Xvfb, Phoenix, `wx.App` et layout représentatif.
+
+Une CI verte valide le socle technique, pas chaque dialogue métier ni chaque périphérique.
+
+## Packaging Windows
+
+Le build s'effectue via :
+
+```bash
+pyinstaller --noconfirm --clean packaging/noethys.spec
+```
+
+Le layout `onedir` est volontairement **plat** (`contents_directory="."`) car `Chemins.py` résout historiquement les ressources depuis le dossier de `Noethys.exe`.
+
+Le workflow `Package Windows` :
+
+1. installe les dépendances ;
+2. exécute les smoke tests fonctionnels ;
+3. construit le bundle ;
+4. vérifie ressources et layout ;
+5. active le dossier historique `Portable/` ;
+6. crée `BUILD-INFO.txt` ;
+7. archive le dossier ;
+8. ré-extrait l'archive ;
+9. neutralise l'environnement Python du runner ;
+10. exécute réellement l'EXE figé en mode smoke ;
+11. publie `Noethys-Windows-portable`.
+
+Le runtime hook de smoke quitte avant l'ouverture de la configuration ou d'une base utilisateur.
+
+## Mode portable
+
+La présence de `Portable/` à côté de l'EXE active le comportement historique :
+
+- configuration dans `Portable/` ;
+- bases locales dans `Portable/Data/` ;
+- répertoires runtime sous `Portable/`.
+
+Ne pas supprimer ce dossier lors d'une mise à jour d'une installation qui l'utilise : il peut contenir les données utilisateur.
+
+## Style de modification attendu
+
+- diff ciblé ;
+- pas de refactorisation cosmétique massive ;
+- pas de nouvelle fonctionnalité métier mélangée à un correctif de compatibilité ;
+- conserver les interfaces historiques lorsque leur remplacement n'apporte pas de gain réel ;
+- documenter les exceptions de plateforme ;
+- ajouter un garde-fou lorsqu'une régression importante peut être reproduite automatiquement.
+
+## Avant une PR ou une fusion
+
+Au minimum :
+
+```bash
+python -m compileall -q noethys
+python -m unittest discover -s tests -p 'test_*.py' -v
+```
+
+Pour tout changement touchant packaging, wxPython, base ou dépendances, s'appuyer ensuite sur les jobs GitHub Actions correspondants avant fusion.

--- a/docs/UPGRADE-HISTORY.md
+++ b/docs/UPGRADE-HISTORY.md
@@ -1,0 +1,224 @@
+# Historique du chantier Upgrade Noethys
+
+## Pourquoi ce document ?
+
+Noethys est un logiciel ancien, vaste et fortement lié à des usages métier réels. Le chantier Upgrade Noethys a donc choisi une modernisation incrémentale plutôt qu'une réécriture.
+
+Ce document conserve les décisions structurantes afin qu'une reprise future du projet ne réintroduise pas des choix déjà étudiés ou ne casse pas involontairement la compatibilité historique.
+
+## Principes figés
+
+### Compatibilité avant nouveauté
+
+Le chantier vise d'abord à prolonger Noethys Desktop :
+
+- mêmes bases existantes autant que possible ;
+- mêmes configurations ;
+- même logique métier ;
+- pas de migration implicite ;
+- retour arrière possible ;
+- corrections ciblées plutôt que refactorisation globale.
+
+### Base réelle protégée
+
+Une CI verte ne justifie jamais un test directement sur l'unique base de production. Toute RC doit passer par une copie et le scénario Noe-030.
+
+### Windows prioritaire, code source multi-plateforme
+
+Windows est la cible de distribution prioritaire. Le code source reste toutefois qualifié sur macOS et Linux GTK3 afin d'éviter une dérive Windows-only inutile.
+
+### Python 3.10 comme baseline
+
+Python 3.10 est retenu comme baseline de production pour la première RC modernisée. Python 3.11 et 3.12 ont été qualifiés mais restent des cibles de requalification, pas une migration imposée.
+
+### Bases MySQL/MariaDB historiques
+
+Aucune migration de serveur n'est imposée dans le chantier de modernisation. Les changements SQL doivent rester conservateurs et compatibles avec les installations anciennes lorsque cela est raisonnablement possible.
+
+## Audit des forks
+
+Un audit du réseau de forks a montré que `fr4nck/Noethys` est le fork moderne le plus avancé du réseau examiné.
+
+Les autres forks ont servi de sources d'idées et de checklists de régression, pas de branches à fusionner en bloc :
+
+- `JurassicPork/Noethys` : plusieurs correctifs historiques utiles comme liste de vérification ;
+- `fautpasycraindre/Noethys` : idées de packaging Python moderne, mais versions/dépendances trop agressives pour un cherry-pick global ;
+- autres forks : généralement anciens ou très peu divergents.
+
+Décision : importer les **idées démontrées utiles**, jamais les historiques complets sans audit.
+
+## SQL strict et bases
+
+Le premier bloc a audité les requêtes susceptibles d'échouer avec des modes SQL stricts.
+
+### Règlements
+
+`OL_Reglements` regroupait une sélection large par seul `IDreglement`. La correction a remplacé le `GROUP BY` permissif par une pré-agrégation de `ventilation`, conservant :
+
+- une ligne par règlement ;
+- l'ordre des colonnes attendu par `Track` ;
+- la somme historique de ventilation ;
+- la compatibilité avec les anciens serveurs.
+
+Des tests reproduisent l'ancien et le nouveau résultat.
+
+### Export comptable
+
+Les `GROUP BY` historiques ont été audités et corrigés sans changer la sémantique des exports. Des tests protègent notamment les cas QuadraCOMPTA/Cerig concernés.
+
+### Index et performances
+
+L'audit a privilégié les mesures et les usages réels plutôt qu'une création massive d'index pouvant modifier le coût des écritures ou la compatibilité des bases.
+
+## Qualification Python
+
+### Python 3.11
+
+Qualification fusionnée : `07a62df7`.
+
+- cœur/audits Linux ;
+- wxPython macOS ;
+- dépendances Windows ;
+- build PyInstaller complet Windows.
+
+### Python 3.12
+
+Étude fusionnée : `25e56c2b`.
+
+La compatibilité a été démontrée sans modifier la baseline. Les workflows profonds 3.11/3.12 ont ensuite été passés en déclenchement manuel afin de garder une CI courante frugale.
+
+## wxPython Phoenix et plateformes
+
+### Noe-020 — Phoenix
+
+Fusion : `de0dc583`.
+
+Un audit runtime a distingué les anciens noms wxPython encore supportés des vraies incompatibilités. Il a trouvé un défaut concret :
+
+```text
+wx.SystemSettings_GetFont
+```
+
+remplacé par :
+
+```text
+wx.SystemSettings.GetFont
+```
+
+Décision : ne pas réécrire massivement les aliases historiques qui restent fonctionnels.
+
+### Noe-021 — Linux GTK3
+
+Fusion : `150c9ea9`.
+
+La CI utilise Ubuntu, wxPython GTK3 et Xvfb pour tester :
+
+- backend GTK ;
+- API Phoenix ;
+- cycle `wx.App` ;
+- layout avec sizers et `UltimateListCtrl`.
+
+### Noe-022 — macOS
+
+Fusion : `d8d61a31`.
+
+Le code source est qualifié automatiquement sur macOS avec un smoke de layout représentatif. Cette qualification n'est pas présentée comme un paquet macOS utilisateur signé/notarisé.
+
+## Recette et non-régression
+
+### Noe-030 — base existante
+
+Outillage fusionné : `acedfa58`.
+
+Le préflight :
+
+- ouvre SQLite en lecture seule ;
+- calcule SHA-256 avant/après ;
+- produit un `schema_digest` ;
+- ne sort pas de données nominatives ;
+- dispose d'un mode MySQL/MariaDB conservateur.
+
+L'issue reste ouverte jusqu'à la recette sur une copie de base réellement utilisée.
+
+### Noe-031 — suite métier
+
+Fusion : `e8e286a2`.
+
+Tous les `tests/test_*.py` sont exécutés dans la CI principale. Le travail a également réduit le couplage de services PMSL à `GestionDB` lorsqu'une `FakeDB` est injectée.
+
+Décision : un test métier doit vérifier un invariant observable, pas un détail d'implémentation.
+
+## Sauvegarde et restauration
+
+### Noe-032
+
+Fusion : `f8cd03fe`.
+
+L'audit a découvert plusieurs `return False` mal indentés dans `UTILS_Sauvegarde.Restauration`, rendant plusieurs chemins de restauration inconditionnellement défaillants.
+
+La correction conserve les formats historiques et ajoute des tests de restauration SQLite et de flux MySQL simulé.
+
+Décision : aucun changement de format de sauvegarde dans cette RC ; réparer d'abord la fiabilité du comportement existant.
+
+## Packaging Windows
+
+### Noe-040 — véritable artefact
+
+Fusion : `4916ca15`.
+
+Le premier smoke du véritable EXE a révélé un défaut important : PyInstaller 6 utilise par défaut un sous-dossier `_internal`, tandis que `Chemins.py` recherche historiquement les ressources à côté de `Noethys.exe`.
+
+Correction :
+
+```python
+contents_directory="."
+```
+
+Le layout `onedir` plat est donc explicitement conservé.
+
+Le workflow :
+
+- construit le bundle ;
+- contrôle les ressources ;
+- crée l'archive ;
+- la ré-extrait dans un dossier neuf ;
+- retire Python externe du contexte ;
+- lance réellement l'EXE ;
+- vérifie les imports embarqués ;
+- publie l'artefact.
+
+Le runtime hook de smoke produit un marqueur de succès/erreur et utilise une sortie non interactive afin qu'un build `console=False` ne puisse pas bloquer la CI sur une boîte de dialogue invisible.
+
+### Noe-041 — vrai mode portable
+
+Fusion : `bcd8ca96`.
+
+Le dossier `Portable/`, déjà reconnu historiquement par Noethys, est désormais livré explicitement dans l'archive Windows.
+
+Les chemins sont isolés sous ce dossier et les sous-répertoires runtime sont créés à la demande. Les installations classiques sans marqueur `Portable/` conservent leur comportement.
+
+Décision : réutiliser le mécanisme historique plutôt que créer un second système de configuration portable.
+
+## Préparation RC
+
+Préparation documentaire fusionnée : `7bb7121d`.
+
+Toutes les portes automatisées critiques sont désormais considérées franchies. Les deux verrous restants avant une RC validée sont volontairement humains :
+
+1. recette Noe-030 sur une copie de base réellement utilisée ;
+2. validation visuelle et métier de l'interface Windows sur cette copie.
+
+Tant que ces deux étapes ne sont pas réalisées, le dépôt peut produire un **candidat technique RC**, mais pas une RC déclarée validée.
+
+## Choix explicitement reportés après la première RC
+
+- installateur Windows système ;
+- signature de code ;
+- packaging utilisateur macOS ;
+- packaging utilisateur Linux ;
+- bascule baseline Python 3.11/3.12 ;
+- migration obligatoire MySQL/MariaDB ;
+- réécriture de l'architecture desktop ;
+- interopérabilité approfondie Noethys Desktop / NoethysWeb.
+
+Ces reports sont volontaires : ils réduisent le risque et permettent de stabiliser d'abord la modernisation compatible avec l'existant.

--- a/docs/USER-GUIDE-UPGRADE.md
+++ b/docs/USER-GUIDE-UPGRADE.md
@@ -1,0 +1,152 @@
+# Guide utilisateur — Noethys Upgrade
+
+## À qui s'adresse ce guide ?
+
+Ce document concerne les utilisateurs qui souhaitent tester ou utiliser le fork modernisé de Noethys Desktop tout en conservant une installation et des données historiques.
+
+La règle essentielle est simple : **une nouvelle version se teste d'abord sur une copie de la base**.
+
+## Distribution Windows portable
+
+La distribution prioritaire est l'artefact GitHub Actions :
+
+```text
+Noethys-Windows-portable
+```
+
+Après extraction, le dossier contient notamment :
+
+```text
+Noethys.exe
+BUILD-INFO.txt
+Static/
+Portable/
+```
+
+Le dossier `Portable/` active le mode portable historique. La configuration et les bases locales restent alors dans le dossier extrait plutôt que dans le profil Windows.
+
+## Première installation de test
+
+1. créer un nouveau dossier, par exemple `Noethys-RC-Test` ;
+2. extraire intégralement l'archive dans ce dossier ;
+3. ouvrir `BUILD-INFO.txt` pour identifier précisément la version testée ;
+4. ne pas déplacer immédiatement votre base de production ;
+5. lancer `Noethys.exe` une première fois ;
+6. vérifier que l'accueil s'affiche sans erreur de DLL, module ou ressource.
+
+## Tester avec une base existante
+
+### Base locale SQLite
+
+1. fermer complètement l'ancien Noethys ;
+2. faire une copie indépendante du fichier de base ;
+3. conserver l'original dans son emplacement habituel ;
+4. placer uniquement la **copie** dans `Portable/Data/` du dossier de test ;
+5. ouvrir cette copie avec le Noethys modernisé.
+
+Avant la recette, le préflight Noe-030 peut produire une empreinte de référence :
+
+```bash
+python scripts/recette_existing_db_readonly.py --sqlite copie.dat --json avant.json
+```
+
+Après la recette, un second passage permet de vérifier l'absence de changement de schéma inattendu.
+
+### Base MySQL/MariaDB
+
+Pour une première qualification :
+
+- préférer une copie de la base sur une instance ou une base de recette ;
+- ne pas tester une nouvelle RC directement sur l'unique base distante en production ;
+- conserver les paramètres de connexion historiques tant qu'aucune migration n'est explicitement décidée.
+
+Le chantier Upgrade Noethys n'impose pas une migration vers un serveur MySQL/MariaDB plus récent pour cette RC.
+
+## Recette minimale
+
+Sur la copie, contrôler au minimum :
+
+- ouverture d'une famille ;
+- ouverture d'un individu ;
+- consultation et modification d'une inscription de test ;
+- consommations/réservations ;
+- prestation et facturation ;
+- saisie et ventilation d'un règlement ;
+- liste des règlements/dépôts ;
+- export comptable réellement utilisé ;
+- génération d'un PDF ;
+- fermeture puis réouverture de Noethys.
+
+Si votre installation utilise des fonctions particulières, ajouter leurs vérifications : portail, MySQL distant, SFTP/FTPS, impression, périphériques, extensions, etc.
+
+## Sauvegarde
+
+Avant toute mise à jour ou recette :
+
+- conserver une sauvegarde extérieure au dossier de test ;
+- pour SQLite, conserver une copie intacte du fichier de base ;
+- pour MySQL/MariaDB, disposer d'un export ou d'une copie serveur indépendante ;
+- ne pas considérer le seul dossier portable comme une stratégie de sauvegarde.
+
+Le format de sauvegarde Noethys historique reste utilisé (`.nod` non chiffré, `.noc` chiffré lorsque ce mode est choisi).
+
+## Restauration
+
+La restauration a été auditée et plusieurs erreurs historiques de contrôle de flux ont été corrigées dans le fork. Malgré cela, une restauration doit d'abord être testée sur une copie ou un environnement de recette.
+
+Après restauration :
+
+1. ouvrir la base restaurée ;
+2. vérifier les données essentielles ;
+3. réaliser quelques parcours métier représentatifs ;
+4. ne remplacer la base de travail qu'après validation.
+
+## Mise à jour d'un portable existant
+
+Le dossier `Portable/` peut contenir votre configuration et vos bases locales. **Ne le supprimez pas sans sauvegarde.**
+
+Méthode recommandée :
+
+1. conserver l'ancien dossier Noethys complet ;
+2. extraire la nouvelle version dans un dossier neuf ;
+3. sauvegarder le contenu de l'ancien `Portable/` ;
+4. tester la nouvelle version avec une copie des données ;
+5. seulement après validation, décider du transfert de la configuration/données nécessaires.
+
+Cette méthode permet un retour arrière immédiat.
+
+## Retour arrière
+
+Tant que la base n'a subi aucune migration incompatible, le retour arrière consiste à :
+
+- fermer la version modernisée ;
+- conserver la base utilisée pour analyse ;
+- reprendre l'ancien dossier/application avec votre sauvegarde intacte.
+
+Le projet comporte des garde-fous contre les migrations implicites, mais la recette sur copie reste obligatoire avant une RC.
+
+## Windows, macOS et Linux
+
+### Windows
+
+Windows est la plateforme de distribution la plus avancée. L'archive portable est construite puis réellement extraite et exécutée en CI sans environnement Python externe.
+
+### macOS
+
+Le code source est testé automatiquement avec Python/wxPython sur macOS. Il n'existe pas encore, au même niveau de qualification, de paquet utilisateur signé/notarisé équivalent au portable Windows.
+
+### Linux
+
+Le code source est testé sous Ubuntu avec wxPython GTK3 et un environnement graphique virtuel. Il n'existe pas encore de paquet Linux final équivalent au portable Windows.
+
+## Ce que signifie une CI verte
+
+Une CI verte confirme de nombreuses frontières techniques et non-régressions, mais ne peut pas inspecter chaque écran ni connaître les particularités de votre base historique.
+
+Avant d'adopter une RC :
+
+- vérifier le SHA du build ;
+- tester le démarrage réel ;
+- ouvrir une copie de votre base ;
+- exécuter la recette minimale ;
+- conserver une sauvegarde de retour arrière.


### PR DESCRIPTION
Clôt la tranche documentaire de la roadmap :
- guide développeur : architecture, Python 3.10, tests, audits, DB, wxPython et packaging ;
- guide utilisateur : portable Windows, mise à jour, sauvegarde/restauration et recette sur copie ;
- historique Upgrade Noethys : décisions structurantes, compatibilité et jalons ;
- README remis à jour avec l'état réel : candidat technique RC, véritable EXE qualifié et mode `Portable/`.

Issues : #20, #21, #22