### PR TITLE
Affichage : échelle globale et apparence système/clair/sombre

### DIFF
--- a/noethys/Dlg/DLG_Echelle_interface.py
+++ b/noethys/Dlg/DLG_Echelle_interface.py
@@ -8,53 +8,181 @@
 import wx
 
 from Utils.UTILS_Traduction import _
-from Utils import UTILS_Config
+from Utils import UTILS_Interface
 
 
-VALEURS_ECHELLE = (80, 90, 100, 110, 125, 150, 175, 200)
-CLE_CONFIG = "interface_echelle_pct"
+class Apercu(wx.Panel):
+    """Petit aperçu sans effet sur l'interface en cours."""
+    def __init__(self, parent):
+        wx.Panel.__init__(self, parent, -1, style=wx.BORDER_SIMPLE)
+        self.SetMinSize((500, 190))
+        self.echelle = 100
+        self.apparence = "systeme"
+        self.theme = "Vert"
+        self.Bind(wx.EVT_PAINT, self.OnPaint)
 
+    def SetValeurs(self, echelle=100, apparence="systeme", theme="Vert"):
+        self.echelle = echelle
+        self.apparence = apparence
+        self.theme = theme
+        self.Refresh()
 
-def NormaliseEchelle(valeur, defaut=100):
-    try:
-        valeur = int(valeur)
-    except (TypeError, ValueError):
-        valeur = defaut
-    return min(VALEURS_ECHELLE, key=lambda item: abs(item - valeur))
+    def _font(self, coefficient=1.0, gras=False):
+        police = wx.SystemSettings.GetFont(wx.SYS_DEFAULT_GUI_FONT)
+        police = wx.Font(police)
+        try:
+            taille = police.GetFractionalPointSize()
+        except Exception:
+            taille = float(police.GetPointSize())
+        taille = max(5.0, taille * (self.echelle / 100.0) * coefficient)
+        if hasattr(police, "SetFractionalPointSize"):
+            police.SetFractionalPointSize(taille)
+        else:
+            police.SetPointSize(max(5, int(round(taille))))
+        if gras:
+            police.SetWeight(wx.FONTWEIGHT_BOLD)
+        return police
 
+    def OnPaint(self, event):
+        dc = wx.AutoBufferedPaintDC(self)
+        largeur, hauteur = self.GetClientSize()
+        sombre = UTILS_Interface.EstSombre(self.apparence)
 
-def GetEchelle():
-    return NormaliseEchelle(UTILS_Config.GetParametre(CLE_CONFIG, 100))
+        if sombre:
+            fond = UTILS_Interface.PALETTE_SOMBRE["fond"]
+            fond_controle = UTILS_Interface.PALETTE_SOMBRE["fond_controle"]
+            texte = UTILS_Interface.PALETTE_SOMBRE["texte"]
+            bordure = UTILS_Interface.PALETTE_SOMBRE["bordure"]
+        else:
+            fond = wx.Colour(245, 245, 245)
+            fond_controle = wx.Colour(255, 255, 255)
+            texte = wx.Colour(25, 25, 25)
+            bordure = wx.Colour(190, 190, 190)
 
+        accent = UTILS_Interface.GetValeur(
+            "couleur_claire", wx.Colour(137, 206, 27), theme=self.theme
+        )
 
-def SetEchelle(valeur):
-    valeur = NormaliseEchelle(valeur)
-    UTILS_Config.SetParametre(CLE_CONFIG, valeur)
-    return valeur
+        dc.SetBackground(wx.Brush(fond))
+        dc.Clear()
+
+        marge = 12
+        dc.SetPen(wx.Pen(bordure))
+        dc.SetBrush(wx.Brush(fond_controle))
+        dc.DrawRectangle(marge, marge, max(10, largeur - marge * 2), max(10, hauteur - marge * 2))
+
+        dc.SetTextForeground(texte)
+        dc.SetFont(self._font(1.15, gras=True))
+        dc.DrawText(_(u"Noethys — aperçu"), marge + 12, marge + 10)
+
+        dc.SetFont(self._font())
+        y = marge + 42
+        dc.DrawText(_(u"Mercredi 2 septembre 2026"), marge + 12, y)
+
+        # Bouton / action simulé avec la couleur du thème.
+        texte_bouton = _(u"Ajouter")
+        dc.SetFont(self._font(0.95, gras=True))
+        tw, th = dc.GetTextExtent(texte_bouton)
+        bx = largeur - marge - tw - 30
+        by = marge + 34
+        dc.SetPen(wx.Pen(accent))
+        dc.SetBrush(wx.Brush(accent))
+        dc.DrawRoundedRectangle(bx, by, tw + 20, th + 10, 4)
+        luminance = accent.Red() * 0.299 + accent.Green() * 0.587 + accent.Blue() * 0.114
+        dc.SetTextForeground(wx.BLACK if luminance > 150 else wx.WHITE)
+        dc.DrawText(texte_bouton, bx + 10, by + 5)
+
+        # Mini tableau : on conserve volontairement les couleurs métier.
+        y = marge + 76
+        lignes = [
+            (_(u"Bais — repas enfants"), u"42", wx.Colour(223, 245, 219)),
+            (_(u"Animateurs"), u"6", wx.Colour(236, 242, 248)),
+            (_(u"Alerte capacité"), u"60", wx.Colour(250, 205, 205)),
+        ]
+        hauteur_ligne = max(24, int(round(24 * self.echelle / 100.0)))
+        dc.SetFont(self._font(0.92))
+        for libelle, valeur, couleur in lignes:
+            dc.SetPen(wx.Pen(bordure))
+            dc.SetBrush(wx.Brush(couleur))
+            dc.DrawRectangle(marge + 12, y, max(30, largeur - marge * 2 - 24), hauteur_ligne)
+            dc.SetTextForeground(wx.Colour(30, 30, 30))
+            dc.DrawText(libelle, marge + 20, y + max(2, (hauteur_ligne - dc.GetCharHeight()) // 2))
+            vw, vh = dc.GetTextExtent(valeur)
+            dc.DrawText(valeur, largeur - marge - 22 - vw, y + max(2, (hauteur_ligne - vh) // 2))
+            y += hauteur_ligne
+            if y > hauteur - marge - 8:
+                break
 
 
 class Dialog(wx.Dialog):
     def __init__(self, parent):
-        wx.Dialog.__init__(self, parent, -1, title=_(u"Échelle de l'interface"), style=wx.DEFAULT_DIALOG_STYLE)
+        wx.Dialog.__init__(self, parent, -1, title=_(u"Échelle et apparence"), style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER)
 
-        self.label = wx.StaticText(self, -1, _(u"Agrandissement de l'interface :"))
-        self.choix = wx.Choice(self, -1, choices=[u"%d %%" % valeur for valeur in VALEURS_ECHELLE])
-        valeur_actuelle = GetEchelle()
-        self.choix.SetSelection(VALEURS_ECHELLE.index(valeur_actuelle))
+        # Apparence
+        self.liste_codes_apparence = [code for code, label in UTILS_Interface.APPARENCES]
+        self.liste_labels_apparence = [label for code, label in UTILS_Interface.APPARENCES]
+        self.label_apparence = wx.StaticText(self, -1, _(u"Apparence :"))
+        self.ctrl_apparence = wx.Choice(self, -1, choices=self.liste_labels_apparence)
+
+        # Couleur d'accent / thème historique Noethys
+        self.liste_codes_theme = [code for code, label in UTILS_Interface.THEMES]
+        self.liste_labels_theme = [label for code, label in UTILS_Interface.THEMES]
+        self.label_theme = wx.StaticText(self, -1, _(u"Couleur du thème :"))
+        self.ctrl_theme = wx.Choice(self, -1, choices=self.liste_labels_theme)
+
+        # Échelle
+        self.label_echelle = wx.StaticText(self, -1, _(u"Échelle de l'interface :"))
+        self.ctrl_echelle = wx.Choice(
+            self,
+            -1,
+            choices=[u"%d %%" % valeur for valeur in UTILS_Interface.ECHELLES],
+        )
+
+        self.info_systeme = wx.StaticText(self, -1, "")
+        self.apercu = Apercu(self)
 
         self.info = wx.StaticText(
             self,
             -1,
-            _(u"Le nouveau pourcentage sera appliqué au prochain démarrage de Noethys."),
+            _(u"L'aperçu est immédiat. L'interface complète utilisera ces réglages au prochain démarrage."),
         )
 
         self.bouton_ok = wx.Button(self, wx.ID_OK, _(u"Valider"))
         self.bouton_annuler = wx.Button(self, wx.ID_CANCEL, _(u"Annuler"))
 
-        grille = wx.FlexGridSizer(rows=1, cols=2, vgap=8, hgap=8)
-        grille.Add(self.label, 0, wx.ALIGN_CENTER_VERTICAL)
-        grille.Add(self.choix, 0, wx.EXPAND)
+        self._importation()
+        self._layout()
+        self._binds()
+        self.MAJaperçu()
+
+        self.SetMinSize((570, 390))
+        self.SetSize((620, 450))
+        self.CenterOnParent()
+
+    def _importation(self):
+        apparence = UTILS_Interface.GetApparence()
+        self.ctrl_apparence.SetSelection(self.liste_codes_apparence.index(apparence))
+
+        theme = UTILS_Interface.GetTheme()
+        if theme not in self.liste_codes_theme:
+            theme = "Vert"
+        self.ctrl_theme.SetSelection(self.liste_codes_theme.index(theme))
+
+        echelle = UTILS_Interface.GetEchelle()
+        self.ctrl_echelle.SetSelection(UTILS_Interface.ECHELLES.index(echelle))
+
+    def _layout(self):
+        grille = wx.FlexGridSizer(rows=3, cols=2, vgap=8, hgap=10)
+        grille.Add(self.label_apparence, 0, wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL)
+        grille.Add(self.ctrl_apparence, 1, wx.EXPAND)
+        grille.Add(self.label_theme, 0, wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL)
+        grille.Add(self.ctrl_theme, 1, wx.EXPAND)
+        grille.Add(self.label_echelle, 0, wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL)
+        grille.Add(self.ctrl_echelle, 1, wx.EXPAND)
         grille.AddGrowableCol(1)
+
+        box_apercu = wx.StaticBoxSizer(wx.StaticBox(self, -1, _(u"Aperçu")), wx.VERTICAL)
+        box_apercu.Add(self.apercu, 1, wx.ALL | wx.EXPAND, 6)
 
         boutons = wx.StdDialogButtonSizer()
         boutons.AddButton(self.bouton_ok)
@@ -63,21 +191,47 @@ class Dialog(wx.Dialog):
 
         sizer = wx.BoxSizer(wx.VERTICAL)
         sizer.Add(grille, 0, wx.ALL | wx.EXPAND, 12)
+        sizer.Add(self.info_systeme, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 12)
+        sizer.Add(box_apercu, 1, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 12)
         sizer.Add(self.info, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 12)
         sizer.Add(boutons, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.ALIGN_RIGHT, 12)
-        self.SetSizerAndFit(sizer)
-        self.SetMinSize((440, -1))
-        self.CenterOnParent()
+        self.SetSizer(sizer)
 
-    def GetValeur(self):
-        return VALEURS_ECHELLE[self.choix.GetSelection()]
+    def _binds(self):
+        self.ctrl_apparence.Bind(wx.EVT_CHOICE, self.OnChoix)
+        self.ctrl_theme.Bind(wx.EVT_CHOICE, self.OnChoix)
+        self.ctrl_echelle.Bind(wx.EVT_CHOICE, self.OnChoix)
+
+    def GetValeurs(self):
+        return {
+            "apparence": self.liste_codes_apparence[self.ctrl_apparence.GetSelection()],
+            "theme": self.liste_codes_theme[self.ctrl_theme.GetSelection()],
+            "echelle": UTILS_Interface.ECHELLES[self.ctrl_echelle.GetSelection()],
+        }
+
+    def OnChoix(self, event):
+        self.MAJaperçu()
+        event.Skip()
+
+    def MAJaperçu(self):
+        valeurs = self.GetValeurs()
+        self.apercu.SetValeurs(**valeurs)
+        if valeurs["apparence"] == "systeme":
+            etat = _(u"sombre") if UTILS_Interface.SystemeEstSombre() else _(u"clair")
+            self.info_systeme.SetLabel(_(u"Mode système détecté actuellement : %s.") % etat)
+        else:
+            self.info_systeme.SetLabel("")
+        self.Layout()
 
 
 def Ouvrir(parent):
     dlg = Dialog(parent)
     resultat = dlg.ShowModal()
-    valeur = None
+    valeurs = None
     if resultat == wx.ID_OK:
-        valeur = SetEchelle(dlg.GetValeur())
+        valeurs = dlg.GetValeurs()
+        UTILS_Interface.SetApparence(valeurs["apparence"])
+        UTILS_Interface.SetTheme(valeurs["theme"])
+        UTILS_Interface.SetEchelle(valeurs["echelle"])
     dlg.Destroy()
-    return valeur
+    return valeurs

--- a/noethys/Dlg/DLG_Echelle_interface.py
+++ b/noethys/Dlg/DLG_Echelle_interface.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#------------------------------------------------------------------------
+# Application :    Noethys, gestion multi-activités
+# Licence :        GNU GPL
+#------------------------------------------------------------------------
+
+import wx
+
+from Utils.UTILS_Traduction import _
+from Utils import UTILS_Config
+
+
+VALEURS_ECHELLE = (80, 90, 100, 110, 125, 150, 175, 200)
+CLE_CONFIG = "interface_echelle_pct"
+
+
+def NormaliseEchelle(valeur, defaut=100):
+    try:
+        valeur = int(valeur)
+    except (TypeError, ValueError):
+        valeur = defaut
+    return min(VALEURS_ECHELLE, key=lambda item: abs(item - valeur))
+
+
+def GetEchelle():
+    return NormaliseEchelle(UTILS_Config.GetParametre(CLE_CONFIG, 100))
+
+
+def SetEchelle(valeur):
+    valeur = NormaliseEchelle(valeur)
+    UTILS_Config.SetParametre(CLE_CONFIG, valeur)
+    return valeur
+
+
+class Dialog(wx.Dialog):
+    def __init__(self, parent):
+        wx.Dialog.__init__(self, parent, -1, title=_(u"Échelle de l'interface"), style=wx.DEFAULT_DIALOG_STYLE)
+
+        self.label = wx.StaticText(self, -1, _(u"Agrandissement de l'interface :"))
+        self.choix = wx.Choice(self, -1, choices=[u"%d %%" % valeur for valeur in VALEURS_ECHELLE])
+        valeur_actuelle = GetEchelle()
+        self.choix.SetSelection(VALEURS_ECHELLE.index(valeur_actuelle))
+
+        self.info = wx.StaticText(
+            self,
+            -1,
+            _(u"Le nouveau pourcentage sera appliqué au prochain démarrage de Noethys."),
+        )
+
+        self.bouton_ok = wx.Button(self, wx.ID_OK, _(u"Valider"))
+        self.bouton_annuler = wx.Button(self, wx.ID_CANCEL, _(u"Annuler"))
+
+        grille = wx.FlexGridSizer(rows=1, cols=2, vgap=8, hgap=8)
+        grille.Add(self.label, 0, wx.ALIGN_CENTER_VERTICAL)
+        grille.Add(self.choix, 0, wx.EXPAND)
+        grille.AddGrowableCol(1)
+
+        boutons = wx.StdDialogButtonSizer()
+        boutons.AddButton(self.bouton_ok)
+        boutons.AddButton(self.bouton_annuler)
+        boutons.Realize()
+
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        sizer.Add(grille, 0, wx.ALL | wx.EXPAND, 12)
+        sizer.Add(self.info, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 12)
+        sizer.Add(boutons, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.ALIGN_RIGHT, 12)
+        self.SetSizerAndFit(sizer)
+        self.SetMinSize((440, -1))
+        self.CenterOnParent()
+
+    def GetValeur(self):
+        return VALEURS_ECHELLE[self.choix.GetSelection()]
+
+
+def Ouvrir(parent):
+    dlg = Dialog(parent)
+    resultat = dlg.ShowModal()
+    valeur = None
+    if resultat == wx.ID_OK:
+        valeur = SetEchelle(dlg.GetValeur())
+    dlg.Destroy()
+    return valeur

--- a/noethys/Utils/UTILS_Interface.py
+++ b/noethys/Utils/UTILS_Interface.py
@@ -8,16 +8,27 @@
 # Licence:         Licence GNU GPL
 #------------------------------------------------------------------------
 
-import Chemins
-from Utils.UTILS_Traduction import _
+import sys
 import wx
+
+from Utils.UTILS_Traduction import _
 from Utils import UTILS_Customize
+from Utils import UTILS_Config
+
 
 THEMES = [
     ("Vert", _(u"Vert (Par défaut)")),
     ("Bleu", _(u"Bleu")),
     ("Noir", _(u"Noir")),
 ]
+
+APPARENCES = [
+    ("systeme", _(u"Système")),
+    ("clair", _(u"Clair")),
+    ("sombre", _(u"Sombre")),
+]
+
+ECHELLES = (80, 90, 100, 110, 125, 150, 175, 200)
 
 DONNEES = {
 
@@ -44,13 +55,99 @@ DONNEES = {
 
 }
 
-def GetTheme() :
+PALETTE_SOMBRE = {
+    "fond": wx.Colour(32, 32, 32),
+    "fond_controle": wx.Colour(43, 43, 43),
+    "texte": wx.Colour(238, 238, 238),
+    "texte_secondaire": wx.Colour(190, 190, 190),
+    "bordure": wx.Colour(74, 74, 74),
+}
+
+_GESTIONNAIRE_AFFICHAGE = None
+_ID_MENU_AFFICHAGE = wx.Window.NewControlId()
+
+
+def _normalise_echelle(valeur, defaut=100):
+    try:
+        valeur = int(valeur)
+    except (TypeError, ValueError):
+        valeur = defaut
+    return min(ECHELLES, key=lambda item: abs(item - valeur))
+
+
+def GetEchelle():
+    return _normalise_echelle(UTILS_Config.GetParametre("interface_echelle_pct", 100))
+
+
+def SetEchelle(valeur=100):
+    valeur = _normalise_echelle(valeur)
+    UTILS_Config.SetParametre("interface_echelle_pct", valeur)
+    return valeur
+
+
+def GetApparence():
+    valeur = UTILS_Config.GetParametre("interface_apparence", "systeme")
+    if valeur not in [code for code, label in APPARENCES]:
+        valeur = "systeme"
+    return valeur
+
+
+def SetApparence(valeur="systeme"):
+    if valeur not in [code for code, label in APPARENCES]:
+        valeur = "systeme"
+    UTILS_Config.SetParametre("interface_apparence", valeur)
+    return valeur
+
+
+def SystemeEstSombre():
+    """Retourne le mode sombre choisi pour les applications par le système."""
+    # Windows : la valeur AppsUseLightTheme correspond au réglage
+    # Paramètres > Personnalisation > Couleurs > mode d'application.
+    if sys.platform.startswith("win"):
+        try:
+            import winreg
+            chemin = r"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize"
+            with winreg.OpenKey(winreg.HKEY_CURRENT_USER, chemin) as cle:
+                valeur, _type = winreg.QueryValueEx(cle, "AppsUseLightTheme")
+            return int(valeur) == 0
+        except Exception:
+            pass
+
+    # Fallback wxWidgets, notamment macOS/Linux et versions récentes de wx.
+    try:
+        apparence = wx.SystemSettings.GetAppearance()
+        if hasattr(apparence, "AreAppsDark"):
+            return bool(apparence.AreAppsDark())
+        if hasattr(apparence, "IsDark"):
+            return bool(apparence.IsDark())
+    except Exception:
+        pass
+    return False
+
+
+def EstSombre(apparence=None):
+    if apparence is None:
+        apparence = GetApparence()
+    if apparence == "sombre":
+        return True
+    if apparence == "clair":
+        return False
+    return SystemeEstSombre()
+
+
+def GetTheme():
+    InstallerGestionAffichage()
     return UTILS_Customize.GetValeur("interface", "theme", "Vert")
 
+
 def SetTheme(theme="Vert"):
+    if theme not in [code for code, label in THEMES]:
+        theme = "Vert"
     UTILS_Customize.SetValeur("interface", "theme", theme)
 
+
 def GetValeur(cle="", defaut="", theme=None):
+    InstallerGestionAffichage()
     # lecture du thème
     if theme == None :
         theme = UTILS_Customize.GetValeur("interface", "theme", "Vert")
@@ -62,6 +159,267 @@ def GetValeur(cle="", defaut="", theme=None):
 
     # Sinon renvoie la valeur par défaut
     return defaut
+
+
+def _couleur_identique(couleur1, couleur2):
+    try:
+        return tuple(couleur1.Get())[:3] == tuple(couleur2.Get())[:3]
+    except Exception:
+        return False
+
+
+def _memorise_base(window, attribut, valeur):
+    if not hasattr(window, attribut):
+        try:
+            setattr(window, attribut, valeur)
+        except Exception:
+            pass
+    return getattr(window, attribut, valeur)
+
+
+def _appliquer_police(window, facteur):
+    try:
+        police = window.GetFont()
+        if not police or not police.IsOk():
+            return
+
+        taille = police.GetFractionalPointSize() if hasattr(police, "GetFractionalPointSize") else float(police.GetPointSize())
+        if taille <= 0:
+            return
+
+        # Si le contrôle vient d'être créé après son parent déjà agrandi,
+        # il peut avoir hérité de la police agrandie. On réutilise alors la
+        # taille de base mémorisée sur le parent pour éviter un double zoom.
+        parent = window.GetParent()
+        base = getattr(window, "_noethys_taille_police_base", None)
+        if base is None:
+            if parent is not None and hasattr(parent, "_noethys_taille_police_base"):
+                try:
+                    taille_parent = parent.GetFont().GetFractionalPointSize() if hasattr(parent.GetFont(), "GetFractionalPointSize") else float(parent.GetFont().GetPointSize())
+                    if abs(taille - taille_parent) < 0.05:
+                        base = float(parent._noethys_taille_police_base)
+                except Exception:
+                    pass
+            if base is None:
+                base = float(taille)
+            try:
+                window._noethys_taille_police_base = base
+            except Exception:
+                pass
+
+        cible = max(5.0, base * facteur)
+        if abs(taille - cible) < 0.05:
+            return
+
+        nouvelle = wx.Font(police)
+        if hasattr(nouvelle, "SetFractionalPointSize"):
+            nouvelle.SetFractionalPointSize(cible)
+        else:
+            nouvelle.SetPointSize(max(5, int(round(cible))))
+        window.SetFont(nouvelle)
+        try:
+            window.InvalidateBestSize()
+        except Exception:
+            pass
+    except Exception:
+        pass
+
+
+def _appliquer_dimensions_speciales(window, facteur):
+    """Agrandit les métriques verticales utiles sans gonfler toutes les colonnes."""
+    # wx.Grid et contrôles compatibles : hauteur des lignes.
+    if hasattr(window, "GetDefaultRowSize") and hasattr(window, "SetDefaultRowSize"):
+        try:
+            valeur = _memorise_base(window, "_noethys_hauteur_ligne_base", window.GetDefaultRowSize())
+            cible = max(1, int(round(valeur * facteur)))
+            try:
+                window.SetDefaultRowSize(cible, True)
+            except TypeError:
+                window.SetDefaultRowSize(cible)
+        except Exception:
+            pass
+
+
+def _appliquer_couleurs(window, sombre):
+    if not sombre:
+        return
+
+    try:
+        fond_actuel = window.GetBackgroundColour()
+        texte_actuel = window.GetForegroundColour()
+    except Exception:
+        return
+
+    fond_bouton_systeme = wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE)
+    fond_fenetre_systeme = wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOW)
+    texte_systeme = wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOWTEXT)
+
+    # Ne jamais écraser une couleur métier explicitement posée par Noethys
+    # (cases vertes/rouges des effectifs, alertes, états, etc.).
+    fond_est_standard = (
+        _couleur_identique(fond_actuel, fond_bouton_systeme)
+        or _couleur_identique(fond_actuel, fond_fenetre_systeme)
+        or not fond_actuel.IsOk()
+    )
+    texte_est_standard = _couleur_identique(texte_actuel, texte_systeme) or not texte_actuel.IsOk()
+
+    nom_classe = window.__class__.__name__.lower()
+    controle_saisie = any(mot in nom_classe for mot in ("textctrl", "listctrl", "treectrl", "choice", "combobox", "spin", "grid"))
+
+    if fond_est_standard:
+        try:
+            window.SetBackgroundColour(PALETTE_SOMBRE["fond_controle"] if controle_saisie else PALETTE_SOMBRE["fond"])
+        except Exception:
+            pass
+    if texte_est_standard:
+        try:
+            window.SetForegroundColour(PALETTE_SOMBRE["texte"])
+        except Exception:
+            pass
+
+
+def _appliquer_barre_titre_sombre(window, sombre):
+    """Active la barre de titre sombre sous Windows 10/11 quand disponible."""
+    if not sombre or not sys.platform.startswith("win"):
+        return
+    if not isinstance(window, wx.TopLevelWindow):
+        return
+    try:
+        import ctypes
+        hwnd = int(window.GetHandle())
+        valeur = ctypes.c_int(1)
+        # 20 est la valeur actuelle ; 19 couvre certaines versions antérieures.
+        for attribut in (20, 19):
+            resultat = ctypes.windll.dwmapi.DwmSetWindowAttribute(
+                hwnd, attribut, ctypes.byref(valeur), ctypes.sizeof(valeur)
+            )
+            if resultat == 0:
+                break
+    except Exception:
+        pass
+
+
+def AppliquerAffichage(window, recursif=True):
+    if window is None:
+        return
+    facteur = GetEchelle() / 100.0
+    sombre = EstSombre()
+
+    _appliquer_police(window, facteur)
+    _appliquer_dimensions_speciales(window, facteur)
+    _appliquer_couleurs(window, sombre)
+    _appliquer_barre_titre_sombre(window, sombre)
+
+    if recursif:
+        try:
+            enfants = window.GetChildren()
+        except Exception:
+            enfants = []
+        for enfant in enfants:
+            AppliquerAffichage(enfant, recursif=True)
+
+    if isinstance(window, wx.TopLevelWindow):
+        try:
+            window.Layout()
+            window.Refresh()
+        except Exception:
+            pass
+
+
+def AppliquerAffichageGlobal():
+    try:
+        fenetres = wx.GetTopLevelWindows()
+    except Exception:
+        fenetres = []
+    for fenetre in fenetres:
+        AppliquerAffichage(fenetre, recursif=True)
+
+
+def _ouvrir_reglages_affichage(parent):
+    from Dlg import DLG_Echelle_interface
+    valeur = DLG_Echelle_interface.Ouvrir(parent)
+    if valeur is not None:
+        dlg = wx.MessageDialog(
+            parent,
+            _(u"Les nouveaux réglages d'affichage seront appliqués complètement au prochain démarrage de Noethys."),
+            _(u"Affichage"),
+            wx.OK | wx.ICON_INFORMATION,
+        )
+        dlg.ShowModal()
+        dlg.Destroy()
+
+
+def _installer_menu_affichage():
+    try:
+        app = wx.GetApp()
+        parent = app.GetTopWindow() if app else None
+        if parent is None:
+            return
+        if getattr(parent, "_noethys_menu_affichage_installe", False):
+            return
+        barre = parent.GetMenuBar()
+        if barre is None:
+            return
+
+        menu_cible = None
+        for index in range(barre.GetMenuCount()):
+            label = barre.GetMenuLabel(index).replace("&", "").lower()
+            if "affichage" in label:
+                menu_cible = barre.GetMenu(index)
+                break
+        if menu_cible is None:
+            return
+
+        menu_cible.AppendSeparator()
+        menu_cible.Append(
+            _ID_MENU_AFFICHAGE,
+            _(u"Échelle et apparence…\tCtrl+Alt+Z"),
+            _(u"Ajuster la taille de l'interface et le mode clair/sombre."),
+        )
+        parent.Bind(
+            wx.EVT_MENU,
+            lambda event: _ouvrir_reglages_affichage(parent),
+            id=_ID_MENU_AFFICHAGE,
+        )
+        parent._noethys_menu_affichage_installe = True
+    except Exception as err:
+        print("Impossible d'ajouter le menu d'affichage : %s" % err)
+
+
+class _GestionnaireAffichage(wx.EventFilter):
+    """Applique l'affichage aux fenêtres créées après le démarrage."""
+    def __init__(self):
+        wx.EventFilter.__init__(self)
+        self.type_creation = wx.EVT_WINDOW_CREATE.typeId
+        wx.EvtHandler.AddFilter(self)
+
+    def FilterEvent(self, event):
+        if event.GetEventType() == self.type_creation:
+            try:
+                window = event.GetWindow()
+                if window is not None:
+                    wx.CallAfter(AppliquerAffichage, window, False)
+            except Exception:
+                pass
+        return self.Event_Skip
+
+
+def InstallerGestionAffichage():
+    global _GESTIONNAIRE_AFFICHAGE
+    try:
+        app = wx.GetApp()
+    except Exception:
+        app = None
+    if app is None:
+        return
+
+    if _GESTIONNAIRE_AFFICHAGE is None:
+        try:
+            _GESTIONNAIRE_AFFICHAGE = _GestionnaireAffichage()
+            wx.CallAfter(AppliquerAffichageGlobal)
+            wx.CallAfter(_installer_menu_affichage)
+        except Exception as err:
+            print("Initialisation de l'affichage impossible : %s" % err)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Objectif
Rendre Noethys lisible sur les écrans 2K/4K sans modifier l'échelle Windows entière.

## Fonctionnalités
- réglage d'échelle de l'interface : 80, 90, 100, 110, 125, 150, 175 et 200 % ;
- apparence : Système / Clair / Sombre ;
- sous Windows, le mode Système suit `AppsUseLightTheme` (Paramètres > Personnalisation > Couleurs > mode des applications) ;
- conservation du thème/couleur d'accent historique Vert / Bleu / Noir ;
- petit aperçu live avant validation ;
- entrée `Affichage > Échelle et apparence…` avec raccourci Ctrl+Alt+Z ;
- application du zoom aux polices et hauteurs de lignes compatibles ;
- palette sombre prudente : les couleurs métier explicitement définies (alertes, capacités, vert/rouge des tableaux) ne sont pas écrasées ;
- barre de titre sombre Windows quand l'API DWM le permet.

## Compatibilité
Le vrai dark mode natif complet de wxMSW est une fonctionnalité wxWidgets 3.3. Sur le socle wxWidgets 3.2.x actuel, cette PR fournit donc une palette sombre Noethys + détection du système, sans prétendre remplacer le futur support natif.

## Test attendu
- CI multi-plateforme ;
- recette Windows 11 sur écran 2K à 125/150 % ;
- vérification des grilles, barres d'outils, dialogues et couleurs métier.