### PR TITLE
Diagnostic perf : fenêtres, MySQL WAN et faux gels

### DIFF
--- a/packaging/noethys.spec
+++ b/packaging/noethys.spec
@@ -67,6 +67,9 @@ runtime_hooks = [
     # Installer d'abord le journal d'erreurs : si un hook de compatibilité casse,
     # le diagnostic est persisté au lieu de disparaître dans l'EXE sans console.
     str(ROOT / "packaging" / "runtime_crashlog.py"),
+    # Mesure localement les délais d'ouverture des fenêtres et les allers-retours
+    # MySQL, sans conserver les paramètres SQL ni les titres métier.
+    str(ROOT / "packaging" / "runtime_perf.py"),
     # Les hooks de compatibilité sont volontairement exécutés avant le smoke-test
     # afin que la qualification du bundle couvre aussi leur initialisation.
     str(ROOT / "packaging" / "runtime_wx_compat.py"),

--- a/packaging/runtime_perf.py
+++ b/packaging/runtime_perf.py
@@ -10,6 +10,10 @@ Mesures produites dans ``noethys_perf.log`` :
   de premier niveau est visible ;
 - temps des connexions MySQL ;
 - temps des requêtes MySQL avec littéraux anonymisés.
+
+Ce hook protège aussi le watchdog de ``runtime_crashlog`` contre un faux gel
+pendant ``wx.App.OnInit()`` : avant l'entrée dans la vraie MainLoop, le thread
+NoethysHangWatchdog voit volontairement ``wx.GetApp()`` comme indisponible.
 """
 
 import datetime
@@ -85,7 +89,7 @@ def _sanitize_sql(query):
     if isinstance(query, bytes):
         query = query.decode("utf-8", errors="replace")
     text = str(query)
-    text = re.sub(r"'(?:''|\\'|[^'])*'", "'? '".rstrip(), text)
+    text = re.sub(r"'(?:''|\\'|[^'])*'", "'?'", text)
     text = re.sub(r'"(?:""|\\"|[^"])*"', '"?"', text)
     text = re.sub(r"\b0x[0-9a-fA-F]+\b", "?", text)
     text = re.sub(r"\b\d+(?:\.\d+)?\b", "?", text)
@@ -116,7 +120,10 @@ def _wrap_connect(module, attr="connect", label="CONNECT"):
             _log_mysql(label, time.perf_counter() - start)
 
     wrapped.__noethys_perf__ = True
-    setattr(module, attr, wrapped)
+    try:
+        setattr(module, attr, wrapped)
+    except Exception as exc:
+        _append("%s PERF_PATCH_FAIL target=%s.%s error=%s" % (_stamp(), getattr(module, "__name__", "?"), attr, type(exc).__name__))
 
 
 def _wrap_cursor_class(cls, method_name, label):
@@ -144,6 +151,7 @@ def _install_mysql_instrumentation():
         from MySQLdb import cursors as mysql_cursors
 
         _wrap_connect(MySQLdb, "connect", "CONNECT_MYSQLDB")
+        _wrap_connect(MySQLdb, "Connect", "CONNECT_MYSQLDB")
         for cls_name in ("BaseCursor", "Cursor", "DictCursor", "SSCursor", "SSDictCursor"):
             cls = getattr(mysql_cursors, cls_name, None)
             if cls is not None:
@@ -192,7 +200,23 @@ def _install_wx_instrumentation():
         "last_action": "startup",
         "known_windows": set(),
         "mainloop_start": None,
+        "mainloop_started": False,
     }
+
+    # runtime_crashlog démarre son watchdog avant la création de wx.App. Une
+    # fenêtre modale affichée dans OnInit() peut alors durer >30 s alors que la
+    # vraie MainLoop n'a pas encore commencé. On ne modifie le comportement de
+    # wx.GetApp() que pour CE thread de diagnostic et uniquement avant MainLoop.
+    original_get_app = wx.GetApp
+    if not getattr(original_get_app, "__noethys_watchdog_guard__", False):
+        def guarded_get_app(*args, **kwargs):
+            app = original_get_app(*args, **kwargs)
+            if threading.current_thread().name == "NoethysHangWatchdog" and not state["mainloop_started"]:
+                return None
+            return app
+
+        guarded_get_app.__noethys_watchdog_guard__ = True
+        wx.GetApp = guarded_get_app
 
     def trace_action(event):
         try:
@@ -247,6 +271,7 @@ def _install_wx_instrumentation():
 
     def main_loop_with_perf(self, *args, **kwargs):
         state["mainloop_start"] = time.perf_counter()
+        state["mainloop_started"] = True
         state["known_windows"] = set()
         try:
             for binder in (
@@ -260,7 +285,10 @@ def _install_wx_instrumentation():
             self.Bind(wx.EVT_IDLE, inspect_idle)
         except Exception as exc:
             _append("%s PERF_WX_BIND_FAIL error=%s" % (_stamp(), type(exc).__name__))
-        return original_main_loop(self, *args, **kwargs)
+        try:
+            return original_main_loop(self, *args, **kwargs)
+        finally:
+            state["mainloop_started"] = False
 
     main_loop_with_perf.__noethys_perf__ = True
     wx.App.MainLoop = main_loop_with_perf

--- a/packaging/runtime_perf.py
+++ b/packaging/runtime_perf.py
@@ -1,0 +1,272 @@
+# -*- coding: utf-8 -*-
+"""Mesures locales de performance pour Noethys.
+
+Le but est de distinguer les lenteurs d'interface des allers-retours MySQL,
+notamment quand une base réseau est utilisée à travers un WAN. Le journal ne
+stocke ni valeurs saisies, ni paramètres SQL, ni titres métier des fenêtres.
+
+Mesures produites dans ``noethys_perf.log`` :
+- délai entre une action GUI et la première phase idle où une nouvelle fenêtre
+  de premier niveau est visible ;
+- temps des connexions MySQL ;
+- temps des requêtes MySQL avec littéraux anonymisés.
+"""
+
+import datetime
+import os
+import re
+import sys
+import threading
+import time
+
+
+def _user_log_directory():
+    executable_dir = os.path.dirname(os.path.abspath(sys.executable))
+    portable_dir = os.path.join(executable_dir, "Portable")
+    if os.path.isdir(portable_dir):
+        return portable_dir
+    roaming = os.environ.get("APPDATA")
+    if roaming:
+        return os.path.join(roaming, "noethys")
+    return executable_dir
+
+
+LOG_DIR = _user_log_directory()
+try:
+    os.makedirs(LOG_DIR, exist_ok=True)
+except Exception:
+    LOG_DIR = os.path.dirname(os.path.abspath(sys.executable))
+
+PERF_PATH = os.path.join(LOG_DIR, "noethys_perf.log")
+_SESSION_ID = "%s-%s" % (datetime.datetime.now().strftime("%Y%m%d-%H%M%S"), os.getpid())
+_WRITE_LOCK = threading.RLock()
+_MAX_LOG_BYTES = 10 * 1024 * 1024
+
+
+def _append(line):
+    try:
+        with _WRITE_LOCK:
+            if os.path.isfile(PERF_PATH) and os.path.getsize(PERF_PATH) > _MAX_LOG_BYTES:
+                previous = PERF_PATH + ".1"
+                try:
+                    if os.path.exists(previous):
+                        os.remove(previous)
+                    os.replace(PERF_PATH, previous)
+                except Exception:
+                    pass
+            with open(PERF_PATH, "a", encoding="utf-8", errors="replace") as stream:
+                stream.write(line)
+                if not line.endswith("\n"):
+                    stream.write("\n")
+                stream.flush()
+    except Exception:
+        pass
+
+
+def _stamp():
+    return datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+
+
+def _window_key(window):
+    try:
+        module = window.__class__.__module__ or "?"
+        name = window.__class__.__name__ or "?"
+    except Exception:
+        module, name = "?", "?"
+    try:
+        wx_name = window.GetName() or ""
+    except Exception:
+        wx_name = ""
+    return "%s.%s name=%r" % (module, name, wx_name)
+
+
+def _sanitize_sql(query):
+    """Conserve la forme de la requête sans ses valeurs métier."""
+    if isinstance(query, bytes):
+        query = query.decode("utf-8", errors="replace")
+    text = str(query)
+    text = re.sub(r"'(?:''|\\'|[^'])*'", "'? '".rstrip(), text)
+    text = re.sub(r'"(?:""|\\"|[^"])*"', '"?"', text)
+    text = re.sub(r"\b0x[0-9a-fA-F]+\b", "?", text)
+    text = re.sub(r"\b\d+(?:\.\d+)?\b", "?", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    if len(text) > 260:
+        text = text[:257] + "..."
+    return text
+
+
+def _log_mysql(kind, elapsed, query=None):
+    millis = elapsed * 1000.0
+    if query is None:
+        _append("%s MYSQL_%s elapsed_ms=%.1f" % (_stamp(), kind, millis))
+    else:
+        _append("%s MYSQL_%s elapsed_ms=%.1f sql=%r" % (_stamp(), kind, millis, _sanitize_sql(query)))
+
+
+def _wrap_connect(module, attr="connect", label="CONNECT"):
+    original = getattr(module, attr, None)
+    if original is None or getattr(original, "__noethys_perf__", False):
+        return
+
+    def wrapped(*args, **kwargs):
+        start = time.perf_counter()
+        try:
+            return original(*args, **kwargs)
+        finally:
+            _log_mysql(label, time.perf_counter() - start)
+
+    wrapped.__noethys_perf__ = True
+    setattr(module, attr, wrapped)
+
+
+def _wrap_cursor_class(cls, method_name, label):
+    original = getattr(cls, method_name, None)
+    if original is None or getattr(original, "__noethys_perf__", False):
+        return
+
+    def wrapped(self, query, *args, **kwargs):
+        start = time.perf_counter()
+        try:
+            return original(self, query, *args, **kwargs)
+        finally:
+            _log_mysql(label, time.perf_counter() - start, query=query)
+
+    wrapped.__noethys_perf__ = True
+    try:
+        setattr(cls, method_name, wrapped)
+    except Exception as exc:
+        _append("%s PERF_PATCH_FAIL target=%s.%s error=%s" % (_stamp(), getattr(cls, "__name__", "?"), method_name, type(exc).__name__))
+
+
+def _install_mysql_instrumentation():
+    try:
+        import MySQLdb
+        from MySQLdb import cursors as mysql_cursors
+
+        _wrap_connect(MySQLdb, "connect", "CONNECT_MYSQLDB")
+        for cls_name in ("BaseCursor", "Cursor", "DictCursor", "SSCursor", "SSDictCursor"):
+            cls = getattr(mysql_cursors, cls_name, None)
+            if cls is not None:
+                _wrap_cursor_class(cls, "execute", "QUERY_MYSQLDB")
+                _wrap_cursor_class(cls, "executemany", "MANY_MYSQLDB")
+    except Exception as exc:
+        _append("%s PERF_MYSQLDB_UNAVAILABLE error=%s" % (_stamp(), type(exc).__name__))
+
+    try:
+        import mysql.connector
+        _wrap_connect(mysql.connector, "connect", "CONNECT_CONNECTOR")
+
+        classes = []
+        try:
+            from mysql.connector import cursor as connector_cursor
+            for cls_name in ("MySQLCursor", "MySQLCursorBuffered", "MySQLCursorDict", "MySQLCursorBufferedDict"):
+                cls = getattr(connector_cursor, cls_name, None)
+                if cls is not None:
+                    classes.append(cls)
+        except Exception:
+            pass
+        try:
+            from mysql.connector import cursor_cext
+            for cls_name in ("CMySQLCursor", "CMySQLCursorBuffered", "CMySQLCursorDict", "CMySQLCursorBufferedDict"):
+                cls = getattr(cursor_cext, cls_name, None)
+                if cls is not None:
+                    classes.append(cls)
+        except Exception:
+            pass
+        for cls in classes:
+            _wrap_cursor_class(cls, "execute", "QUERY_CONNECTOR")
+            _wrap_cursor_class(cls, "executemany", "MANY_CONNECTOR")
+    except Exception as exc:
+        _append("%s PERF_CONNECTOR_UNAVAILABLE error=%s" % (_stamp(), type(exc).__name__))
+
+
+def _install_wx_instrumentation():
+    try:
+        import wx
+    except Exception as exc:
+        _append("%s PERF_WX_UNAVAILABLE error=%s" % (_stamp(), type(exc).__name__))
+        return
+
+    state = {
+        "last_action_time": None,
+        "last_action": "startup",
+        "known_windows": set(),
+        "mainloop_start": None,
+    }
+
+    def trace_action(event):
+        try:
+            state["last_action_time"] = time.perf_counter()
+            event_type = event.GetEventType()
+            mapping = {
+                wx.wxEVT_MENU: "MENU",
+                wx.wxEVT_BUTTON: "BUTTON",
+                wx.wxEVT_LEFT_DCLICK: "DOUBLE_CLICK",
+                wx.wxEVT_LIST_ITEM_ACTIVATED: "LIST_ACTIVATE",
+                wx.wxEVT_TREE_ITEM_ACTIVATED: "TREE_ACTIVATE",
+            }
+            state["last_action"] = mapping.get(event_type, "EVENT_%s" % event_type)
+        except Exception:
+            pass
+        event.Skip()
+
+    def inspect_idle(event):
+        try:
+            now = time.perf_counter()
+            for window in list(wx.GetTopLevelWindows()):
+                try:
+                    if not window.IsShown():
+                        continue
+                except Exception:
+                    continue
+                identity = id(window)
+                if identity in state["known_windows"]:
+                    continue
+                state["known_windows"].add(identity)
+
+                start = state["last_action_time"]
+                action = state["last_action"]
+                if start is None:
+                    start = state["mainloop_start"]
+                    action = "STARTUP"
+                if start is None:
+                    continue
+                elapsed = now - start
+                if elapsed < 0.0 or elapsed > 15.0:
+                    continue
+                _append("%s WINDOW_READY elapsed_ms=%.1f action=%s window=%s" % (
+                    _stamp(), elapsed * 1000.0, action, _window_key(window)
+                ))
+        except Exception:
+            pass
+        event.Skip()
+
+    original_main_loop = wx.App.MainLoop
+    if getattr(original_main_loop, "__noethys_perf__", False):
+        return
+
+    def main_loop_with_perf(self, *args, **kwargs):
+        state["mainloop_start"] = time.perf_counter()
+        state["known_windows"] = set()
+        try:
+            for binder in (
+                wx.EVT_MENU,
+                wx.EVT_BUTTON,
+                wx.EVT_LEFT_DCLICK,
+                wx.EVT_LIST_ITEM_ACTIVATED,
+                wx.EVT_TREE_ITEM_ACTIVATED,
+            ):
+                self.Bind(binder, trace_action)
+            self.Bind(wx.EVT_IDLE, inspect_idle)
+        except Exception as exc:
+            _append("%s PERF_WX_BIND_FAIL error=%s" % (_stamp(), type(exc).__name__))
+        return original_main_loop(self, *args, **kwargs)
+
+    main_loop_with_perf.__noethys_perf__ = True
+    wx.App.MainLoop = main_loop_with_perf
+
+
+_append("\n===== Noethys performance session %s =====" % _SESSION_ID)
+_append("%s PERF_START python=%s platform=%s" % (_stamp(), sys.version.split()[0], sys.platform))
+_install_mysql_instrumentation()
+_install_wx_instrumentation()

--- a/scripts/run_noethys_dev.py
+++ b/scripts/run_noethys_dev.py
@@ -40,14 +40,16 @@ if EXAMPLES.is_dir():
 sys.path.insert(0, str(NOETHYS))
 sys.path.insert(0, str(ROOT))
 
-# runtime_crashlog détermine son dossier de logs depuis sys.executable. En mode
-# source, on lui présente temporairement l'emplacement de Noethys.py afin qu'il
-# retrouve noethys/Portable, exactement comme le portable trouve Portable à
-# côté de Noethys.exe. On restaure ensuite le vrai python.exe.
+# Les hooks de diagnostic déterminent leur dossier de logs depuis
+# sys.executable. En mode source, on leur présente temporairement l'emplacement
+# de Noethys.py afin qu'ils retrouvent noethys/Portable, exactement comme le
+# portable trouve Portable à côté de Noethys.exe. On restaure ensuite le vrai
+# python.exe.
 real_executable = sys.executable
 try:
     sys.executable = str(NOETHYS / "Noethys.exe")
     runpy.run_path(str(PACKAGING / "runtime_crashlog.py"), run_name="__noethys_runtime_crashlog__")
+    runpy.run_path(str(PACKAGING / "runtime_perf.py"), run_name="__noethys_runtime_perf__")
 finally:
     sys.executable = real_executable
 

--- a/tests/test_runtime_perf_contract.py
+++ b/tests/test_runtime_perf_contract.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Contrats statiques du diagnostic de performance Noethys."""
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class RuntimePerformanceContractTests(unittest.TestCase):
+    def test_perf_hook_is_loaded_in_dev_and_portable(self):
+        dev = (ROOT / "scripts" / "run_noethys_dev.py").read_text(encoding="utf-8")
+        spec = (ROOT / "packaging" / "noethys.spec").read_text(encoding="utf-8")
+        self.assertIn('runtime_perf.py', dev)
+        self.assertIn('runtime_perf.py', spec)
+
+    def test_watchdog_is_ignored_only_before_real_mainloop(self):
+        source = (ROOT / "packaging" / "runtime_perf.py").read_text(encoding="utf-8")
+        self.assertIn('threading.current_thread().name == "NoethysHangWatchdog"', source)
+        self.assertIn('not state["mainloop_started"]', source)
+        self.assertIn('state["mainloop_started"] = True', source)
+        self.assertIn('state["mainloop_started"] = False', source)
+
+    def test_window_ready_and_mysql_timings_are_recorded(self):
+        source = (ROOT / "packaging" / "runtime_perf.py").read_text(encoding="utf-8")
+        self.assertIn('noethys_perf.log', source)
+        self.assertIn('WINDOW_READY elapsed_ms=', source)
+        self.assertIn('MYSQL_%s elapsed_ms=', source)
+        self.assertIn('_sanitize_sql(query)', source)
+
+    def test_window_identity_does_not_use_business_title(self):
+        source = (ROOT / "packaging" / "runtime_perf.py").read_text(encoding="utf-8")
+        start = source.index('def _window_key(window):')
+        end = source.index('\n\ndef _sanitize_sql', start)
+        block = source[start:end]
+        self.assertNotIn('GetTitle', block)
+        self.assertIn('__class__.__module__', block)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Objectif
Instrumenter la recette Windows pour savoir précisément où Noethys perd du temps avec une base MySQL distante, sans confondre une fenêtre modale de démarrage avec un gel GUI.

## Changements
- ajoute `packaging/runtime_perf.py` ;
- crée `noethys_perf.log` dans le même dossier `Portable` que les autres diagnostics ;
- mesure le délai action utilisateur → nouvelle fenêtre visible et revenue à l'idle ;
- identifie les fenêtres par module/classe wx, sans journaliser leur titre métier ;
- mesure connexions et requêtes MySQL/Mysql Connector ;
- anonymise les littéraux SQL avant écriture du log ;
- rotation du journal à 10 Mio ;
- évite le faux positif `NoethysHangWatchdog` avant l'entrée réelle dans `wx.App.MainLoop()` ;
- charge le même hook en recette source et dans le portable PyInstaller ;
- ajoute des tests de contrat.

Aucun délai visuel artificiel ni fondu n'est ajouté dans ce lot : les mesures serviront d'abord à identifier les vrais goulets d'étranglement WAN.