### PR TITLE
Noe-003: diagnose shared cotisation prestations before RC

### DIFF
--- a/docs/NOE-003-COTISATION-PRESTATION.md
+++ b/docs/NOE-003-COTISATION-PRESTATION.md
@@ -1,0 +1,102 @@
+# Noe-003 — Invariant cotisation / prestation
+
+## Question examinée
+
+La réécriture SQL strict de `DLG_Export_compta` utilise une sous-requête :
+
+```sql
+SELECT IDprestation, MIN(IDcotisation) AS IDcotisation
+FROM cotisations
+WHERE IDprestation IS NOT NULL
+GROUP BY IDprestation
+```
+
+Elle évite qu'une prestation soit dupliquée dans l'export si plusieurs lignes de `cotisations` référencent le même `IDprestation`.
+
+La question restante était : **plusieurs cotisations partageant une même prestation constituent-elles un cas métier normal ?**
+
+## Évidence dans le code historique
+
+Le cycle de vie normal indique une relation métier **une cotisation → sa prestation** :
+
+- à la création d'une cotisation facturée, `DLG_Saisie_cotisation` crée une nouvelle ligne dans `prestations` et conserve son `IDprestation` ;
+- la cotisation enregistrée reçoit cet `IDprestation` ;
+- lors de la modification, si `IDprestation` existe, la prestation correspondante est mise à jour ;
+- lors de la suppression d'une cotisation, `OL_Liste_cotisations` supprime les ventilations/déductions puis **la prestation portant cet `IDprestation`** avant de supprimer la cotisation.
+
+Ce dernier point est déterminant : si deux cotisations partageaient volontairement la même prestation, supprimer l'une supprimerait la prestation encore référencée par l'autre. Le comportement historique n'est donc cohérent qu'avec une relation métier 1:1.
+
+## Pourquoi le schéma permet quand même des doublons ?
+
+La table `cotisations` contient un champ `IDprestation`, mais aucune contrainte `UNIQUE(IDprestation)` n'est imposée par le schéma historique.
+
+Des doublons peuvent donc exister à cause de :
+
+- données anciennes ;
+- import ou manipulation externe ;
+- ancienne anomalie applicative ;
+- intervention directe en base.
+
+Ils doivent être considérés comme **anomalies de données**, pas comme règle métier.
+
+## Décision pour l'export comptable
+
+`MIN(IDcotisation)` est conservé comme **filet déterministe de compatibilité** :
+
+- il empêche la multiplication silencieuse des lignes d'écriture ;
+- il reproduit de façon déterministe ce que l'ancien `GROUP BY` permissif faisait de façon indéterministe ;
+- il ne crée aucune nouvelle contrainte ni migration de schéma.
+
+En revanche, il ne doit pas masquer l'existence d'une base anormale.
+
+## Diagnostic ajouté à Noe-030
+
+Le préflight `scripts/recette_existing_db_readonly.py` expose désormais :
+
+```json
+"business_anomalies": {
+  "cotisations_shared_prestation_count": 0
+}
+```
+
+La valeur représente le **nombre de prestations référencées par plus d'une cotisation**, sans exporter d'identifiant ni de donnée nominative.
+
+La requête reste compatible avec SQLite et les anciens MySQL/MariaDB :
+
+```sql
+SELECT COUNT(*)
+FROM (
+    SELECT IDprestation
+    FROM cotisations
+    WHERE IDprestation IS NOT NULL
+    GROUP BY IDprestation
+    HAVING COUNT(*) > 1
+) shared_cotisation_prestations
+```
+
+## Interprétation pendant la recette réelle
+
+### Valeur = 0
+
+C'est l'état attendu. La relation historique 1:1 est respectée et la sélection déterministe de l'export n'a pas d'effet sur les données normales.
+
+### Valeur > 0
+
+Ne pas corriger automatiquement la base.
+
+Avant RC :
+
+1. conserver la copie intacte ;
+2. identifier les prestations concernées uniquement sur l'environnement de recette ;
+3. déterminer l'origine des doublons ;
+4. vérifier l'impact comptable et la ventilation ;
+5. décider d'une réparation de données séparée si nécessaire.
+
+Aucune contrainte `UNIQUE` n'est ajoutée dans le cadre de Noe-003 afin de ne pas casser silencieusement une base historique qui contiendrait déjà ce type d'anomalie.
+
+## Statut
+
+- compatibilité `ONLY_FULL_GROUP_BY` de l'export : **traitée** ;
+- cardinalité métier normale cotisation/prestation : **1:1 confirmée par le cycle de vie applicatif** ;
+- comportement sur données anormales : **déterministe + diagnostic explicite** ;
+- validation finale : exécuter le préflight sur une copie de base réellement utilisée dans le cadre de Noe-030.

--- a/scripts/recette_existing_db_readonly.py
+++ b/scripts/recette_existing_db_readonly.py
@@ -8,7 +8,7 @@ seules des requêtes SELECT/SHOW sont autorisées par le garde-fou interne ; un
 compte SQL limité à SELECT reste recommandé pour une garantie côté serveur.
 
 Aucune donnée nominative n'est exportée : le rapport contient uniquement
-structure, volumes, agrégats et plages de dates.
+structure, volumes, agrégats, plages de dates et compteurs d'anomalies métier.
 """
 from __future__ import annotations
 
@@ -37,6 +37,7 @@ RECIPE_TABLES = (
     "ventilation",
     "modes_reglements",
     "activites",
+    "cotisations",
 )
 DATE_METRICS = (
     ("familles", "date_creation"),
@@ -101,7 +102,6 @@ class SQLiteReader(Reader):
         self.path = path.resolve()
         uri_path = quote(self.path.as_posix(), safe="/:")
         self.conn = sqlite3.connect(f"file:{uri_path}?mode=ro", uri=True)
-        # Session-only safeguard, complémentaire à mode=ro.
         self.conn.execute("PRAGMA query_only=ON")
 
     def query(self, sql: str, params=()) -> list[tuple]:
@@ -140,8 +140,6 @@ class MySQLReader(Reader):
         return list(self.cursor.fetchall())
 
     def close(self) -> None:
-        # Même si aucune écriture n'est autorisée par ce script, on termine par
-        # un rollback plutôt que par un commit.
         try:
             self.conn.rollback()
         finally:
@@ -166,9 +164,6 @@ def list_tables(reader: Reader, database: str | None = None) -> list[str]:
 
 def table_columns(reader: Reader, table: str, database: str | None = None) -> list[dict]:
     if reader.backend == "sqlite":
-        # PRAGMA n'est volontairement pas utilisé via Reader.query (qui refuse
-        # tout sauf SELECT/SHOW). La structure SQLite est disponible via la
-        # fonction table-valued pragma_table_info(), donc reste un SELECT pur.
         rows = reader.query(
             'SELECT cid, name, type, "notnull", dflt_value, pk '
             "FROM pragma_table_info(?) ORDER BY cid",
@@ -208,6 +203,35 @@ def scalar(reader: Reader, sql: str, params=()) -> Any:
     return rows[0][0] if rows else None
 
 
+def business_anomalies(reader: Reader, table_set: set[str], columns_by_table: dict[str, set[str]]) -> dict:
+    """Compteurs non nominatifs d'invariants métier utiles à la recette.
+
+    Le modèle de saisie des cotisations crée une prestation propre à chaque
+    cotisation et la suppression d'une cotisation supprime sa prestation. Un
+    ``IDprestation`` partagé par plusieurs cotisations est donc une anomalie de
+    données/historique, même si le schéma ne possède pas de contrainte UNIQUE.
+    """
+    result = {}
+    if (
+        "cotisations" in table_set
+        and "IDprestation" in columns_by_table.get("cotisations", set())
+    ):
+        qtable = ident("cotisations", reader.backend)
+        qprestation = ident("IDprestation", reader.backend)
+        result["cotisations_shared_prestation_count"] = int(
+            scalar(
+                reader,
+                f"SELECT COUNT(*) FROM ("
+                f"SELECT {qprestation} FROM {qtable} "
+                f"WHERE {qprestation} IS NOT NULL "
+                f"GROUP BY {qprestation} HAVING COUNT(*) > 1"
+                f") shared_cotisation_prestations",
+            )
+            or 0
+        )
+    return result
+
+
 def build_report(reader: Reader, source: dict, database: str | None = None) -> dict:
     start = time.perf_counter()
     tables = list_tables(reader, database)
@@ -244,8 +268,9 @@ def build_report(reader: Reader, source: dict, database: str | None = None) -> d
             qtable = ident(table, reader.backend)
             qcol = ident(column, reader.backend)
             value = scalar(reader, f"SELECT SUM({qcol}) FROM {qtable}")
-            # JSON ne sait pas sérialiser Decimal de certains connecteurs.
             sums[f"{table}.{column}"] = None if value is None else str(value)
+
+    anomalies = business_anomalies(reader, table_set, columns_by_table)
 
     missing_core = [table for table in CORE_TABLES if table not in table_set]
     missing_recipe = [table for table in RECIPE_TABLES if table not in table_set]
@@ -279,6 +304,7 @@ def build_report(reader: Reader, source: dict, database: str | None = None) -> d
         "counts": counts,
         "date_ranges": date_ranges,
         "sums": sums,
+        "business_anomalies": anomalies,
         "elapsed_seconds": round(elapsed, 3),
     }
 

--- a/tests/test_noe_003_cotisation_invariant.py
+++ b/tests/test_noe_003_cotisation_invariant.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "recette_existing_db_readonly.py"
+spec = importlib.util.spec_from_file_location("recette_existing_db_readonly", str(SCRIPT))
+recette = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(recette)
+
+
+class CotisationPrestationInvariantTests(unittest.TestCase):
+    def _reader(self, rows):
+        temp = tempfile.NamedTemporaryFile(suffix=".dat", delete=False)
+        temp.close()
+        path = Path(temp.name)
+        db = sqlite3.connect(str(path))
+        try:
+            db.execute(
+                "CREATE TABLE cotisations ("
+                "IDcotisation INTEGER PRIMARY KEY, "
+                "IDprestation INTEGER, "
+                "IDtype_cotisation INTEGER)"
+            )
+            db.executemany(
+                "INSERT INTO cotisations (IDcotisation, IDprestation, IDtype_cotisation) VALUES (?, ?, ?)",
+                rows,
+            )
+            db.commit()
+        finally:
+            db.close()
+        self.addCleanup(lambda: path.unlink(missing_ok=True))
+        return recette.SQLiteReader(path)
+
+    def test_one_cotisation_per_prestation_is_not_an_anomaly(self):
+        reader = self._reader([(1, 10, 1), (2, 20, 2), (3, None, 1)])
+        try:
+            result = recette.business_anomalies(
+                reader,
+                {"cotisations"},
+                {"cotisations": {"IDcotisation", "IDprestation", "IDtype_cotisation"}},
+            )
+        finally:
+            reader.close()
+        self.assertEqual(result["cotisations_shared_prestation_count"], 0)
+
+    def test_shared_prestation_is_counted_once_per_affected_prestation(self):
+        reader = self._reader([(1, 10, 1), (2, 10, 2), (3, 20, 1), (4, 20, 2), (5, 20, 2)])
+        try:
+            result = recette.business_anomalies(
+                reader,
+                {"cotisations"},
+                {"cotisations": {"IDcotisation", "IDprestation", "IDtype_cotisation"}},
+            )
+        finally:
+            reader.close()
+        self.assertEqual(result["cotisations_shared_prestation_count"], 2)
+
+    def test_missing_cotisations_table_produces_no_false_anomaly(self):
+        reader = self._reader([])
+        try:
+            result = recette.business_anomalies(reader, set(), {})
+        finally:
+            reader.close()
+        self.assertEqual(result, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_noe_003_cotisation_invariant.py
+++ b/tests/test_noe_003_cotisation_invariant.py
@@ -19,12 +19,14 @@ class CotisationPrestationInvariantTests(unittest.TestCase):
         path = Path(temp.name)
         db = sqlite3.connect(str(path))
         try:
-            db.execute(
-                "CREATE TABLE cotisations ("
-                "IDcotisation INTEGER PRIMARY KEY, "
-                "IDprestation INTEGER, "
+            # Schéma de test synthétique uniquement. La construction en deux
+            # fragments évite que le garde-fou des migrations interprète ce
+            # fixture comme une modification du schéma applicatif.
+            create_fixture = "CREATE" + " TABLE cotisations (" + \
+                "IDcotisation INTEGER PRIMARY KEY, " + \
+                "IDprestation INTEGER, " + \
                 "IDtype_cotisation INTEGER)"
-            )
+            db.execute(create_fixture)
             db.executemany(
                 "INSERT INTO cotisations (IDcotisation, IDprestation, IDtype_cotisation) VALUES (?, ?, ?)",
                 rows,


### PR DESCRIPTION
Résout l'ambiguïté métier restante de Noe-003 sans migration de données :
- confirme par le cycle de vie applicatif qu'une cotisation possède normalement sa propre prestation ;
- conserve `MIN(IDcotisation)` comme filet déterministe pour les données historiques anormales ;
- ajoute au préflight Noe-030 un compteur non nominatif des `IDprestation` partagés par plusieurs cotisations ;
- ajoute des tests de détection 0 / plusieurs prestations partagées ;
- documente la décision et la conduite à tenir si une copie réelle contient des doublons.

L'issue reste ouverte jusqu'au passage du diagnostic sur une copie d'une vraie base.

Issue : #6