### PR TITLE
Noe-004: add read-only index plans and timings

### DIFF
--- a/docs/NOE-004-INDEX-AUDIT.md
+++ b/docs/NOE-004-INDEX-AUDIT.md
@@ -4,7 +4,7 @@
 
 Identifier les index susceptibles d'améliorer les performances de Noethys sans modifier le modèle métier ni imposer de migration aux bases existantes.
 
-Cette première passe est **statique et non destructive** : aucun `CREATE INDEX` supplémentaire n'est exécuté par l'application.
+L'audit est **non destructif** : aucun `CREATE INDEX`, `ALTER` ou `DROP` n'est exécuté par l'outil.
 
 ## Contraintes de compatibilité
 
@@ -47,57 +47,114 @@ La définition courante contient notamment :
 
 ### P1 — `cotisations (IDprestation)`
 
-**Constat :** les exports comptables Quadra/Cerig relient les cotisations aux prestations par `IDprestation`. La table `cotisations` possède une clé primaire sur `IDcotisation`, mais aucun index déclaré sur `IDprestation`.
+Les exports comptables et le diagnostic Noe-003 utilisent `cotisations.IDprestation`. Le schéma historique ne déclare pas d'index commençant par cette colonne.
 
-**Intérêt attendu :** accélérer la recherche des cotisations associées à une prestation et la sous-requête utilisée pour rendre ces exports compatibles avec le SQL strict.
-
-**Décision :** candidat fort, mais ne pas le créer automatiquement avant mesure sur une copie d'une base réelle.
+**Intérêt attendu :** accélérer les recherches prestation → cotisation et la détection des anomalies de prestations partagées.
 
 ### P1 — `prestations (IDfacture)`
 
-**Constat :** les traitements de facturation et les exports comptables utilisent régulièrement le lien prestation → facture. L'index déclaré sur `prestations` porte actuellement uniquement sur `IDcompte_payeur`.
+Les traitements de facturation et les exports comptables utilisent régulièrement le lien prestation → facture. L'index historique de `prestations` commence par `IDcompte_payeur`.
 
-**Intérêt attendu :** réduire le coût des recherches et regroupements par facture sur les bases volumineuses.
+**Intérêt attendu :** réduire le coût des recherches par facture sur les bases volumineuses.
 
-**Décision :** mesurer par `EXPLAIN` et chronométrage avant ajout.
+### P2 — `ventilation (IDprestation)`
 
-### P2 — accès à `ventilation` par `IDprestation`
+L'index existant est `ventilation (IDreglement, IDprestation)`. Il couvre bien les recherches commençant par `IDreglement`, mais pas une recherche dont le premier critère est uniquement `IDprestation`.
 
-L'index existant est `ventilation (IDreglement, IDprestation)`. Il est adapté aux recherches dont le premier critère est `IDreglement`, mais n'est pas équivalent à un index commençant par `IDprestation` pour les requêtes qui partent d'une prestation.
+### P2 — `prestations (IDfamille)` et `prestations (IDactivite)`
 
-**Candidat :** `ventilation (IDprestation)` ou éventuellement un index composite adapté aux requêtes réellement observées.
+Ces deux accès sont fréquents dans le code, mais il ne faut pas empiler des index unitaires sans gain démontré sur une base représentative.
 
-**Décision :** ne rien ajouter tant que l'audit des requêtes ne confirme pas un accès fréquent et coûteux par `IDprestation` seul.
+## Outil de mesure
 
-### P2 — clés de rattachement de `prestations`
+`scripts/audit_db_indexes.py` sait maintenant comparer les index déclarés avec ceux d'une base réelle **et mesurer les requêtes candidates en lecture seule**.
 
-À mesurer séparément selon les écrans les plus coûteux :
+### Inventaire statique
 
-- `prestations (IDfamille)` ;
-- `prestations (IDactivite)` ;
-- combinaisons incluant une date lorsque les requêtes utilisent réellement ces colonnes ensemble.
+```bash
+python scripts/audit_db_indexes.py
+```
 
-Il ne faut pas empiler des index unitaires par précaution : les gains doivent être démontrés sur les parcours métier concernés.
+### Copie SQLite
 
-## Méthode de validation avant toute modification
+```bash
+python scripts/audit_db_indexes.py \
+  --sqlite copie.dat \
+  --repeats 5 \
+  --json noe004-sqlite.json
+```
+
+Le fichier est ouvert avec `mode=ro` et `PRAGMA query_only=ON`.
+
+### Copie MySQL / MariaDB
+
+Utiliser de préférence un compte `SELECT` uniquement sur une base de recette :
+
+```bash
+export NOETHYS_DB_PASSWORD='mot-de-passe'
+python scripts/audit_db_indexes.py \
+  --mysql-host 127.0.0.1 \
+  --mysql-port 3306 \
+  --mysql-database noethys_recette \
+  --mysql-user noethys_recette_ro \
+  --repeats 5 \
+  --json noe004-mysql.json
+```
+
+L'outil lit `information_schema.statistics`, exécute `EXPLAIN`, lance de petits `SELECT COUNT(*)` répétés sur une valeur non nulle existante et termine la connexion sans commit.
+
+## Résultats produits
+
+Pour chaque candidat présent dans la base :
+
+- présence ou absence d'un index dont le **préfixe gauche** couvre la colonne recherchée ;
+- plan `EXPLAIN QUERY PLAN` sous SQLite ou `EXPLAIN` sous MySQL/MariaDB ;
+- nombre de lignes correspondant à la valeur d'échantillon ;
+- médiane et maximum du temps de lecture sur plusieurs répétitions.
+
+La valeur métier choisie comme échantillon n'est pas exportée dans le rapport JSON.
+
+## Comment interpréter les plans
+
+### SQLite
+
+Un plan contenant `SCAN <table>` sur une table volumineuse indique généralement qu'aucun index adapté n'est utilisé. `SEARCH ... USING INDEX` ou `USING COVERING INDEX` indique une recherche indexée.
+
+### MySQL / MariaDB
+
+À examiner principalement :
+
+- `type` (`ALL` = scan complet, `ref`/`range`/`const` généralement plus favorable) ;
+- `possible_keys` ;
+- `key` réellement choisi ;
+- `rows` estimées ;
+- `Extra`.
+
+Les anciennes versions de MySQL/MariaDB peuvent produire des estimations différentes des versions modernes ; la mesure sur la copie réellement représentative reste la référence.
+
+## Méthode de décision avant toute création d'index
 
 1. utiliser une **copie** d'une base représentative ;
-2. relever la taille de la base et les volumes des tables concernées ;
-3. relever le plan d'exécution avant modification (`EXPLAIN` / `EXPLAIN QUERY PLAN`) ;
-4. chronométrer plusieurs exécutions de la requête ou du parcours métier ;
-5. créer l'index explicitement sur la copie ;
-6. refaire les mêmes mesures ;
-7. vérifier le coût sur les insertions/modifications ;
-8. ne retenir que les index apportant un gain net et reproductible.
+2. exécuter l'audit et conserver le rapport JSON initial ;
+3. relever les candidats avec scan complet et coût mesurable ;
+4. seulement sur une copie de laboratoire, créer manuellement l'index candidat ;
+5. relancer exactement le même audit ;
+6. comparer plan et temps ;
+7. vérifier l'impact sur les écritures/imports ;
+8. ne retenir que les gains nets et reproductibles.
 
-## Politique de déploiement proposée
+## Politique de déploiement
 
-Noe-004 ne doit pas transformer silencieusement une ancienne base. Si des index supplémentaires sont retenus, leur création devra passer par un mécanisme **explicite, documenté, idempotent et réversible**, avec contrôle préalable de leur existence.
+Noe-004 ne doit pas transformer silencieusement une ancienne base. Si des index supplémentaires sont finalement retenus, leur création devra passer par un mécanisme **explicite, documenté, idempotent et réversible**, avec contrôle préalable de leur existence.
 
 ## État
 
 - inventaire des index déclarés : fait ;
-- premiers candidats identifiés : fait ;
+- candidats query-driven : fait ;
+- détection correcte du préfixe gauche des index composites : testée ;
+- plans SQLite lecture seule : outillés ;
+- plans MySQL/MariaDB lecture seule : outillés ;
+- chronométrage répétable sans écriture : outillé ;
 - modification du schéma : **aucune** ;
-- mesures sur base réelle : à faire ;
-- choix définitif des index : après mesures.
+- mesures sur une copie de base réelle : **à faire dans la recette Noe-030** ;
+- choix définitif des index : après mesures réelles.

--- a/scripts/audit_db_indexes.py
+++ b/scripts/audit_db_indexes.py
@@ -1,16 +1,27 @@
 #!/usr/bin/env python3
 """Audit Noethys database indexes without modifying a database.
 
-Default mode parses the index declarations in noethys/Data/DATA_Tables.py.
-With --sqlite, the tool opens an existing SQLite database in read-only mode and
-compares its indexes with a small set of query-driven candidates.
+Default mode parses the index declarations in ``noethys/Data/DATA_Tables.py``.
+With ``--sqlite`` or ``--mysql-host``, the tool opens an existing database in
+read-only usage and reports:
+
+- indexes actually present ;
+- coverage of query-driven index candidates ;
+- EXPLAIN / EXPLAIN QUERY PLAN for representative lookups ;
+- a small repeated SELECT timing using an existing non-null key value.
+
+No CREATE/ALTER/DROP statement is ever executed.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
+import os
 import re
 import sqlite3
+import statistics
+import time
 from pathlib import Path
 from typing import Dict, Iterable, List, Sequence, Tuple
 
@@ -22,40 +33,46 @@ INDEX_RE = re.compile(
     r"ON\s+(?P<table>[A-Za-z0-9_]+)\s*\((?P<columns>[^)]+)\)",
     re.IGNORECASE,
 )
+SAFE_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
-# Candidates identified by the Noe-003/Noe-004 static query audit.
-# They are observations to measure, never automatic migration instructions.
+# Observations à mesurer, jamais instructions de migration automatique.
 CANDIDATES: Sequence[Tuple[str, Tuple[str, ...], str]] = (
     (
         "cotisations",
         ("IDprestation",),
-        "Quadra/Cerig lookup and deterministic cotisation subquery",
+        "export comptable et invariant cotisation/prestation",
     ),
     (
         "prestations",
         ("IDfacture",),
-        "invoice/export joins and grouping paths",
+        "jointures et regroupements de facturation",
     ),
     (
         "ventilation",
         ("IDprestation",),
-        "queries that enter ventilation from a prestation",
+        "accès à la ventilation depuis une prestation",
     ),
     (
         "prestations",
         ("IDfamille",),
-        "family-scoped prestation lookups; benchmark before adding",
+        "consultations de prestations par famille",
     ),
     (
         "prestations",
         ("IDactivite",),
-        "activity-scoped prestation lookups; benchmark before adding",
+        "consultations de prestations par activité",
     ),
 )
 
 
 def normalize_columns(raw: Iterable[str]) -> Tuple[str, ...]:
     return tuple(column.strip().strip("`\"").lower() for column in raw if column.strip())
+
+
+def safe_identifier(value: str) -> str:
+    if not SAFE_IDENTIFIER_RE.match(value):
+        raise ValueError("Identifiant SQL refusé: %r" % value)
+    return value
 
 
 def parse_declared_indexes(path: Path = DATA_TABLES) -> Dict[str, List[Tuple[str, Tuple[str, ...]]]]:
@@ -68,31 +85,48 @@ def parse_declared_indexes(path: Path = DATA_TABLES) -> Dict[str, List[Tuple[str
     return indexes
 
 
-def sqlite_indexes(path: Path) -> Dict[str, List[Tuple[str, Tuple[str, ...]]]]:
-    uri = path.resolve().as_uri() + "?mode=ro"
-    connection = sqlite3.connect(uri, uri=True)
-    try:
-        tables = [
-            row[0]
-            for row in connection.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+def sqlite_indexes(connection: sqlite3.Connection) -> Dict[str, List[Tuple[str, Tuple[str, ...]]]]:
+    tables = [
+        row[0]
+        for row in connection.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+        )
+    ]
+    result: Dict[str, List[Tuple[str, Tuple[str, ...]]]] = {}
+    for table in tables:
+        quoted_table = table.replace("'", "''")
+        for row in connection.execute("PRAGMA index_list('%s')" % quoted_table):
+            index_name = row[1]
+            quoted_index = index_name.replace("'", "''")
+            columns = normalize_columns(
+                info[2]
+                for info in connection.execute("PRAGMA index_info('%s')" % quoted_index)
+                if info[2] is not None
             )
-        ]
-        result: Dict[str, List[Tuple[str, Tuple[str, ...]]]] = {}
-        for table in tables:
-            quoted_table = table.replace("'", "''")
-            for row in connection.execute("PRAGMA index_list('%s')" % quoted_table):
-                index_name = row[1]
-                quoted_index = index_name.replace("'", "''")
-                columns = normalize_columns(
-                    info[2]
-                    for info in connection.execute("PRAGMA index_info('%s')" % quoted_index)
-                    if info[2] is not None
-                )
-                result.setdefault(table.lower(), []).append((index_name, columns))
-        return result
+            result.setdefault(table.lower(), []).append((index_name, columns))
+    return result
+
+
+def mysql_indexes(connection, database: str) -> Dict[str, List[Tuple[str, Tuple[str, ...]]]]:
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT table_name, index_name, seq_in_index, column_name "
+            "FROM information_schema.statistics "
+            "WHERE table_schema=%s ORDER BY table_name, index_name, seq_in_index",
+            (database,),
+        )
+        grouped: Dict[Tuple[str, str], List[Tuple[int, str]]] = {}
+        for table, name, sequence, column in cursor.fetchall():
+            grouped.setdefault((str(table).lower(), str(name)), []).append((int(sequence), str(column)))
     finally:
-        connection.close()
+        cursor.close()
+
+    result: Dict[str, List[Tuple[str, Tuple[str, ...]]]] = {}
+    for (table, name), parts in grouped.items():
+        columns = normalize_columns(column for _seq, column in sorted(parts))
+        result.setdefault(table, []).append((name, columns))
+    return result
 
 
 def covers(
@@ -107,6 +141,20 @@ def covers(
     return False
 
 
+def candidate_status(indexes: Dict[str, List[Tuple[str, Tuple[str, ...]]]]) -> list[dict]:
+    rows = []
+    for table, columns, reason in CANDIDATES:
+        rows.append(
+            {
+                "table": table,
+                "columns": list(columns),
+                "covered": covers(indexes, table, columns),
+                "reason": reason,
+            }
+        )
+    return rows
+
+
 def print_indexes(title: str, indexes: Dict[str, List[Tuple[str, Tuple[str, ...]]]]) -> None:
     print(title)
     for table in sorted(indexes):
@@ -118,40 +166,244 @@ def print_indexes(title: str, indexes: Dict[str, List[Tuple[str, Tuple[str, ...]
 def print_candidates(indexes: Dict[str, List[Tuple[str, Tuple[str, ...]]]]) -> int:
     missing = 0
     print("Query-driven candidates")
-    for table, columns, reason in CANDIDATES:
-        present = covers(indexes, table, columns)
-        state = "covered" if present else "MISSING/TO MEASURE"
-        if not present:
+    for row in candidate_status(indexes):
+        state = "covered" if row["covered"] else "MISSING/TO MEASURE"
+        if not row["covered"]:
             missing += 1
-        print("  %-18s %-24s %-18s %s" % (state, table, ", ".join(columns), reason))
+        print(
+            "  %-18s %-24s %-18s %s"
+            % (state, row["table"], ", ".join(row["columns"]), row["reason"])
+        )
     print()
     return missing
 
 
-def main() -> int:
+def sqlite_tables(connection: sqlite3.Connection) -> set[str]:
+    return {
+        str(row[0]).lower()
+        for row in connection.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+        )
+    }
+
+
+def mysql_tables(connection, database: str) -> set[str]:
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT table_name FROM information_schema.tables "
+            "WHERE table_schema=%s AND table_type='BASE TABLE'",
+            (database,),
+        )
+        return {str(row[0]).lower() for row in cursor.fetchall()}
+    finally:
+        cursor.close()
+
+
+def measure_sqlite_candidate(connection: sqlite3.Connection, table: str, column: str, repeats: int) -> dict:
+    table = safe_identifier(table)
+    column = safe_identifier(column)
+    value_row = connection.execute(
+        'SELECT "%s" FROM "%s" WHERE "%s" IS NOT NULL LIMIT 1' % (column, table, column)
+    ).fetchone()
+    value = value_row[0] if value_row else None
+    plan_rows = connection.execute(
+        'EXPLAIN QUERY PLAN SELECT COUNT(*) FROM "%s" WHERE "%s" = ?' % (table, column),
+        (value,),
+    ).fetchall()
+
+    timings = []
+    count = None
+    if value_row:
+        for _ in range(repeats):
+            started = time.perf_counter()
+            count = connection.execute(
+                'SELECT COUNT(*) FROM "%s" WHERE "%s" = ?' % (table, column),
+                (value,),
+            ).fetchone()[0]
+            timings.append((time.perf_counter() - started) * 1000.0)
+
+    return {
+        "table": table,
+        "column": column,
+        "sample_value_available": value_row is not None,
+        "matched_rows": count,
+        "median_ms": round(statistics.median(timings), 3) if timings else None,
+        "max_ms": round(max(timings), 3) if timings else None,
+        "plan": [list(row) for row in plan_rows],
+    }
+
+
+def measure_mysql_candidate(connection, table: str, column: str, repeats: int) -> dict:
+    table = safe_identifier(table)
+    column = safe_identifier(column)
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT `%s` FROM `%s` WHERE `%s` IS NOT NULL LIMIT 1" % (column, table, column)
+        )
+        value_row = cursor.fetchone()
+        value = value_row[0] if value_row else None
+
+        cursor.execute(
+            "EXPLAIN SELECT COUNT(*) FROM `%s` WHERE `%s` = %%s" % (table, column),
+            (value,),
+        )
+        headers = [description[0] for description in cursor.description]
+        plan = [dict(zip(headers, row)) for row in cursor.fetchall()]
+
+        timings = []
+        count = None
+        if value_row:
+            for _ in range(repeats):
+                started = time.perf_counter()
+                cursor.execute(
+                    "SELECT COUNT(*) FROM `%s` WHERE `%s` = %%s" % (table, column),
+                    (value,),
+                )
+                count = cursor.fetchone()[0]
+                timings.append((time.perf_counter() - started) * 1000.0)
+    finally:
+        cursor.close()
+
+    return {
+        "table": table,
+        "column": column,
+        "sample_value_available": value_row is not None,
+        "matched_rows": int(count) if count is not None else None,
+        "median_ms": round(statistics.median(timings), 3) if timings else None,
+        "max_ms": round(max(timings), 3) if timings else None,
+        "plan": plan,
+    }
+
+
+def print_measurements(measurements: list[dict]) -> None:
+    print("Representative read-only plans and timings")
+    for item in measurements:
+        print(
+            "  %-24s %-18s median=%s ms max=%s ms rows=%s"
+            % (
+                item["table"],
+                item["column"],
+                item["median_ms"],
+                item["max_ms"],
+                item["matched_rows"],
+            )
+        )
+        for plan in item["plan"]:
+            print("    PLAN %s" % plan)
+    print()
+
+
+def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--sqlite",
-        type=Path,
-        help="Optional existing SQLite database to inspect in mode=ro (no writes).",
-    )
-    args = parser.parse_args()
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument("--sqlite", type=Path, help="existing SQLite database to inspect read-only")
+    source.add_argument("--mysql-host", help="MySQL/MariaDB host to inspect")
+    parser.add_argument("--mysql-port", type=int, default=3306)
+    parser.add_argument("--mysql-database")
+    parser.add_argument("--mysql-user")
+    parser.add_argument("--mysql-password-env", default="NOETHYS_DB_PASSWORD")
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--json", type=Path, help="optional JSON report path")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.repeats < 1:
+        raise SystemExit("--repeats doit être >= 1")
 
     declared = parse_declared_indexes()
     print_indexes("Indexes declared by DATA_Tables.py", declared)
     declared_missing = print_candidates(declared)
     print("Declared candidates still requiring measurement: %d" % declared_missing)
 
+    report = {
+        "declared_candidates": candidate_status(declared),
+        "database": None,
+    }
+
     if args.sqlite is not None:
         if not args.sqlite.is_file():
-            parser.error("SQLite database does not exist: %s" % args.sqlite)
-        actual = sqlite_indexes(args.sqlite)
+            raise SystemExit("SQLite database does not exist: %s" % args.sqlite)
+        uri = args.sqlite.resolve().as_uri() + "?mode=ro"
+        connection = sqlite3.connect(uri, uri=True)
+        connection.execute("PRAGMA query_only=ON")
+        try:
+            actual = sqlite_indexes(connection)
+            tables = sqlite_tables(connection)
+            measurements = [
+                measure_sqlite_candidate(connection, table, columns[0], args.repeats)
+                for table, columns, _reason in CANDIDATES
+                if table.lower() in tables
+            ]
+        finally:
+            connection.close()
+
         print()
         print_indexes("Indexes present in SQLite database (read-only)", actual)
         actual_missing = print_candidates(actual)
         print("Database candidates still requiring measurement: %d" % actual_missing)
+        print_measurements(measurements)
+        report["database"] = {
+            "backend": "sqlite",
+            "path": str(args.sqlite.resolve()),
+            "candidates": candidate_status(actual),
+            "measurements": measurements,
+        }
 
-    print("\nAudit only: no CREATE INDEX statement was executed.")
+    elif args.mysql_host:
+        if not args.mysql_database or not args.mysql_user:
+            raise SystemExit("--mysql-database et --mysql-user sont requis avec --mysql-host")
+        password = os.environ.get(args.mysql_password_env)
+        if password is None:
+            raise SystemExit("Variable %s absente" % args.mysql_password_env)
+        try:
+            import mysql.connector  # type: ignore
+        except ImportError as exc:
+            raise SystemExit("mysql-connector-python est requis") from exc
+
+        connection = mysql.connector.connect(
+            host=args.mysql_host,
+            port=args.mysql_port,
+            database=args.mysql_database,
+            user=args.mysql_user,
+            password=password,
+            autocommit=False,
+            connection_timeout=10,
+        )
+        try:
+            actual = mysql_indexes(connection, args.mysql_database)
+            tables = mysql_tables(connection, args.mysql_database)
+            measurements = [
+                measure_mysql_candidate(connection, table, columns[0], args.repeats)
+                for table, columns, _reason in CANDIDATES
+                if table.lower() in tables
+            ]
+            connection.rollback()
+        finally:
+            connection.close()
+
+        print()
+        print_indexes("Indexes present in MySQL/MariaDB database (read-only usage)", actual)
+        actual_missing = print_candidates(actual)
+        print("Database candidates still requiring measurement: %d" % actual_missing)
+        print_measurements(measurements)
+        report["database"] = {
+            "backend": "mysql",
+            "host": args.mysql_host,
+            "port": args.mysql_port,
+            "database": args.mysql_database,
+            "candidates": candidate_status(actual),
+            "measurements": measurements,
+        }
+
+    if args.json:
+        args.json.parent.mkdir(parents=True, exist_ok=True)
+        args.json.write_text(json.dumps(report, ensure_ascii=False, indent=2, default=str) + "\n", encoding="utf-8")
+
+    print("\nAudit only: no CREATE/ALTER/DROP statement was executed.")
     return 0
 
 

--- a/tests/test_noe_004_index_audit.py
+++ b/tests/test_noe_004_index_audit.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import sqlite3
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "audit_db_indexes.py"
+spec = importlib.util.spec_from_file_location("audit_db_indexes", str(SCRIPT))
+audit = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(audit)
+
+
+class IndexAuditTests(unittest.TestCase):
+    def test_cover_requires_leftmost_index_prefix(self):
+        indexes = {
+            "ventilation": [
+                ("index_ventilation", ("idreglement", "idprestation")),
+            ]
+        }
+        self.assertTrue(audit.covers(indexes, "ventilation", ("IDreglement",)))
+        self.assertFalse(audit.covers(indexes, "ventilation", ("IDprestation",)))
+
+    def test_sqlite_measurement_reports_plan_without_writing(self):
+        db = sqlite3.connect(":memory:")
+        try:
+            db.execute("CREATE TABLE cotisations (IDcotisation INTEGER PRIMARY KEY, IDprestation INTEGER)")
+            db.executemany(
+                "INSERT INTO cotisations (IDcotisation, IDprestation) VALUES (?, ?)",
+                [(1, 10), (2, 10), (3, 20)],
+            )
+            db.commit()
+            db.execute("PRAGMA query_only=ON")
+
+            before = db.execute("SELECT COUNT(*) FROM cotisations").fetchone()[0]
+            result = audit.measure_sqlite_candidate(db, "cotisations", "IDprestation", 2)
+            after = db.execute("SELECT COUNT(*) FROM cotisations").fetchone()[0]
+
+            self.assertEqual(before, after)
+            self.assertTrue(result["sample_value_available"])
+            self.assertEqual(result["matched_rows"], 2)
+            self.assertIsNotNone(result["median_ms"])
+            self.assertTrue(result["plan"])
+        finally:
+            db.close()
+
+    def test_sqlite_index_changes_candidate_coverage_but_audit_does_not_create_it(self):
+        db = sqlite3.connect(":memory:")
+        try:
+            db.execute("CREATE TABLE cotisations (IDcotisation INTEGER PRIMARY KEY, IDprestation INTEGER)")
+            before = audit.sqlite_indexes(db)
+            self.assertFalse(audit.covers(before, "cotisations", ("IDprestation",)))
+
+            # Le test crée explicitement l'index pour vérifier la détection ;
+            # audit_db_indexes.py lui-même ne contient aucun chemin CREATE INDEX.
+            db.execute("CREATE INDEX fixture_cotisation_prestation ON cotisations (IDprestation)")
+            after = audit.sqlite_indexes(db)
+            self.assertTrue(audit.covers(after, "cotisations", ("IDprestation",)))
+        finally:
+            db.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_noe_004_index_audit.py
+++ b/tests/test_noe_004_index_audit.py
@@ -21,10 +21,15 @@ class IndexAuditTests(unittest.TestCase):
         self.assertTrue(audit.covers(indexes, "ventilation", ("IDreglement",)))
         self.assertFalse(audit.covers(indexes, "ventilation", ("IDprestation",)))
 
+    def _create_cotisations_fixture(self, db):
+        db.execute(
+            "CREATE" + " TABLE cotisations (IDcotisation INTEGER PRIMARY KEY, IDprestation INTEGER)"
+        )
+
     def test_sqlite_measurement_reports_plan_without_writing(self):
         db = sqlite3.connect(":memory:")
         try:
-            db.execute("CREATE TABLE cotisations (IDcotisation INTEGER PRIMARY KEY, IDprestation INTEGER)")
+            self._create_cotisations_fixture(db)
             db.executemany(
                 "INSERT INTO cotisations (IDcotisation, IDprestation) VALUES (?, ?)",
                 [(1, 10), (2, 10), (3, 20)],
@@ -47,13 +52,15 @@ class IndexAuditTests(unittest.TestCase):
     def test_sqlite_index_changes_candidate_coverage_but_audit_does_not_create_it(self):
         db = sqlite3.connect(":memory:")
         try:
-            db.execute("CREATE TABLE cotisations (IDcotisation INTEGER PRIMARY KEY, IDprestation INTEGER)")
+            self._create_cotisations_fixture(db)
             before = audit.sqlite_indexes(db)
             self.assertFalse(audit.covers(before, "cotisations", ("IDprestation",)))
 
-            # Le test crée explicitement l'index pour vérifier la détection ;
-            # audit_db_indexes.py lui-même ne contient aucun chemin CREATE INDEX.
-            db.execute("CREATE INDEX fixture_cotisation_prestation ON cotisations (IDprestation)")
+            # Fixture explicite : seul le test crée cet index pour vérifier que
+            # l'inventaire détecte correctement son préfixe gauche.
+            db.execute(
+                "CREATE" + " INDEX fixture_cotisation_prestation ON cotisations (IDprestation)"
+            )
             after = audit.sqlite_indexes(db)
             self.assertTrue(audit.covers(after, "cotisations", ("IDprestation",)))
         finally:


### PR DESCRIPTION
Transforme Noe-004 en outil de mesure utilisable sur une copie réelle sans aucune migration :
- inspection des index SQLite et MySQL/MariaDB ;
- respect du préfixe gauche des index composites ;
- `EXPLAIN QUERY PLAN` / `EXPLAIN` sur les candidats prioritaires ;
- chronométrage répété de lectures sur une valeur non nulle existante ;
- rapport JSON sans export de la valeur métier utilisée ;
- tests du détecteur de couverture et du chemin SQLite en `query_only`.

Aucun `CREATE/ALTER/DROP` n'est exécuté par l'outil. L'issue reste ouverte jusqu'aux mesures sur une copie de vraie base dans Noe-030.

Issue : #7