### PR TITLE
Noe-062 — Socle conventions et mises à disposition

### DIFF
--- a/docs/NOE-062-MISES-A-DISPOSITION.md
+++ b/docs/NOE-062-MISES-A-DISPOSITION.md
@@ -1,0 +1,130 @@
+# Noe-062 — Mises à disposition et conventions
+
+## But
+
+Construire la gestion des mises à disposition sans recopier les moteurs déjà présents dans Noethys.
+
+Le vocabulaire métier exposé à l'utilisateur est **Mises à disposition**. Le vieux module **Locations** reste une source de briques techniques ; il ne devient pas pour autant le modèle métier définitif d'une convention avec une association, une école ou une collectivité.
+
+## Ce que le moteur `Locations` sait déjà faire
+
+L'audit des fichiers `DLG_Saisie_location.py`, `OL_Locations.py` et `UTILS_Locations.py` montre que le socle historique fournit déjà :
+
+- une période début/fin ;
+- la création d'occurrences récurrentes ;
+- la détection des indisponibilités ;
+- des prestations liées avec leur date et leur montant ;
+- l'historisation des créations/modifications/suppressions ;
+- un questionnaire configurable de type `location` ;
+- l'exposition des réponses de questionnaires dans les listes ;
+- la construction de champs de fusion ;
+- la génération PDF depuis les modèles de documents ;
+- l'envoi par e-mail ;
+- l'archivage possible d'un PDF dans les documents liés à une réponse de questionnaire.
+
+Il faut réutiliser ces moteurs plutôt que créer des variantes `MiseADisposition_*` indépendantes.
+
+## Limite du modèle historique
+
+Une location est aujourd'hui centrée sur :
+
+- `IDfamille` comme loueur ;
+- `IDproduit` comme objet loué ;
+- `locations` comme occurrence ;
+- une prestation portant `categorie="location"` et `IDdonnee=IDlocation`.
+
+Cette représentation est adaptée à la location de produits mais insuffisante pour porter proprement une relation contractuelle avec une personne morale, ses contacts, son groupe/sa section, ses règles d'adhésion éventuelles, sa programmation annuelle et son mode de facturation.
+
+Le module historique ne doit donc pas être renommé artificiellement ni détourné en modèle universel.
+
+## Premier noyau introduit
+
+`Utils/UTILS_Mises_a_disposition.py` introduit un objet métier pur `ConventionMiseADisposition`.
+
+Il est volontairement indépendant de wxPython et de `GestionDB` afin que les mêmes règles puissent être utilisées par :
+
+- l'interface desktop ;
+- les futures migrations de données ;
+- l'édition de convention et d'avenant ;
+- le reporting ;
+- les échanges PMSL-Équipe ;
+- des tests unitaires rapides.
+
+Le noyau porte uniquement ce qui est déjà suffisamment stable pour être partagé :
+
+- identifiant UUID stable ;
+- période contractuelle ;
+- référence ;
+- statut ;
+- version ;
+- lien vers la convention parente pour un avenant ;
+- mode de facturation ;
+- champs de fusion canoniques.
+
+Il ne crée aucune table et n'altère aucune base existante à ce stade.
+
+## Cycle de vie initial
+
+Statuts techniques autorisés :
+
+- `brouillon` ;
+- `validee` ;
+- `signee` ;
+- `terminee` ;
+- `annulee`.
+
+Modes de facturation initiaux issus de l'architecture cible :
+
+- `manuelle` ;
+- `mensuelle` ;
+- `trimestrielle` ;
+- `apres_realise`.
+
+La période de validité est distincte du statut. Une convention peut couvrir une date tout en étant encore en brouillon ; les écrans devront donc choisir explicitement s'ils filtrent sur la période, le statut ou les deux.
+
+## Champs de fusion canoniques
+
+Le noyau expose :
+
+- `{CONVENTION_ID_STABLE}` ;
+- `{CONVENTION_REFERENCE}` ;
+- `{CONVENTION_VERSION}` ;
+- `{CONVENTION_STATUT}` ;
+- `{CONVENTION_DATE_DEBUT}` ;
+- `{CONVENTION_DATE_FIN}` ;
+- `{CONVENTION_MODE_FACTURATION}` ;
+- `{CONVENTION_PARENT_ID_STABLE}` ;
+- `{CONVENTION_EST_AVENANT}`.
+
+Ces champs ont vocation à rejoindre le moteur documentaire existant ; le modèle de convention fourni par PMSL doit être conservé dans son ordre et sa structure, sans réécriture arbitraire.
+
+## Étapes suivantes
+
+### Noe-062A — Tiers et contacts
+
+Introduire de manière additive le tiers personne morale et ses contacts, sans identifiant administratif obligatoire. Une structure pourra cumuler plusieurs rôles.
+
+### Noe-062B — Relation contractuelle
+
+Relier tiers, saison, bénéficiaire/payeur, activité, groupe libre, tarif, adhésion éventuelle, mode de facturation et convention. La règle appartient à la relation et non au type de structure.
+
+### Noe-062C — Programmation annuelle
+
+Enregistrer les créneaux souhaités puis validés et permettre le renouvellement N-1 avec lignes inchangées/modifiées/supprimées/ajoutées.
+
+### Noe-062D — Convention, annexe et avenants
+
+Brancher les champs canoniques sur le moteur documentaire existant. L'annexe doit être générée date par date depuis la programmation validée ; un changement en cours d'année produit un avenant sans écraser la convention initiale.
+
+### Noe-062E — Réalisé, facturation et reporting
+
+Le même jeu de données doit alimenter planning, validation du réalisé, prestations, facturation et indicateurs. Aucune requête métier concurrente ne doit recalculer différemment les mêmes chiffres.
+
+## Règles de compatibilité
+
+- aucune migration destructive ;
+- aucune modification implicite d'une base existante ;
+- conservation des locations actuelles ;
+- conservation du moteur prestations/facturation ;
+- conservation des questionnaires et modèles documentaires ;
+- tests sur copie de base réelle avant activation d'une future migration additive.

--- a/docs/NOE-062-MISES-A-DISPOSITION.md
+++ b/docs/NOE-062-MISES-A-DISPOSITION.md
@@ -98,6 +98,62 @@ Les règles d'adhésion possibles sont :
 
 Cette séparation permet notamment à une même collectivité d'avoir une relation de financement où l'adhésion est non applicable et, dans un autre contexte, une mise à disposition avec une règle différente. Aucune règle du type « mairie = adhésion » n'est codée en dur.
 
+### Noe-062C — Programmation annuelle et renouvellement
+
+`Utils/UTILS_Mises_a_disposition_programmation.py` porte la programmation contractuelle sans générer de dates d'occurrence.
+
+Un créneau contient :
+
+- jour de semaine ;
+- horaires ;
+- période d'application éventuelle ;
+- groupe / section ;
+- lieu ;
+- observations ;
+- identifiant stable ;
+- filiation vers le créneau N-1 lorsque la ligne est renouvelée.
+
+Le renouvellement distingue explicitement `inchange`, `modifie`, `supprime` et `ajoute`. Les dates de l'année précédente ne sont jamais transposées implicitement.
+
+### Noe-062D — Convention, annexe et avenants
+
+`Utils/UTILS_Mises_a_disposition_documents.py` prépare la sortie documentaire sans dupliquer le moteur historique.
+
+`RegleCalendrierMiseADisposition` traduit un créneau vers **le contrat exact attendu par la récurrence Locations** :
+
+- `date_debut` / `date_fin` ;
+- `heure_debut` / `heure_fin` ;
+- `jours_scolaires` / `jours_vacances` ;
+- `semaines` ;
+- `feries`.
+
+Le module ne contient volontairement **aucun calcul de vacances, jours fériés ou fréquence**. `GenererAnnexeDepuisProgrammation()` reçoit un `calculateur_occurences` et lui transmet ces paramètres. Le calculateur historique reste donc la source de vérité des dates.
+
+L'annexe obtenue :
+
+- est triée date par date ;
+- conserve le lien vers chaque créneau ;
+- déduplique une occurrence identique retournée deux fois ;
+- totalise les durées ;
+- expose des lignes structurées et des champs de fusion ;
+- utilise des identifiants UUID5 déterministes pour qu'une même programmation et une même période produisent les mêmes identités d'annexe et d'occurrence.
+
+`DossierDocumentaireMiseADisposition` fusionne ensuite les champs de :
+
+- convention ou avenant ;
+- relation contractuelle ;
+- bénéficiaire ;
+- payeur ;
+- contact convention ;
+- programmation ;
+- annexe prévisionnelle.
+
+Le résultat est un **paquet de modèle**, pas un second moteur PDF. Il est destiné à être consommé par les modèles documentaires Noethys existants afin de conserver strictement la structure du modèle PMSL.
+
+Un avenant est identifié par sa filiation vers la convention parente. Il ne remplace pas la convention d'origine.
+
+`SnapshotDocumentContractuel` permet enfin de figer le paquet de modèle avec une empreinte SHA-256. La règle de stockage future est simple : un document validé reçoit un snapshot ; une modification contractuelle crée un nouvel avenant / snapshot au lieu de recalculer silencieusement l'ancien document.
+
 ## Cycle de vie initial
 
 Statuts techniques autorisés :
@@ -122,11 +178,28 @@ La période de validité est distincte du statut. Une convention peut couvrir un
 Le noyau expose des champs stables pour :
 
 - la convention ;
-- la structure ;
-- le contact ;
-- la relation contractuelle.
+- la structure bénéficiaire ;
+- la structure payeuse ;
+- le contact convention ;
+- la relation contractuelle ;
+- la programmation ;
+- l'annexe ;
+- le type de document.
 
 Ils ont vocation à alimenter le moteur documentaire existant afin que convention, annexe, e-mail et reporting utilisent les mêmes données. Le modèle de convention fourni par PMSL doit être conservé dans son ordre et sa structure, sans réécriture arbitraire.
+
+## Raccord au moteur historique
+
+Le raccord est volontairement défini comme une **interface de calcul**, pas comme une copie de l'algorithme.
+
+Aujourd'hui `DLG_Saisie_location.Calcule_occurences()` porte encore l'implémentation historique vacances / fériés / fréquence. Noe-062D sait déjà lui fournir exactement le dictionnaire attendu.
+
+La dernière étape de raccord desktop consistera à sortir ce calcul du dialogue `DLG_Saisie_location.py` vers une fonction réutilisable, puis à faire appeler cette même fonction par :
+
+1. le dialogue historique Locations ;
+2. la génération d'annexe des mises à disposition.
+
+Cette extraction doit préserver strictement le comportement actuel des locations. Elle n'est pas remplacée par une seconde implémentation.
 
 ## Stockage : décision reportée volontairement
 
@@ -134,21 +207,19 @@ Ce lot ne crée toujours aucune table et n'altère aucune base existante.
 
 Le dépôt contient déjà une table historique `contacts`. Avant d'introduire un stockage pour les structures et leurs contacts, il faut cartographier ses usages réels et décider explicitement si elle peut être étendue sans ambiguïté ou si un stockage additif dédié est préférable.
 
-Le même principe vaut pour la relation contractuelle : le schéma ne sera introduit qu'après validation du modèle pur et avec une migration additive testée sur copie de base réelle.
+Le même principe vaut pour la relation contractuelle, la programmation et les snapshots documentaires : le schéma ne sera introduit qu'après validation du modèle pur et avec une migration additive testée sur copie de base réelle.
 
-## Étapes suivantes
-
-### Noe-062C — Programmation annuelle
-
-Enregistrer les créneaux souhaités puis validés et permettre le renouvellement N-1 avec lignes inchangées/modifiées/supprimées/ajoutées.
-
-### Noe-062D — Convention, annexe et avenants
-
-Brancher les champs canoniques sur le moteur documentaire existant. L'annexe doit être générée date par date depuis la programmation validée ; un changement en cours d'année produit un avenant sans écraser la convention initiale.
+## Étape suivante
 
 ### Noe-062E — Réalisé, facturation et reporting
 
 Le même jeu de données doit alimenter planning, validation du réalisé, prestations, facturation et indicateurs. Aucune requête métier concurrente ne doit recalculer différemment les mêmes chiffres.
+
+Avant activation en production, il restera également à :
+
+- effectuer l'extraction technique du calculateur de récurrence hors du dialogue Locations ;
+- brancher le paquet de modèle sur le modèle de convention PMSL effectivement utilisé ;
+- introduire le stockage additif après recette sur copie de base réelle.
 
 ## Règles de compatibilité
 
@@ -157,4 +228,5 @@ Le même jeu de données doit alimenter planning, validation du réalisé, prest
 - conservation des locations actuelles ;
 - conservation du moteur prestations/facturation ;
 - conservation des questionnaires et modèles documentaires ;
+- aucun recalcul concurrent des vacances, jours fériés ou fréquences ;
 - tests sur copie de base réelle avant activation d'une future migration additive.

--- a/docs/NOE-062-MISES-A-DISPOSITION.md
+++ b/docs/NOE-062-MISES-A-DISPOSITION.md
@@ -37,11 +37,9 @@ Cette représentation est adaptée à la location de produits mais insuffisante 
 
 Le module historique ne doit donc pas être renommé artificiellement ni détourné en modèle universel.
 
-## Premier noyau introduit
+## Noyau métier introduit
 
-`Utils/UTILS_Mises_a_disposition.py` introduit un objet métier pur `ConventionMiseADisposition`.
-
-Il est volontairement indépendant de wxPython et de `GestionDB` afin que les mêmes règles puissent être utilisées par :
+`Utils/UTILS_Mises_a_disposition.py` est volontairement indépendant de wxPython et de `GestionDB` afin que les mêmes règles puissent être utilisées par :
 
 - l'interface desktop ;
 - les futures migrations de données ;
@@ -50,7 +48,9 @@ Il est volontairement indépendant de wxPython et de `GestionDB` afin que les m�
 - les échanges PMSL-Équipe ;
 - des tests unitaires rapides.
 
-Le noyau porte uniquement ce qui est déjà suffisamment stable pour être partagé :
+### Convention et avenants
+
+`ConventionMiseADisposition` porte :
 
 - identifiant UUID stable ;
 - période contractuelle ;
@@ -58,10 +58,45 @@ Le noyau porte uniquement ce qui est déjà suffisamment stable pour être parta
 - statut ;
 - version ;
 - lien vers la convention parente pour un avenant ;
+- lien optionnel vers la relation contractuelle ;
 - mode de facturation ;
 - champs de fusion canoniques.
 
-Il ne crée aucune table et n'altère aucune base existante à ce stade.
+### Noe-062A — Structures et contacts
+
+`StructureMiseADisposition` représente une structure opérationnelle ou juridique sans exiger d'identifiant administratif. Les types initiaux sont : association, école, collectivité, organisme, entreprise et autre.
+
+Une école peut donc être bénéficiaire d'une intervention même si le payeur est une mairie, un OGEC ou une autre structure.
+
+`ContactStructure` rattache une personne à une structure avec plusieurs rôles possibles : présidence, trésorerie, direction, APEL, responsable de section, planning, facturation, convention, administratif et urgence.
+
+Les rôles sont cumulables et dédupliqués. Ils ne sont pas encodés dans le nom ou la fonction du contact.
+
+### Noe-062B — Relation contractuelle
+
+`RelationContractuelleMiseADisposition` porte les règles qui appartiennent à la relation et non au type de structure :
+
+- structure bénéficiaire ;
+- structure payeuse, distincte si nécessaire ;
+- saison ;
+- activité ;
+- groupe / section libre ;
+- tarif unitaire ;
+- unité de tarif : heure, séance, forfait ou journée ;
+- règle d'adhésion ;
+- mode de facturation ;
+- UUID stable partageable avec les autres composants.
+
+Le tarif utilise `Decimal` afin de ne pas introduire d'arrondis binaires de type `float` dans le noyau financier.
+
+Les règles d'adhésion possibles sont :
+
+- `requise` ;
+- `non_requise` ;
+- `non_applicable` ;
+- `exoneree`.
+
+Cette séparation permet notamment à une même collectivité d'avoir une relation de financement où l'adhésion est non applicable et, dans un autre contexte, une mise à disposition avec une règle différente. Aucune règle du type « mairie = adhésion » n'est codée en dur.
 
 ## Cycle de vie initial
 
@@ -84,29 +119,24 @@ La période de validité est distincte du statut. Une convention peut couvrir un
 
 ## Champs de fusion canoniques
 
-Le noyau expose :
+Le noyau expose des champs stables pour :
 
-- `{CONVENTION_ID_STABLE}` ;
-- `{CONVENTION_REFERENCE}` ;
-- `{CONVENTION_VERSION}` ;
-- `{CONVENTION_STATUT}` ;
-- `{CONVENTION_DATE_DEBUT}` ;
-- `{CONVENTION_DATE_FIN}` ;
-- `{CONVENTION_MODE_FACTURATION}` ;
-- `{CONVENTION_PARENT_ID_STABLE}` ;
-- `{CONVENTION_EST_AVENANT}`.
+- la convention ;
+- la structure ;
+- le contact ;
+- la relation contractuelle.
 
-Ces champs ont vocation à rejoindre le moteur documentaire existant ; le modèle de convention fourni par PMSL doit être conservé dans son ordre et sa structure, sans réécriture arbitraire.
+Ils ont vocation à alimenter le moteur documentaire existant afin que convention, annexe, e-mail et reporting utilisent les mêmes données. Le modèle de convention fourni par PMSL doit être conservé dans son ordre et sa structure, sans réécriture arbitraire.
+
+## Stockage : décision reportée volontairement
+
+Ce lot ne crée toujours aucune table et n'altère aucune base existante.
+
+Le dépôt contient déjà une table historique `contacts`. Avant d'introduire un stockage pour les structures et leurs contacts, il faut cartographier ses usages réels et décider explicitement si elle peut être étendue sans ambiguïté ou si un stockage additif dédié est préférable.
+
+Le même principe vaut pour la relation contractuelle : le schéma ne sera introduit qu'après validation du modèle pur et avec une migration additive testée sur copie de base réelle.
 
 ## Étapes suivantes
-
-### Noe-062A — Tiers et contacts
-
-Introduire de manière additive le tiers personne morale et ses contacts, sans identifiant administratif obligatoire. Une structure pourra cumuler plusieurs rôles.
-
-### Noe-062B — Relation contractuelle
-
-Relier tiers, saison, bénéficiaire/payeur, activité, groupe libre, tarif, adhésion éventuelle, mode de facturation et convention. La règle appartient à la relation et non au type de structure.
 
 ### Noe-062C — Programmation annuelle
 

--- a/docs/NOE-062C-PROGRAMMATION.md
+++ b/docs/NOE-062C-PROGRAMMATION.md
@@ -1,0 +1,135 @@
+# Noe-062C — Programmation annuelle des mises à disposition
+
+## Objectif
+
+Décrire une programmation annuelle réutilisable par l'interface, les conventions, l'annexe prévisionnelle, PMSL-Équipe et le reporting, sans recopier le moteur de calendrier historique de Noethys.
+
+Le socle est dans `Utils/UTILS_Mises_a_disposition_programmation.py` et ne dépend ni de wxPython ni de `GestionDB`.
+
+## Séparation des responsabilités
+
+La programmation décrit **ce qui est prévu contractuellement** :
+
+- relation contractuelle ;
+- saison ;
+- jour de semaine ;
+- heure de début et de fin ;
+- période éventuelle ;
+- groupe / section libre ;
+- lieu ;
+- observations ;
+- état par rapport à N-1.
+
+Elle ne calcule pas elle-même les dates réelles des séances.
+
+Les vacances scolaires, jours fériés, semaines paires/impaires et autres règles de récurrence sont déjà gérés dans le module historique `Locations`. La future génération de l'annexe date par date devra passer par un adaptateur vers ce moteur, afin de conserver une seule logique de calendrier.
+
+## `CreneauProgrammation`
+
+Chaque créneau possède un UUID stable et est lié à l'UUID de sa relation contractuelle.
+
+Règles :
+
+- jour compris entre lundi et dimanche (`0..6`) ;
+- heure de fin strictement postérieure à l'heure de début ;
+- période facultative mais cohérente si elle est renseignée ;
+- les horaires de nuit traversant minuit ne sont pas admis implicitement ; ils devront faire l'objet d'une règle explicite si le besoin apparaît ;
+- durée prévisionnelle calculée en minutes ;
+- données sérialisables sans objet wxPython ou base de données.
+
+## Renouvellement N-1
+
+Une ligne recopiée vers la nouvelle saison :
+
+- reçoit un nouvel UUID ;
+- conserve `identifiant_source`, l'UUID de la ligne N-1 ;
+- commence en état `inchange` ;
+- conserve jour, horaires, groupe, lieu et observations ;
+- **ne recopie jamais implicitement les dates exactes de l'année précédente**.
+
+La nouvelle période est fournie explicitement par l'appelant. Cela évite qu'une programmation 2025-2026 conserve silencieusement des dates 2025 lors de son passage en 2026-2027.
+
+## États de comparaison
+
+Chaque ligne de la saison renouvelée est classée :
+
+- `inchange` ;
+- `modifie` ;
+- `supprime` ;
+- `ajoute`.
+
+Une ligne héritée puis modifiée garde son UUID de la nouvelle saison et son lien vers la source N-1.
+
+Une ligne héritée puis supprimée reste présente avec l'état `supprime`, afin de conserver la décision métier et de pouvoir produire un comparatif.
+
+Une ligne créée puis supprimée pendant la préparation de la même saison disparaît simplement : elle n'a jamais existé dans N-1 et ne doit pas créer une fausse trace de suppression.
+
+## `ProgrammationAnnuelle`
+
+La programmation annuelle porte :
+
+- UUID stable ;
+- UUID de la relation contractuelle ;
+- saison ;
+- statut ;
+- UUID de la programmation source N-1 lorsqu'elle provient d'un renouvellement ;
+- ensemble des créneaux.
+
+Statuts initiaux :
+
+- `brouillon` ;
+- `soumise` ;
+- `validee` ;
+- `annulee`.
+
+Le renouvellement d'une programmation validée crée une nouvelle programmation en brouillon. Seules les lignes conservées de N-1 sont recopiées.
+
+## Synthèse du renouvellement
+
+Le noyau peut fournir directement le nombre de lignes :
+
+- inchangées ;
+- modifiées ;
+- supprimées ;
+- ajoutées.
+
+Cette synthèse pourra alimenter l'écran de traitement de la demande annuelle et le futur formulaire web de renouvellement sans recalcul concurrent.
+
+## Champs de fusion
+
+La programmation et les créneaux exposent des champs de fusion canoniques, notamment :
+
+- saison ;
+- statut ;
+- relation ;
+- nombre de créneaux ;
+- compteurs de comparaison N-1 ;
+- jour ;
+- horaires ;
+- durée ;
+- groupe ;
+- lieu ;
+- période ;
+- état de renouvellement.
+
+Ces données serviront ensuite à l'annexe prévisionnelle, mais l'expansion date par date restera effectuée par le moteur calendrier existant.
+
+## Compatibilité
+
+Ce lot :
+
+- ne crée aucune table ;
+- ne modifie aucune table ;
+- ne déclenche aucune migration ;
+- ne touche pas aux locations existantes ;
+- n'altère aucune prestation ni facturation ;
+- reste testable sans wxPython.
+
+## Étape suivante
+
+**Noe-062D** : créer l'adaptateur entre la programmation validée et les moteurs existants de récurrence/document afin de produire :
+
+1. les occurrences prévisionnelles ;
+2. l'annexe date par date ;
+3. les champs de fusion complets convention + bénéficiaire + payeur + contacts + programmation ;
+4. un avenant lorsqu'une programmation validée change en cours de saison, sans écraser le document initial.

--- a/noethys/Utils/UTILS_Mises_a_disposition.py
+++ b/noethys/Utils/UTILS_Mises_a_disposition.py
@@ -5,7 +5,7 @@
 # Licence :        GNU GPL
 #------------------------------------------------------------------------
 
-"""Règles métier pures pour les conventions de mise à disposition.
+"""Règles métier pures pour les mises à disposition.
 
 Ce module ne dépend volontairement ni de wxPython ni de GestionDB. Il sert de
 noyau commun aux écrans, aux éditions de conventions/avenants, au reporting et
@@ -14,6 +14,7 @@ aux futurs échanges avec PMSL-Équipe.
 
 import datetime
 import uuid
+from decimal import Decimal, InvalidOperation
 
 
 STATUT_BROUILLON = "brouillon"
@@ -40,6 +41,70 @@ MODES_FACTURATION = (
     FACTURATION_MENSUELLE,
     FACTURATION_TRIMESTRIELLE,
     FACTURATION_APRES_REALISE,
+)
+
+TYPE_ASSOCIATION = "association"
+TYPE_ECOLE = "ecole"
+TYPE_COLLECTIVITE = "collectivite"
+TYPE_ORGANISME = "organisme"
+TYPE_ENTREPRISE = "entreprise"
+TYPE_AUTRE = "autre"
+
+TYPES_STRUCTURE = (
+    TYPE_ASSOCIATION,
+    TYPE_ECOLE,
+    TYPE_COLLECTIVITE,
+    TYPE_ORGANISME,
+    TYPE_ENTREPRISE,
+    TYPE_AUTRE,
+)
+
+ROLE_CONTACT_PRESIDENCE = "presidence"
+ROLE_CONTACT_TRESORERIE = "tresorerie"
+ROLE_CONTACT_DIRECTION = "direction"
+ROLE_CONTACT_APEL = "apel"
+ROLE_CONTACT_SECTION = "responsable_section"
+ROLE_CONTACT_PLANNING = "planning"
+ROLE_CONTACT_FACTURATION = "facturation"
+ROLE_CONTACT_CONVENTION = "convention"
+ROLE_CONTACT_ADMINISTRATIF = "administratif"
+ROLE_CONTACT_URGENCE = "urgence"
+
+ROLES_CONTACT = (
+    ROLE_CONTACT_PRESIDENCE,
+    ROLE_CONTACT_TRESORERIE,
+    ROLE_CONTACT_DIRECTION,
+    ROLE_CONTACT_APEL,
+    ROLE_CONTACT_SECTION,
+    ROLE_CONTACT_PLANNING,
+    ROLE_CONTACT_FACTURATION,
+    ROLE_CONTACT_CONVENTION,
+    ROLE_CONTACT_ADMINISTRATIF,
+    ROLE_CONTACT_URGENCE,
+)
+
+ADHESION_REQUISE = "requise"
+ADHESION_NON_REQUISE = "non_requise"
+ADHESION_NON_APPLICABLE = "non_applicable"
+ADHESION_EXONEREE = "exoneree"
+
+REGLES_ADHESION = (
+    ADHESION_REQUISE,
+    ADHESION_NON_REQUISE,
+    ADHESION_NON_APPLICABLE,
+    ADHESION_EXONEREE,
+)
+
+UNITE_HEURE = "heure"
+UNITE_SEANCE = "seance"
+UNITE_FORFAIT = "forfait"
+UNITE_JOURNEE = "journee"
+
+UNITES_TARIF = (
+    UNITE_HEURE,
+    UNITE_SEANCE,
+    UNITE_FORFAIT,
+    UNITE_JOURNEE,
 )
 
 
@@ -71,19 +136,278 @@ def _GetUUID(valeur, nom_champ, obligatoire=True):
         raise ValueError("%s doit être un UUID valide" % nom_champ)
 
 
+def _GetDecimal(valeur, nom_champ, obligatoire=False):
+    if valeur in (None, ""):
+        if obligatoire:
+            raise ValueError("%s est obligatoire" % nom_champ)
+        return None
+    try:
+        resultat = Decimal(str(valeur))
+    except (InvalidOperation, ValueError, TypeError):
+        raise ValueError("%s doit être un nombre décimal valide" % nom_champ)
+    if resultat < 0:
+        raise ValueError("%s ne peut pas être négatif" % nom_champ)
+    return resultat
+
+
 def _FormatDate(valeur):
     if valeur is None:
         return ""
     return valeur.strftime("%d/%m/%Y")
 
 
-class ConventionMiseADisposition(object):
-    """Représentation canonique d'une convention ou d'un avenant.
+def _FormatDecimal(valeur):
+    if valeur is None:
+        return ""
+    return format(valeur, "f")
 
-    L'identifiant stable est indépendant des futures clés primaires de base de
-    données. Il pourra être partagé avec PMSL-Équipe et survivre à un export,
-    une réplication de paramétrage ou une migration de base.
+
+def _NettoyerRoles(roles):
+    resultat = []
+    for role in roles or ():
+        role = (role or "").strip()
+        if role not in ROLES_CONTACT:
+            raise ValueError("rôle de contact inconnu : %s" % role)
+        if role not in resultat:
+            resultat.append(role)
+    return tuple(resultat)
+
+
+class StructureMiseADisposition(object):
+    """Structure bénéficiaire, payeuse ou partenaire d'une mise à disposition.
+
+    Une école peut être représentée ici comme structure opérationnelle même si
+    son payeur juridique est une mairie, un OGEC ou une autre entité.
     """
+
+    def __init__(
+        self,
+        nom,
+        type_structure=TYPE_ASSOCIATION,
+        identifiant_stable=None,
+        siret="",
+        siren="",
+        rna="",
+        code_ape="",
+        rue="",
+        cp="",
+        ville="",
+        mail="",
+        telephone="",
+    ):
+        self.nom = (nom or "").strip()
+        self.type_structure = type_structure
+        self.identifiant_stable = _GetUUID(
+            identifiant_stable, "identifiant_stable", obligatoire=True
+        )
+        self.siret = (siret or "").strip()
+        self.siren = (siren or "").strip()
+        self.rna = (rna or "").strip()
+        self.code_ape = (code_ape or "").strip()
+        self.rue = (rue or "").strip()
+        self.cp = (cp or "").strip()
+        self.ville = (ville or "").strip()
+        self.mail = (mail or "").strip()
+        self.telephone = (telephone or "").strip()
+        self.Validation()
+
+    def Validation(self):
+        if not self.nom:
+            raise ValueError("nom de structure obligatoire")
+        if self.type_structure not in TYPES_STRUCTURE:
+            raise ValueError("type de structure inconnu : %s" % self.type_structure)
+        return True
+
+    def GetChampsFusion(self, prefixe="STRUCTURE"):
+        prefixe = (prefixe or "STRUCTURE").strip().upper()
+        return {
+            "{%s_ID_STABLE}" % prefixe: self.identifiant_stable,
+            "{%s_NOM}" % prefixe: self.nom,
+            "{%s_TYPE}" % prefixe: self.type_structure,
+            "{%s_SIRET}" % prefixe: self.siret,
+            "{%s_SIREN}" % prefixe: self.siren,
+            "{%s_RNA}" % prefixe: self.rna,
+            "{%s_APE}" % prefixe: self.code_ape,
+            "{%s_RUE}" % prefixe: self.rue,
+            "{%s_CP}" % prefixe: self.cp,
+            "{%s_VILLE}" % prefixe: self.ville,
+            "{%s_MAIL}" % prefixe: self.mail,
+            "{%s_TELEPHONE}" % prefixe: self.telephone,
+        }
+
+    def GetDonnees(self):
+        return {
+            "identifiant_stable": self.identifiant_stable,
+            "nom": self.nom,
+            "type_structure": self.type_structure,
+            "siret": self.siret,
+            "siren": self.siren,
+            "rna": self.rna,
+            "code_ape": self.code_ape,
+            "rue": self.rue,
+            "cp": self.cp,
+            "ville": self.ville,
+            "mail": self.mail,
+            "telephone": self.telephone,
+        }
+
+
+class ContactStructure(object):
+    """Contact d'une structure avec un ou plusieurs rôles métier."""
+
+    def __init__(
+        self,
+        identifiant_structure,
+        nom,
+        prenom="",
+        roles=None,
+        identifiant_stable=None,
+        fonction="",
+        mail="",
+        telephone="",
+    ):
+        self.identifiant_structure = _GetUUID(
+            identifiant_structure, "identifiant_structure", obligatoire=True
+        )
+        self.identifiant_stable = _GetUUID(
+            identifiant_stable, "identifiant_stable", obligatoire=True
+        )
+        self.nom = (nom or "").strip()
+        self.prenom = (prenom or "").strip()
+        self.fonction = (fonction or "").strip()
+        self.mail = (mail or "").strip()
+        self.telephone = (telephone or "").strip()
+        self.roles = _NettoyerRoles(roles)
+        self.Validation()
+
+    def Validation(self):
+        if not self.nom:
+            raise ValueError("nom du contact obligatoire")
+        return True
+
+    def ALeRole(self, role):
+        return role in self.roles
+
+    def GetNomComplet(self):
+        return " ".join([valeur for valeur in (self.prenom, self.nom) if valeur])
+
+    def GetChampsFusion(self, prefixe="CONTACT"):
+        prefixe = (prefixe or "CONTACT").strip().upper()
+        return {
+            "{%s_ID_STABLE}" % prefixe: self.identifiant_stable,
+            "{%s_STRUCTURE_ID_STABLE}" % prefixe: self.identifiant_structure,
+            "{%s_NOM}" % prefixe: self.nom,
+            "{%s_PRENOM}" % prefixe: self.prenom,
+            "{%s_NOM_COMPLET}" % prefixe: self.GetNomComplet(),
+            "{%s_FONCTION}" % prefixe: self.fonction,
+            "{%s_MAIL}" % prefixe: self.mail,
+            "{%s_TELEPHONE}" % prefixe: self.telephone,
+            "{%s_ROLES}" % prefixe: ",".join(self.roles),
+        }
+
+    def GetDonnees(self):
+        return {
+            "identifiant_stable": self.identifiant_stable,
+            "identifiant_structure": self.identifiant_structure,
+            "nom": self.nom,
+            "prenom": self.prenom,
+            "fonction": self.fonction,
+            "mail": self.mail,
+            "telephone": self.telephone,
+            "roles": list(self.roles),
+        }
+
+
+class RelationContractuelleMiseADisposition(object):
+    """Règles commerciales attachées à une relation, pas au type de structure."""
+
+    def __init__(
+        self,
+        identifiant_beneficiaire,
+        saison,
+        activite,
+        identifiant_payeur=None,
+        groupe="",
+        tarif_unitaire=None,
+        unite_tarif=UNITE_HEURE,
+        regle_adhesion=ADHESION_NON_REQUISE,
+        mode_facturation=FACTURATION_MANUELLE,
+        identifiant_stable=None,
+    ):
+        self.identifiant_beneficiaire = _GetUUID(
+            identifiant_beneficiaire, "identifiant_beneficiaire", obligatoire=True
+        )
+        self.identifiant_payeur = _GetUUID(
+            identifiant_payeur, "identifiant_payeur", obligatoire=False
+        ) or self.identifiant_beneficiaire
+        self.identifiant_stable = _GetUUID(
+            identifiant_stable, "identifiant_stable", obligatoire=True
+        )
+        self.saison = (saison or "").strip()
+        self.activite = (activite or "").strip()
+        self.groupe = (groupe or "").strip()
+        self.tarif_unitaire = _GetDecimal(
+            tarif_unitaire, "tarif_unitaire", obligatoire=False
+        )
+        self.unite_tarif = unite_tarif
+        self.regle_adhesion = regle_adhesion
+        self.mode_facturation = mode_facturation
+        self.Validation()
+
+    def Validation(self):
+        if not self.saison:
+            raise ValueError("saison obligatoire")
+        if not self.activite:
+            raise ValueError("activité obligatoire")
+        if self.unite_tarif not in UNITES_TARIF:
+            raise ValueError("unité tarifaire inconnue : %s" % self.unite_tarif)
+        if self.regle_adhesion not in REGLES_ADHESION:
+            raise ValueError("règle d'adhésion inconnue : %s" % self.regle_adhesion)
+        if self.mode_facturation not in MODES_FACTURATION:
+            raise ValueError(
+                "mode de facturation inconnu : %s" % self.mode_facturation
+            )
+        return True
+
+    def EstPayeurDistinct(self):
+        return self.identifiant_payeur != self.identifiant_beneficiaire
+
+    def GetChampsFusion(self):
+        return {
+            "{RELATION_ID_STABLE}": self.identifiant_stable,
+            "{RELATION_BENEFICIAIRE_ID_STABLE}": self.identifiant_beneficiaire,
+            "{RELATION_PAYEUR_ID_STABLE}": self.identifiant_payeur,
+            "{RELATION_PAYEUR_DISTINCT}": "1" if self.EstPayeurDistinct() else "0",
+            "{RELATION_SAISON}": self.saison,
+            "{RELATION_ACTIVITE}": self.activite,
+            "{RELATION_GROUPE}": self.groupe,
+            "{RELATION_TARIF_UNITAIRE}": _FormatDecimal(self.tarif_unitaire),
+            "{RELATION_UNITE_TARIF}": self.unite_tarif,
+            "{RELATION_ADHESION}": self.regle_adhesion,
+            "{RELATION_MODE_FACTURATION}": self.mode_facturation,
+        }
+
+    def GetDonnees(self):
+        return {
+            "identifiant_stable": self.identifiant_stable,
+            "identifiant_beneficiaire": self.identifiant_beneficiaire,
+            "identifiant_payeur": self.identifiant_payeur,
+            "saison": self.saison,
+            "activite": self.activite,
+            "groupe": self.groupe,
+            "tarif_unitaire": (
+                _FormatDecimal(self.tarif_unitaire)
+                if self.tarif_unitaire is not None
+                else None
+            ),
+            "unite_tarif": self.unite_tarif,
+            "regle_adhesion": self.regle_adhesion,
+            "mode_facturation": self.mode_facturation,
+        }
+
+
+class ConventionMiseADisposition(object):
+    """Représentation canonique d'une convention ou d'un avenant."""
 
     def __init__(
         self,
@@ -95,6 +419,7 @@ class ConventionMiseADisposition(object):
         version=1,
         identifiant_stable=None,
         identifiant_parent=None,
+        identifiant_relation=None,
     ):
         self.date_debut = _GetDate(date_debut, "date_debut")
         self.date_fin = _GetDate(date_fin, "date_fin")
@@ -107,6 +432,9 @@ class ConventionMiseADisposition(object):
         )
         self.identifiant_parent = _GetUUID(
             identifiant_parent, "identifiant_parent", obligatoire=False
+        )
+        self.identifiant_relation = _GetUUID(
+            identifiant_relation, "identifiant_relation", obligatoire=False
         )
         self.Validation()
 
@@ -149,6 +477,7 @@ class ConventionMiseADisposition(object):
         """Retourne les champs canoniques utilisables par le moteur documentaire."""
         return {
             "{CONVENTION_ID_STABLE}": self.identifiant_stable,
+            "{CONVENTION_RELATION_ID_STABLE}": self.identifiant_relation or "",
             "{CONVENTION_REFERENCE}": self.reference,
             "{CONVENTION_VERSION}": str(self.version),
             "{CONVENTION_STATUT}": self.statut,
@@ -164,6 +493,7 @@ class ConventionMiseADisposition(object):
         return {
             "identifiant_stable": self.identifiant_stable,
             "identifiant_parent": self.identifiant_parent,
+            "identifiant_relation": self.identifiant_relation,
             "reference": self.reference,
             "version": self.version,
             "statut": self.statut,

--- a/noethys/Utils/UTILS_Mises_a_disposition.py
+++ b/noethys/Utils/UTILS_Mises_a_disposition.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#------------------------------------------------------------------------
+# Application :    Noethys, gestion multi-activités
+# Licence :        GNU GPL
+#------------------------------------------------------------------------
+
+"""Règles métier pures pour les conventions de mise à disposition.
+
+Ce module ne dépend volontairement ni de wxPython ni de GestionDB. Il sert de
+noyau commun aux écrans, aux éditions de conventions/avenants, au reporting et
+aux futurs échanges avec PMSL-Équipe.
+"""
+
+import datetime
+import uuid
+
+
+STATUT_BROUILLON = "brouillon"
+STATUT_VALIDEE = "validee"
+STATUT_SIGNEE = "signee"
+STATUT_TERMINEE = "terminee"
+STATUT_ANNULEE = "annulee"
+
+STATUTS = (
+    STATUT_BROUILLON,
+    STATUT_VALIDEE,
+    STATUT_SIGNEE,
+    STATUT_TERMINEE,
+    STATUT_ANNULEE,
+)
+
+FACTURATION_MANUELLE = "manuelle"
+FACTURATION_MENSUELLE = "mensuelle"
+FACTURATION_TRIMESTRIELLE = "trimestrielle"
+FACTURATION_APRES_REALISE = "apres_realise"
+
+MODES_FACTURATION = (
+    FACTURATION_MANUELLE,
+    FACTURATION_MENSUELLE,
+    FACTURATION_TRIMESTRIELLE,
+    FACTURATION_APRES_REALISE,
+)
+
+
+def _GetDate(valeur, nom_champ):
+    """Retourne une date à partir d'une date, datetime ou chaîne ISO."""
+    if valeur in (None, ""):
+        return None
+    if isinstance(valeur, datetime.datetime):
+        return valeur.date()
+    if isinstance(valeur, datetime.date):
+        return valeur
+    if isinstance(valeur, str):
+        try:
+            return datetime.datetime.strptime(valeur, "%Y-%m-%d").date()
+        except ValueError:
+            pass
+    raise ValueError("%s doit être une date ou une date ISO YYYY-MM-DD" % nom_champ)
+
+
+def _GetUUID(valeur, nom_champ, obligatoire=True):
+    """Normalise un identifiant stable UUID sous forme de chaîne."""
+    if valeur in (None, ""):
+        if obligatoire:
+            return str(uuid.uuid4())
+        return None
+    try:
+        return str(uuid.UUID(str(valeur)))
+    except (ValueError, AttributeError, TypeError):
+        raise ValueError("%s doit être un UUID valide" % nom_champ)
+
+
+def _FormatDate(valeur):
+    if valeur is None:
+        return ""
+    return valeur.strftime("%d/%m/%Y")
+
+
+class ConventionMiseADisposition(object):
+    """Représentation canonique d'une convention ou d'un avenant.
+
+    L'identifiant stable est indépendant des futures clés primaires de base de
+    données. Il pourra être partagé avec PMSL-Équipe et survivre à un export,
+    une réplication de paramétrage ou une migration de base.
+    """
+
+    def __init__(
+        self,
+        date_debut,
+        date_fin=None,
+        reference="",
+        statut=STATUT_BROUILLON,
+        mode_facturation=FACTURATION_MANUELLE,
+        version=1,
+        identifiant_stable=None,
+        identifiant_parent=None,
+    ):
+        self.date_debut = _GetDate(date_debut, "date_debut")
+        self.date_fin = _GetDate(date_fin, "date_fin")
+        self.reference = (reference or "").strip()
+        self.statut = statut
+        self.mode_facturation = mode_facturation
+        self.version = int(version)
+        self.identifiant_stable = _GetUUID(
+            identifiant_stable, "identifiant_stable", obligatoire=True
+        )
+        self.identifiant_parent = _GetUUID(
+            identifiant_parent, "identifiant_parent", obligatoire=False
+        )
+        self.Validation()
+
+    def Validation(self):
+        if self.date_debut is None:
+            raise ValueError("date_debut est obligatoire")
+        if self.date_fin is not None and self.date_fin < self.date_debut:
+            raise ValueError("date_fin ne peut pas précéder date_debut")
+        if self.statut not in STATUTS:
+            raise ValueError("statut de convention inconnu : %s" % self.statut)
+        if self.mode_facturation not in MODES_FACTURATION:
+            raise ValueError(
+                "mode de facturation inconnu : %s" % self.mode_facturation
+            )
+        if self.version < 1:
+            raise ValueError("version doit être supérieure ou égale à 1")
+        if self.identifiant_parent == self.identifiant_stable:
+            raise ValueError("une convention ne peut pas être son propre parent")
+        if self.identifiant_parent is not None and self.version < 2:
+            raise ValueError("un avenant doit avoir une version supérieure à 1")
+        return True
+
+    def EstAvenant(self):
+        return self.identifiant_parent is not None
+
+    def EstActiveA(self, date_reference):
+        """Indique si la période contractuelle couvre une date donnée.
+
+        Le statut n'est volontairement pas utilisé ici : période de validité et
+        état de traitement sont deux informations distinctes.
+        """
+        date_reference = _GetDate(date_reference, "date_reference")
+        if date_reference < self.date_debut:
+            return False
+        if self.date_fin is not None and date_reference > self.date_fin:
+            return False
+        return True
+
+    def GetChampsFusion(self):
+        """Retourne les champs canoniques utilisables par le moteur documentaire."""
+        return {
+            "{CONVENTION_ID_STABLE}": self.identifiant_stable,
+            "{CONVENTION_REFERENCE}": self.reference,
+            "{CONVENTION_VERSION}": str(self.version),
+            "{CONVENTION_STATUT}": self.statut,
+            "{CONVENTION_DATE_DEBUT}": _FormatDate(self.date_debut),
+            "{CONVENTION_DATE_FIN}": _FormatDate(self.date_fin),
+            "{CONVENTION_MODE_FACTURATION}": self.mode_facturation,
+            "{CONVENTION_PARENT_ID_STABLE}": self.identifiant_parent or "",
+            "{CONVENTION_EST_AVENANT}": "1" if self.EstAvenant() else "0",
+        }
+
+    def GetDonnees(self):
+        """Retourne un dictionnaire sérialisable sans dépendance de stockage."""
+        return {
+            "identifiant_stable": self.identifiant_stable,
+            "identifiant_parent": self.identifiant_parent,
+            "reference": self.reference,
+            "version": self.version,
+            "statut": self.statut,
+            "mode_facturation": self.mode_facturation,
+            "date_debut": self.date_debut.isoformat(),
+            "date_fin": self.date_fin.isoformat() if self.date_fin else None,
+        }

--- a/noethys/Utils/UTILS_Mises_a_disposition_documents.py
+++ b/noethys/Utils/UTILS_Mises_a_disposition_documents.py
@@ -1,0 +1,629 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#------------------------------------------------------------------------
+# Application :    Noethys, gestion multi-activités
+# Licence :         GNU GPL
+#------------------------------------------------------------------------
+
+"""Adaptation documentaire des mises à disposition.
+
+Le module reste volontairement sans wxPython, GestionDB ni moteur PDF.
+Il transforme la programmation canonique en contrat d'appel compatible avec
+le calculateur de récurrence historique de Noethys, puis prépare les champs
+et lignes nécessaires aux modèles documentaires existants.
+
+Le calcul des vacances, jours fériés et fréquences n'est jamais réimplémenté
+ici : il est fourni par ``calculateur_occurences``.
+"""
+
+import copy
+import datetime
+import hashlib
+import json
+import uuid
+from decimal import Decimal
+
+
+DOCUMENT_CONVENTION = "convention"
+DOCUMENT_AVENANT = "avenant"
+DOCUMENT_ANNEXE = "annexe"
+
+TYPES_DOCUMENT = (
+    DOCUMENT_CONVENTION,
+    DOCUMENT_AVENANT,
+    DOCUMENT_ANNEXE,
+)
+
+FREQUENCE_TOUTES_LES_SEMAINES = 1
+FREQUENCE_UNE_SUR_DEUX = 2
+FREQUENCE_UNE_SUR_TROIS = 3
+FREQUENCE_UNE_SUR_QUATRE = 4
+FREQUENCE_SEMAINES_PAIRES = 5
+FREQUENCE_SEMAINES_IMPAIRES = 6
+
+JOURS_SEMAINE_FR = (
+    "lundi",
+    "mardi",
+    "mercredi",
+    "jeudi",
+    "vendredi",
+    "samedi",
+    "dimanche",
+)
+
+UUID_NAMESPACE_MAD = uuid.UUID("4b8744bd-e1a2-46a9-a4db-c68c72fd92d3")
+
+FREQUENCES_HISTORIQUES = (
+    FREQUENCE_TOUTES_LES_SEMAINES,
+    FREQUENCE_UNE_SUR_DEUX,
+    FREQUENCE_UNE_SUR_TROIS,
+    FREQUENCE_UNE_SUR_QUATRE,
+    FREQUENCE_SEMAINES_PAIRES,
+    FREQUENCE_SEMAINES_IMPAIRES,
+)
+
+
+def _GetUUID(valeur, nom_champ, obligatoire=True):
+    if valeur in (None, ""):
+        if obligatoire:
+            return str(uuid.uuid4())
+        return None
+    try:
+        return str(uuid.UUID(str(valeur)))
+    except (ValueError, AttributeError, TypeError):
+        raise ValueError("%s doit être un UUID valide" % nom_champ)
+
+
+def _GetDate(valeur, nom_champ):
+    if valeur in (None, ""):
+        return None
+    if isinstance(valeur, datetime.datetime):
+        return valeur.date()
+    if isinstance(valeur, datetime.date):
+        return valeur
+    if isinstance(valeur, str):
+        try:
+            return datetime.datetime.strptime(valeur, "%Y-%m-%d").date()
+        except ValueError:
+            pass
+    raise ValueError("%s doit être une date ou une date ISO YYYY-MM-DD" % nom_champ)
+
+
+def _GetDatetime(valeur, nom_champ):
+    if isinstance(valeur, datetime.datetime):
+        return valeur.replace(second=0, microsecond=0)
+    if isinstance(valeur, str):
+        for format_dt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"):
+            try:
+                return datetime.datetime.strptime(valeur, format_dt)
+            except ValueError:
+                pass
+    raise ValueError("%s doit être un datetime ou une chaîne ISO" % nom_champ)
+
+
+def _FormatDateFr(valeur):
+    return valeur.strftime("%d/%m/%Y") if valeur else ""
+
+
+def _FormatHeure(valeur):
+    return valeur.strftime("%H:%M")
+
+
+def _FormatDureeMinutes(minutes):
+    heures = int(minutes) // 60
+    reste = int(minutes) % 60
+    if reste == 0:
+        return "%dh" % heures
+    return "%dh%02d" % (heures, reste)
+
+
+def _SerialiserValeur(valeur):
+    if isinstance(valeur, datetime.datetime):
+        return valeur.isoformat()
+    if isinstance(valeur, datetime.date):
+        return valeur.isoformat()
+    if isinstance(valeur, Decimal):
+        return format(valeur, "f")
+    if isinstance(valeur, tuple):
+        return [_SerialiserValeur(item) for item in valeur]
+    if isinstance(valeur, list):
+        return [_SerialiserValeur(item) for item in valeur]
+    if isinstance(valeur, dict):
+        return dict(
+            (str(cle), _SerialiserValeur(item))
+            for cle, item in valeur.items()
+        )
+    return valeur
+
+
+class RegleCalendrierMiseADisposition(object):
+    """Paramètres contractuels traduits vers le moteur de récurrence historique."""
+
+    def __init__(
+        self,
+        appliquer_scolaire=True,
+        appliquer_vacances=False,
+        inclure_feries=False,
+        frequence=FREQUENCE_TOUTES_LES_SEMAINES,
+    ):
+        self.appliquer_scolaire = bool(appliquer_scolaire)
+        self.appliquer_vacances = bool(appliquer_vacances)
+        self.inclure_feries = bool(inclure_feries)
+        try:
+            self.frequence = int(frequence)
+        except (TypeError, ValueError):
+            raise ValueError("fréquence historique invalide")
+        self.Validation()
+
+    def Validation(self):
+        if self.frequence not in FREQUENCES_HISTORIQUES:
+            raise ValueError("fréquence historique inconnue : %s" % self.frequence)
+        if not self.appliquer_scolaire and not self.appliquer_vacances:
+            raise ValueError(
+                "la règle doit s'appliquer au scolaire, aux vacances ou aux deux"
+            )
+        return True
+
+    def GetParametresRecurrence(self, creneau, date_debut, date_fin):
+        date_debut = _GetDate(date_debut, "date_debut")
+        date_fin = _GetDate(date_fin, "date_fin")
+        if date_debut is None or date_fin is None:
+            raise ValueError("la période de génération est obligatoire")
+        if date_fin < date_debut:
+            raise ValueError("date_fin ne peut pas précéder date_debut")
+        if getattr(creneau, "date_debut", None):
+            date_debut = max(date_debut, creneau.date_debut)
+        if getattr(creneau, "date_fin", None):
+            date_fin = min(date_fin, creneau.date_fin)
+        if date_fin < date_debut:
+            return None
+
+        jour = int(creneau.jour_semaine)
+        return {
+            "date_debut": date_debut,
+            "date_fin": date_fin,
+            "heure_debut": _FormatHeure(creneau.heure_debut),
+            "heure_fin": _FormatHeure(creneau.heure_fin),
+            "jours_vacances": [jour] if self.appliquer_vacances else [],
+            "jours_scolaires": [jour] if self.appliquer_scolaire else [],
+            "semaines": self.frequence,
+            "feries": self.inclure_feries,
+        }
+
+    def GetDonnees(self):
+        return {
+            "appliquer_scolaire": self.appliquer_scolaire,
+            "appliquer_vacances": self.appliquer_vacances,
+            "inclure_feries": self.inclure_feries,
+            "frequence": self.frequence,
+        }
+
+
+class OccurrenceMiseADisposition(object):
+    """Occurrence datée destinée à l'annexe et au futur réalisé."""
+
+    def __init__(
+        self,
+        creneau,
+        date_debut,
+        date_fin,
+        identifiant_stable=None,
+    ):
+        self.identifiant_creneau = _GetUUID(
+            creneau.identifiant_stable, "identifiant_creneau", obligatoire=True
+        )
+        self.identifiant_relation = _GetUUID(
+            creneau.identifiant_relation, "identifiant_relation", obligatoire=True
+        )
+        self.date_debut = _GetDatetime(date_debut, "date_debut")
+        self.date_fin = _GetDatetime(date_fin, "date_fin")
+        if identifiant_stable in (None, ""):
+            identifiant_stable = str(
+                uuid.uuid5(
+                    UUID_NAMESPACE_MAD,
+                    "%s|%s|%s"
+                    % (
+                        self.identifiant_creneau,
+                        self.date_debut.isoformat(),
+                        self.date_fin.isoformat(),
+                    ),
+                )
+            )
+        self.identifiant_stable = _GetUUID(
+            identifiant_stable, "identifiant_stable", obligatoire=True
+        )
+        self.groupe = (getattr(creneau, "groupe", "") or "").strip()
+        self.lieu = (getattr(creneau, "lieu", "") or "").strip()
+        self.observations = (getattr(creneau, "observations", "") or "").strip()
+        self.Validation()
+
+    def Validation(self):
+        if self.date_fin <= self.date_debut:
+            raise ValueError("date_fin doit être postérieure à date_debut")
+        return True
+
+    def DureeMinutes(self):
+        return int((self.date_fin - self.date_debut).total_seconds() // 60)
+
+    def GetLigneAnnexe(self, index=None):
+        ligne = {
+            "identifiant_stable": self.identifiant_stable,
+            "identifiant_creneau": self.identifiant_creneau,
+            "date": _FormatDateFr(self.date_debut.date()),
+            "jour": JOURS_SEMAINE_FR[self.date_debut.weekday()],
+            "heure_debut": _FormatHeure(self.date_debut.time()),
+            "heure_fin": _FormatHeure(self.date_fin.time()),
+            "duree_minutes": self.DureeMinutes(),
+            "duree": _FormatDureeMinutes(self.DureeMinutes()),
+            "groupe": self.groupe,
+            "lieu": self.lieu,
+            "observations": self.observations,
+        }
+        if index is not None:
+            ligne["numero"] = int(index)
+        return ligne
+
+    def GetDonnees(self):
+        return {
+            "identifiant_stable": self.identifiant_stable,
+            "identifiant_creneau": self.identifiant_creneau,
+            "identifiant_relation": self.identifiant_relation,
+            "date_debut": self.date_debut.isoformat(),
+            "date_fin": self.date_fin.isoformat(),
+            "groupe": self.groupe,
+            "lieu": self.lieu,
+            "observations": self.observations,
+        }
+
+
+class AnnexePrevisionnelleMiseADisposition(object):
+    """Liste canonique date par date issue d'une programmation annuelle."""
+
+    def __init__(
+        self,
+        identifiant_programmation,
+        identifiant_relation,
+        date_debut,
+        date_fin,
+        occurrences=None,
+        identifiant_stable=None,
+    ):
+        self.identifiant_programmation = _GetUUID(
+            identifiant_programmation, "identifiant_programmation", obligatoire=True
+        )
+        self.identifiant_relation = _GetUUID(
+            identifiant_relation, "identifiant_relation", obligatoire=True
+        )
+        self.date_debut = _GetDate(date_debut, "date_debut")
+        self.date_fin = _GetDate(date_fin, "date_fin")
+        if identifiant_stable in (None, ""):
+            identifiant_stable = str(
+                uuid.uuid5(
+                    UUID_NAMESPACE_MAD,
+                    "%s|%s|%s"
+                    % (
+                        self.identifiant_programmation,
+                        self.date_debut.isoformat() if self.date_debut else "",
+                        self.date_fin.isoformat() if self.date_fin else "",
+                    ),
+                )
+            )
+        self.identifiant_stable = _GetUUID(
+            identifiant_stable, "identifiant_stable", obligatoire=True
+        )
+        self.occurrences = list(occurrences or ())
+        self.Validation()
+
+    def Validation(self):
+        if self.date_debut is None or self.date_fin is None:
+            raise ValueError("la période d'annexe est obligatoire")
+        if self.date_fin < self.date_debut:
+            raise ValueError("date_fin ne peut pas précéder date_debut")
+        for occurrence in self.occurrences:
+            if occurrence.identifiant_relation != self.identifiant_relation:
+                raise ValueError("une occurrence appartient à une autre relation")
+        return True
+
+    def GetOccurrencesTriees(self):
+        return sorted(
+            self.occurrences,
+            key=lambda item: (
+                item.date_debut,
+                item.date_fin,
+                item.identifiant_creneau,
+            ),
+        )
+
+    def GetLignes(self):
+        return [
+            occurrence.GetLigneAnnexe(index + 1)
+            for index, occurrence in enumerate(self.GetOccurrencesTriees())
+        ]
+
+    def DureeTotaleMinutes(self):
+        return sum(
+            occurrence.DureeMinutes()
+            for occurrence in self.GetOccurrencesTriees()
+        )
+
+    def GetTexteLignes(self):
+        lignes = []
+        for ligne in self.GetLignes():
+            morceaux = [
+                "%s %s-%s" % (
+                    ligne["date"],
+                    ligne["heure_debut"],
+                    ligne["heure_fin"],
+                )
+            ]
+            if ligne["groupe"]:
+                morceaux.append(ligne["groupe"])
+            if ligne["lieu"]:
+                morceaux.append(ligne["lieu"])
+            lignes.append(" | ".join(morceaux))
+        return "\n".join(lignes)
+
+    def GetChampsFusion(self):
+        duree_minutes = self.DureeTotaleMinutes()
+        return {
+            "{ANNEXE_ID_STABLE}": self.identifiant_stable,
+            "{ANNEXE_PROGRAMMATION_ID_STABLE}": self.identifiant_programmation,
+            "{ANNEXE_RELATION_ID_STABLE}": self.identifiant_relation,
+            "{ANNEXE_DATE_DEBUT}": _FormatDateFr(self.date_debut),
+            "{ANNEXE_DATE_FIN}": _FormatDateFr(self.date_fin),
+            "{ANNEXE_NB_SEANCES}": str(len(self.occurrences)),
+            "{ANNEXE_DUREE_TOTALE_MINUTES}": str(duree_minutes),
+            "{ANNEXE_DUREE_TOTALE}": _FormatDureeMinutes(duree_minutes),
+            "{ANNEXE_LIGNES_TEXTE}": self.GetTexteLignes(),
+        }
+
+    def GetDonnees(self):
+        return {
+            "identifiant_stable": self.identifiant_stable,
+            "identifiant_programmation": self.identifiant_programmation,
+            "identifiant_relation": self.identifiant_relation,
+            "date_debut": self.date_debut.isoformat(),
+            "date_fin": self.date_fin.isoformat(),
+            "occurrences": [
+                occurrence.GetDonnees()
+                for occurrence in self.GetOccurrencesTriees()
+            ],
+        }
+
+
+def GenererAnnexeDepuisProgrammation(
+    programmation,
+    date_debut,
+    date_fin,
+    calculateur_occurences,
+    regles_par_creneau=None,
+    regle_defaut=None,
+):
+    """Génère l'annexe via le calculateur historique injecté.
+
+    ``calculateur_occurences`` doit accepter exactement le dictionnaire utilisé
+    par ``DLG_Saisie_location.Calcule_occurences`` et retourner des dictionnaires
+    ``date_debut`` / ``date_fin``.
+    """
+    if not callable(calculateur_occurences):
+        raise TypeError("calculateur_occurences doit être appelable")
+
+    date_debut = _GetDate(date_debut, "date_debut")
+    date_fin = _GetDate(date_fin, "date_fin")
+    if date_debut is None or date_fin is None:
+        raise ValueError("la période de génération est obligatoire")
+    if date_fin < date_debut:
+        raise ValueError("date_fin ne peut pas précéder date_debut")
+
+    regles_par_creneau = regles_par_creneau or {}
+    if regle_defaut is None:
+        regle_defaut = RegleCalendrierMiseADisposition()
+
+    occurrences = []
+    deja_vues = set()
+    for creneau in programmation.GetCreneauxConserves():
+        regle = regles_par_creneau.get(creneau.identifiant_stable, regle_defaut)
+        if not isinstance(regle, RegleCalendrierMiseADisposition):
+            raise TypeError("règle calendrier invalide pour le créneau")
+        parametres = regle.GetParametresRecurrence(
+            creneau, date_debut, date_fin
+        )
+        if parametres is None:
+            continue
+
+        for donnee in calculateur_occurences(parametres) or ():
+            occurrence = OccurrenceMiseADisposition(
+                creneau=creneau,
+                date_debut=donnee["date_debut"],
+                date_fin=donnee["date_fin"],
+            )
+            signature = (
+                occurrence.identifiant_creneau,
+                occurrence.date_debut,
+                occurrence.date_fin,
+            )
+            if signature in deja_vues:
+                continue
+            deja_vues.add(signature)
+            occurrences.append(occurrence)
+
+    return AnnexePrevisionnelleMiseADisposition(
+        identifiant_programmation=programmation.identifiant_stable,
+        identifiant_relation=programmation.identifiant_relation,
+        date_debut=date_debut,
+        date_fin=date_fin,
+        occurrences=occurrences,
+    )
+
+
+def _FusionnerChamps(cible, source):
+    for cle, valeur in source.items():
+        if cle in cible and cible[cle] != valeur:
+            raise ValueError("collision de champ de fusion : %s" % cle)
+        cible[cle] = valeur
+
+
+def _ChampsContactVide(prefixe):
+    prefixe = (prefixe or "CONTACT_CONVENTION").strip().upper()
+    suffixes = (
+        "ID_STABLE",
+        "STRUCTURE_ID_STABLE",
+        "NOM",
+        "PRENOM",
+        "NOM_COMPLET",
+        "FONCTION",
+        "MAIL",
+        "TELEPHONE",
+        "ROLES",
+    )
+    return dict(("{%s_%s}" % (prefixe, suffixe), "") for suffixe in suffixes)
+
+
+class DossierDocumentaireMiseADisposition(object):
+    """Paquet documentaire canonique consommable par les modèles Noethys."""
+
+    def __init__(
+        self,
+        convention,
+        relation,
+        beneficiaire,
+        payeur,
+        programmation,
+        annexe,
+        contact_convention=None,
+    ):
+        self.convention = convention
+        self.relation = relation
+        self.beneficiaire = beneficiaire
+        self.payeur = payeur
+        self.programmation = programmation
+        self.annexe = annexe
+        self.contact_convention = contact_convention
+        self.Validation()
+
+    def Validation(self):
+        relation_id = self.relation.identifiant_stable
+        if self.convention.identifiant_relation not in (None, relation_id):
+            raise ValueError("la convention appartient à une autre relation")
+        if self.programmation.identifiant_relation != relation_id:
+            raise ValueError("la programmation appartient à une autre relation")
+        if self.annexe.identifiant_relation != relation_id:
+            raise ValueError("l'annexe appartient à une autre relation")
+        if self.annexe.identifiant_programmation != self.programmation.identifiant_stable:
+            raise ValueError("l'annexe appartient à une autre programmation")
+        if self.beneficiaire.identifiant_stable != self.relation.identifiant_beneficiaire:
+            raise ValueError("le bénéficiaire ne correspond pas à la relation")
+        if self.payeur.identifiant_stable != self.relation.identifiant_payeur:
+            raise ValueError("le payeur ne correspond pas à la relation")
+        if (
+            self.contact_convention is not None
+            and self.contact_convention.identifiant_structure
+            not in (
+                self.beneficiaire.identifiant_stable,
+                self.payeur.identifiant_stable,
+            )
+        ):
+            raise ValueError("le contact convention appartient à une autre structure")
+        return True
+
+    def GetTypeDocument(self):
+        if self.convention.EstAvenant():
+            return DOCUMENT_AVENANT
+        return DOCUMENT_CONVENTION
+
+    def GetChampsFusion(self):
+        champs = {}
+        _FusionnerChamps(champs, self.convention.GetChampsFusion())
+        _FusionnerChamps(champs, self.relation.GetChampsFusion())
+        _FusionnerChamps(champs, self.beneficiaire.GetChampsFusion("BENEFICIAIRE"))
+        _FusionnerChamps(champs, self.payeur.GetChampsFusion("PAYEUR"))
+        _FusionnerChamps(champs, self.programmation.GetChampsFusion())
+        _FusionnerChamps(champs, self.annexe.GetChampsFusion())
+
+        if self.contact_convention is None:
+            _FusionnerChamps(champs, _ChampsContactVide("CONTACT_CONVENTION"))
+        else:
+            _FusionnerChamps(
+                champs,
+                self.contact_convention.GetChampsFusion("CONTACT_CONVENTION"),
+            )
+
+        type_document = self.GetTypeDocument()
+        _FusionnerChamps(
+            champs,
+            {
+                "{DOCUMENT_TYPE}": type_document,
+                "{DOCUMENT_EST_AVENANT}": "1" if type_document == DOCUMENT_AVENANT else "0",
+            },
+        )
+        return champs
+
+    def GetPaquetModele(self):
+        return {
+            "type_document": self.GetTypeDocument(),
+            "champs": self.GetChampsFusion(),
+            "lignes_annexe": self.annexe.GetLignes(),
+        }
+
+    def Figer(self, date_generation=None, identifiant_stable=None):
+        return SnapshotDocumentContractuel(
+            type_document=self.GetTypeDocument(),
+            identifiant_convention=self.convention.identifiant_stable,
+            paquet_modele=self.GetPaquetModele(),
+            date_generation=date_generation,
+            identifiant_stable=identifiant_stable,
+        )
+
+
+class SnapshotDocumentContractuel(object):
+    """Instantané auditable d'un document validé.
+
+    Le stockage futur devra créer un nouvel instantané au lieu de modifier un
+    instantané déjà figé. Le hash permet de vérifier qu'un document officiel
+    n'a pas été recalculé silencieusement après validation.
+    """
+
+    def __init__(
+        self,
+        type_document,
+        identifiant_convention,
+        paquet_modele,
+        date_generation=None,
+        identifiant_stable=None,
+    ):
+        if type_document not in TYPES_DOCUMENT:
+            raise ValueError("type de document inconnu : %s" % type_document)
+        self.identifiant_stable = _GetUUID(
+            identifiant_stable, "identifiant_stable", obligatoire=True
+        )
+        self.identifiant_convention = _GetUUID(
+            identifiant_convention, "identifiant_convention", obligatoire=True
+        )
+        self.type_document = type_document
+        if date_generation is None:
+            date_generation = datetime.datetime.now()
+        self.date_generation = _GetDatetime(date_generation, "date_generation")
+        self.paquet_modele = copy.deepcopy(_SerialiserValeur(paquet_modele))
+        self.empreinte = self._CalculerEmpreinte()
+
+    def _CalculerEmpreinte(self):
+        contenu = json.dumps(
+            self.paquet_modele,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return hashlib.sha256(contenu).hexdigest()
+
+    def VerifierIntegrite(self):
+        return self.empreinte == self._CalculerEmpreinte()
+
+    def GetDonnees(self):
+        return {
+            "identifiant_stable": self.identifiant_stable,
+            "identifiant_convention": self.identifiant_convention,
+            "type_document": self.type_document,
+            "date_generation": self.date_generation.isoformat(),
+            "empreinte_sha256": self.empreinte,
+            "paquet_modele": copy.deepcopy(self.paquet_modele),
+        }

--- a/noethys/Utils/UTILS_Mises_a_disposition_programmation.py
+++ b/noethys/Utils/UTILS_Mises_a_disposition_programmation.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#------------------------------------------------------------------------
+# Application :    Noethys, gestion multi-activités
+# Licence :        GNU GPL
+#------------------------------------------------------------------------
+
+"""Programmation annuelle pure des mises à disposition.
+
+Ce module décrit les créneaux contractuels et leur renouvellement N-1. Il ne
+calcule volontairement aucune occurrence datée : vacances, jours fériés et
+récurrences restent du ressort du moteur calendrier historique de Noethys.
+"""
+
+import datetime
+import uuid
+
+
+STATUT_PROGRAMMATION_BROUILLON = "brouillon"
+STATUT_PROGRAMMATION_SOUMISE = "soumise"
+STATUT_PROGRAMMATION_VALIDEE = "validee"
+STATUT_PROGRAMMATION_ANNULEE = "annulee"
+
+STATUTS_PROGRAMMATION = (
+    STATUT_PROGRAMMATION_BROUILLON,
+    STATUT_PROGRAMMATION_SOUMISE,
+    STATUT_PROGRAMMATION_VALIDEE,
+    STATUT_PROGRAMMATION_ANNULEE,
+)
+
+RENOUVELLEMENT_INCHANGE = "inchange"
+RENOUVELLEMENT_MODIFIE = "modifie"
+RENOUVELLEMENT_SUPPRIME = "supprime"
+RENOUVELLEMENT_AJOUTE = "ajoute"
+
+ETATS_RENOUVELLEMENT = (
+    RENOUVELLEMENT_INCHANGE,
+    RENOUVELLEMENT_MODIFIE,
+    RENOUVELLEMENT_SUPPRIME,
+    RENOUVELLEMENT_AJOUTE,
+)
+
+JOURS_SEMAINE = (
+    "lundi",
+    "mardi",
+    "mercredi",
+    "jeudi",
+    "vendredi",
+    "samedi",
+    "dimanche",
+)
+
+
+def _GetUUID(valeur, nom_champ, obligatoire=True):
+    if valeur in (None, ""):
+        if obligatoire:
+            return str(uuid.uuid4())
+        return None
+    try:
+        return str(uuid.UUID(str(valeur)))
+    except (ValueError, AttributeError, TypeError):
+        raise ValueError("%s doit être un UUID valide" % nom_champ)
+
+
+def _GetDate(valeur, nom_champ):
+    if valeur in (None, ""):
+        return None
+    if isinstance(valeur, datetime.datetime):
+        return valeur.date()
+    if isinstance(valeur, datetime.date):
+        return valeur
+    if isinstance(valeur, str):
+        try:
+            return datetime.datetime.strptime(valeur, "%Y-%m-%d").date()
+        except ValueError:
+            pass
+    raise ValueError("%s doit être une date ou une date ISO YYYY-MM-DD" % nom_champ)
+
+
+def _GetHeure(valeur, nom_champ):
+    if isinstance(valeur, datetime.datetime):
+        return valeur.time().replace(second=0, microsecond=0)
+    if isinstance(valeur, datetime.time):
+        return valeur.replace(second=0, microsecond=0)
+    if isinstance(valeur, str):
+        for format_heure in ("%H:%M", "%Hh%M"):
+            try:
+                return datetime.datetime.strptime(valeur, format_heure).time()
+            except ValueError:
+                pass
+    raise ValueError("%s doit être une heure HH:MM" % nom_champ)
+
+
+def _FormatDate(valeur):
+    return valeur.isoformat() if valeur else None
+
+
+def _FormatHeure(valeur):
+    return valeur.strftime("%H:%M")
+
+
+class CreneauProgrammation(object):
+    """Créneau hebdomadaire canonique d'une programmation annuelle."""
+
+    CHAMPS_MODIFIABLES = (
+        "jour_semaine",
+        "heure_debut",
+        "heure_fin",
+        "date_debut",
+        "date_fin",
+        "groupe",
+        "lieu",
+        "observations",
+    )
+
+    def __init__(
+        self,
+        identifiant_relation,
+        jour_semaine,
+        heure_debut,
+        heure_fin,
+        date_debut=None,
+        date_fin=None,
+        groupe="",
+        lieu="",
+        observations="",
+        identifiant_stable=None,
+        identifiant_source=None,
+        etat_renouvellement=RENOUVELLEMENT_AJOUTE,
+    ):
+        self.identifiant_relation = _GetUUID(
+            identifiant_relation, "identifiant_relation", obligatoire=True
+        )
+        self.identifiant_stable = _GetUUID(
+            identifiant_stable, "identifiant_stable", obligatoire=True
+        )
+        self.identifiant_source = _GetUUID(
+            identifiant_source, "identifiant_source", obligatoire=False
+        )
+        try:
+            self.jour_semaine = int(jour_semaine)
+        except (TypeError, ValueError):
+            raise ValueError("jour_semaine doit être compris entre 0 et 6")
+        self.heure_debut = _GetHeure(heure_debut, "heure_debut")
+        self.heure_fin = _GetHeure(heure_fin, "heure_fin")
+        self.date_debut = _GetDate(date_debut, "date_debut")
+        self.date_fin = _GetDate(date_fin, "date_fin")
+        self.groupe = (groupe or "").strip()
+        self.lieu = (lieu or "").strip()
+        self.observations = (observations or "").strip()
+        self.etat_renouvellement = etat_renouvellement
+        self.Validation()
+
+    def Validation(self):
+        if self.jour_semaine < 0 or self.jour_semaine > 6:
+            raise ValueError("jour_semaine doit être compris entre 0 et 6")
+        if self.heure_fin <= self.heure_debut:
+            raise ValueError("heure_fin doit être postérieure à heure_debut")
+        if self.date_debut and self.date_fin and self.date_fin < self.date_debut:
+            raise ValueError("date_fin ne peut pas précéder date_debut")
+        if self.identifiant_source == self.identifiant_stable:
+            raise ValueError("un créneau ne peut pas être sa propre source")
+        if self.etat_renouvellement not in ETATS_RENOUVELLEMENT:
+            raise ValueError(
+                "état de renouvellement inconnu : %s" % self.etat_renouvellement
+            )
+        if (
+            self.etat_renouvellement
+            in (RENOUVELLEMENT_INCHANGE, RENOUVELLEMENT_MODIFIE, RENOUVELLEMENT_SUPPRIME)
+            and self.identifiant_source is None
+        ):
+            raise ValueError(
+                "un créneau renouvelé doit conserver l'identifiant de sa source"
+            )
+        return True
+
+    def DureePrevueMinutes(self):
+        debut = datetime.datetime.combine(datetime.date.today(), self.heure_debut)
+        fin = datetime.datetime.combine(datetime.date.today(), self.heure_fin)
+        return int((fin - debut).total_seconds() // 60)
+
+    def EstConserve(self):
+        return self.etat_renouvellement != RENOUVELLEMENT_SUPPRIME
+
+    def Renouveler(self, identifiant_relation, date_debut=None, date_fin=None):
+        """Copie un créneau vers une nouvelle relation en conservant sa filiation.
+
+        Les dates ne sont jamais transposées implicitement d'une année à l'autre :
+        l'appelant fournit la nouvelle période si le créneau en a une.
+        """
+        return CreneauProgrammation(
+            identifiant_relation=identifiant_relation,
+            jour_semaine=self.jour_semaine,
+            heure_debut=self.heure_debut,
+            heure_fin=self.heure_fin,
+            date_debut=date_debut,
+            date_fin=date_fin,
+            groupe=self.groupe,
+            lieu=self.lieu,
+            observations=self.observations,
+            identifiant_source=self.identifiant_stable,
+            etat_renouvellement=RENOUVELLEMENT_INCHANGE,
+        )
+
+    def AvecModifications(self, **modifications):
+        inconnus = set(modifications) - set(self.CHAMPS_MODIFIABLES)
+        if inconnus:
+            raise ValueError(
+                "champ(s) de créneau non modifiable(s) : %s"
+                % ", ".join(sorted(inconnus))
+            )
+
+        donnees = self.GetDonnees()
+        for cle, valeur in modifications.items():
+            donnees[cle] = valeur
+
+        if self.identifiant_source is not None:
+            donnees["etat_renouvellement"] = RENOUVELLEMENT_MODIFIE
+        else:
+            donnees["etat_renouvellement"] = RENOUVELLEMENT_AJOUTE
+
+        return CreneauProgrammation(**donnees)
+
+    def MarquerSupprime(self):
+        if self.identifiant_source is None:
+            raise ValueError(
+                "un créneau ajouté dans la saison doit être retiré, pas marqué supprimé"
+            )
+        donnees = self.GetDonnees()
+        donnees["etat_renouvellement"] = RENOUVELLEMENT_SUPPRIME
+        return CreneauProgrammation(**donnees)
+
+    def GetChampsFusion(self, prefixe="CRENEAU"):
+        prefixe = (prefixe or "CRENEAU").strip().upper()
+        return {
+            "{%s_ID_STABLE}" % prefixe: self.identifiant_stable,
+            "{%s_SOURCE_ID_STABLE}" % prefixe: self.identifiant_source or "",
+            "{%s_RELATION_ID_STABLE}" % prefixe: self.identifiant_relation,
+            "{%s_JOUR}" % prefixe: JOURS_SEMAINE[self.jour_semaine],
+            "{%s_JOUR_INDEX}" % prefixe: str(self.jour_semaine),
+            "{%s_HEURE_DEBUT}" % prefixe: _FormatHeure(self.heure_debut),
+            "{%s_HEURE_FIN}" % prefixe: _FormatHeure(self.heure_fin),
+            "{%s_DUREE_MINUTES}" % prefixe: str(self.DureePrevueMinutes()),
+            "{%s_DATE_DEBUT}" % prefixe: _FormatDate(self.date_debut) or "",
+            "{%s_DATE_FIN}" % prefixe: _FormatDate(self.date_fin) or "",
+            "{%s_GROUPE}" % prefixe: self.groupe,
+            "{%s_LIEU}" % prefixe: self.lieu,
+            "{%s_OBSERVATIONS}" % prefixe: self.observations,
+            "{%s_RENOUVELLEMENT}" % prefixe: self.etat_renouvellement,
+        }
+
+    def GetDonnees(self):
+        return {
+            "identifiant_relation": self.identifiant_relation,
+            "jour_semaine": self.jour_semaine,
+            "heure_debut": _FormatHeure(self.heure_debut),
+            "heure_fin": _FormatHeure(self.heure_fin),
+            "date_debut": _FormatDate(self.date_debut),
+            "date_fin": _FormatDate(self.date_fin),
+            "groupe": self.groupe,
+            "lieu": self.lieu,
+            "observations": self.observations,
+            "identifiant_stable": self.identifiant_stable,
+            "identifiant_source": self.identifiant_source,
+            "etat_renouvellement": self.etat_renouvellement,
+        }
+
+
+class ProgrammationAnnuelle(object):
+    """Ensemble cohérent de créneaux rattachés à une relation contractuelle."""
+
+    def __init__(
+        self,
+        identifiant_relation,
+        saison,
+        statut=STATUT_PROGRAMMATION_BROUILLON,
+        creneaux=None,
+        identifiant_stable=None,
+        identifiant_source=None,
+    ):
+        self.identifiant_relation = _GetUUID(
+            identifiant_relation, "identifiant_relation", obligatoire=True
+        )
+        self.identifiant_stable = _GetUUID(
+            identifiant_stable, "identifiant_stable", obligatoire=True
+        )
+        self.identifiant_source = _GetUUID(
+            identifiant_source, "identifiant_source", obligatoire=False
+        )
+        self.saison = (saison or "").strip()
+        self.statut = statut
+        self.creneaux = []
+        self.Validation()
+        for creneau in creneaux or ():
+            self.AjouterCreneau(creneau)
+
+    def Validation(self):
+        if not self.saison:
+            raise ValueError("saison obligatoire")
+        if self.statut not in STATUTS_PROGRAMMATION:
+            raise ValueError("statut de programmation inconnu : %s" % self.statut)
+        if self.identifiant_source == self.identifiant_stable:
+            raise ValueError("une programmation ne peut pas être sa propre source")
+        return True
+
+    def AjouterCreneau(self, creneau):
+        if not isinstance(creneau, CreneauProgrammation):
+            raise TypeError("creneau doit être un CreneauProgrammation")
+        if creneau.identifiant_relation != self.identifiant_relation:
+            raise ValueError("le créneau appartient à une autre relation")
+        if any(
+            existant.identifiant_stable == creneau.identifiant_stable
+            for existant in self.creneaux
+        ):
+            raise ValueError("identifiant de créneau déjà présent")
+        self.creneaux.append(creneau)
+        return creneau
+
+    def GetCreneau(self, identifiant_stable):
+        identifiant_stable = _GetUUID(
+            identifiant_stable, "identifiant_stable", obligatoire=True
+        )
+        for creneau in self.creneaux:
+            if creneau.identifiant_stable == identifiant_stable:
+                return creneau
+        raise KeyError(identifiant_stable)
+
+    def ModifierCreneau(self, identifiant_stable, **modifications):
+        creneau = self.GetCreneau(identifiant_stable)
+        nouveau = creneau.AvecModifications(**modifications)
+        index = self.creneaux.index(creneau)
+        self.creneaux[index] = nouveau
+        return nouveau
+
+    def SupprimerCreneau(self, identifiant_stable):
+        creneau = self.GetCreneau(identifiant_stable)
+        index = self.creneaux.index(creneau)
+        if creneau.identifiant_source is None:
+            del self.creneaux[index]
+            return None
+        supprime = creneau.MarquerSupprime()
+        self.creneaux[index] = supprime
+        return supprime
+
+    def GetCreneauxConserves(self):
+        return [creneau for creneau in self.creneaux if creneau.EstConserve()]
+
+    def GetSyntheseRenouvellement(self):
+        synthese = dict((etat, 0) for etat in ETATS_RENOUVELLEMENT)
+        for creneau in self.creneaux:
+            synthese[creneau.etat_renouvellement] += 1
+        return synthese
+
+    def Renouveler(
+        self,
+        identifiant_relation,
+        saison,
+        date_debut=None,
+        date_fin=None,
+    ):
+        """Crée une nouvelle programmation depuis les lignes conservées de N-1."""
+        nouvelle = ProgrammationAnnuelle(
+            identifiant_relation=identifiant_relation,
+            saison=saison,
+            statut=STATUT_PROGRAMMATION_BROUILLON,
+            identifiant_source=self.identifiant_stable,
+        )
+        for creneau in self.GetCreneauxConserves():
+            nouvelle.AjouterCreneau(
+                creneau.Renouveler(
+                    identifiant_relation=identifiant_relation,
+                    date_debut=date_debut,
+                    date_fin=date_fin,
+                )
+            )
+        return nouvelle
+
+    def GetChampsFusion(self):
+        synthese = self.GetSyntheseRenouvellement()
+        return {
+            "{PROGRAMMATION_ID_STABLE}": self.identifiant_stable,
+            "{PROGRAMMATION_SOURCE_ID_STABLE}": self.identifiant_source or "",
+            "{PROGRAMMATION_RELATION_ID_STABLE}": self.identifiant_relation,
+            "{PROGRAMMATION_SAISON}": self.saison,
+            "{PROGRAMMATION_STATUT}": self.statut,
+            "{PROGRAMMATION_NB_CRENEAUX}": str(len(self.GetCreneauxConserves())),
+            "{PROGRAMMATION_NB_INCHANGES}": str(synthese[RENOUVELLEMENT_INCHANGE]),
+            "{PROGRAMMATION_NB_MODIFIES}": str(synthese[RENOUVELLEMENT_MODIFIE]),
+            "{PROGRAMMATION_NB_SUPPRIMES}": str(synthese[RENOUVELLEMENT_SUPPRIME]),
+            "{PROGRAMMATION_NB_AJOUTES}": str(synthese[RENOUVELLEMENT_AJOUTE]),
+        }
+
+    def GetDonnees(self):
+        return {
+            "identifiant_relation": self.identifiant_relation,
+            "saison": self.saison,
+            "statut": self.statut,
+            "identifiant_stable": self.identifiant_stable,
+            "identifiant_source": self.identifiant_source,
+            "creneaux": [creneau.GetDonnees() for creneau in self.creneaux],
+        }

--- a/tests/test_noe_062_documents.py
+++ b/tests/test_noe_062_documents.py
@@ -1,0 +1,385 @@
+# -*- coding: utf-8 -*-
+import datetime
+import importlib.util
+import unittest
+import uuid
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+UTILS = ROOT / "noethys" / "Utils"
+
+
+def _load(name, filename):
+    spec = importlib.util.spec_from_file_location(name, str(UTILS / filename))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+mad = _load("UTILS_Mises_a_disposition", "UTILS_Mises_a_disposition.py")
+prog = _load(
+    "UTILS_Mises_a_disposition_programmation",
+    "UTILS_Mises_a_disposition_programmation.py",
+)
+docs = _load(
+    "UTILS_Mises_a_disposition_documents",
+    "UTILS_Mises_a_disposition_documents.py",
+)
+
+
+class Noe062DocumentTests(unittest.TestCase):
+    def _relation(self):
+        beneficiaire = mad.StructureMiseADisposition(
+            "Club Test",
+            type_structure=mad.TYPE_ASSOCIATION,
+            rue="1 rue du Stade",
+            cp="35130",
+            ville="La Guerche-de-Bretagne",
+        )
+        payeur = mad.StructureMiseADisposition(
+            "Mairie Test",
+            type_structure=mad.TYPE_COLLECTIVITE,
+            cp="35130",
+            ville="La Guerche-de-Bretagne",
+        )
+        relation = mad.RelationContractuelleMiseADisposition(
+            identifiant_beneficiaire=beneficiaire.identifiant_stable,
+            identifiant_payeur=payeur.identifiant_stable,
+            saison="2026-2027",
+            activite="Gymnastique",
+            groupe="Loisirs",
+            tarif_unitaire="44.00",
+            unite_tarif=mad.UNITE_HEURE,
+            regle_adhesion=mad.ADHESION_NON_REQUISE,
+            mode_facturation=mad.FACTURATION_TRIMESTRIELLE,
+        )
+        return beneficiaire, payeur, relation
+
+    def _programmation(self, relation):
+        programmation = prog.ProgrammationAnnuelle(
+            identifiant_relation=relation.identifiant_stable,
+            saison="2026-2027",
+            statut=prog.STATUT_PROGRAMMATION_VALIDEE,
+        )
+        creneau = prog.CreneauProgrammation(
+            identifiant_relation=relation.identifiant_stable,
+            jour_semaine=2,
+            heure_debut="10:30",
+            heure_fin="11:15",
+            groupe="Groupe 1",
+            lieu="Salle de sports",
+        )
+        programmation.AjouterCreneau(creneau)
+        return programmation, creneau
+
+    def test_regle_calendrier_produit_le_contrat_historique_exact(self):
+        _, _, relation = self._relation()
+        _, creneau = self._programmation(relation)
+        regle = docs.RegleCalendrierMiseADisposition(
+            appliquer_scolaire=True,
+            appliquer_vacances=False,
+            inclure_feries=False,
+            frequence=docs.FREQUENCE_TOUTES_LES_SEMAINES,
+        )
+        donnees = regle.GetParametresRecurrence(
+            creneau, "2026-09-01", "2027-06-30"
+        )
+        self.assertEqual(
+            set(donnees),
+            {
+                "date_debut",
+                "date_fin",
+                "heure_debut",
+                "heure_fin",
+                "jours_vacances",
+                "jours_scolaires",
+                "semaines",
+                "feries",
+            },
+        )
+        self.assertEqual(donnees["jours_scolaires"], [2])
+        self.assertEqual(donnees["jours_vacances"], [])
+        self.assertEqual(donnees["heure_debut"], "10:30")
+        self.assertEqual(donnees["heure_fin"], "11:15")
+        self.assertFalse(donnees["feries"])
+
+    def test_periode_du_creneau_restreint_la_generation(self):
+        _, _, relation = self._relation()
+        programmation = prog.ProgrammationAnnuelle(
+            identifiant_relation=relation.identifiant_stable,
+            saison="2026-2027",
+        )
+        creneau = prog.CreneauProgrammation(
+            identifiant_relation=relation.identifiant_stable,
+            jour_semaine=3,
+            heure_debut="16:55",
+            heure_fin="17:40",
+            date_debut="2026-11-01",
+            date_fin="2027-03-31",
+        )
+        programmation.AjouterCreneau(creneau)
+        donnees = docs.RegleCalendrierMiseADisposition().GetParametresRecurrence(
+            creneau, "2026-09-01", "2027-06-30"
+        )
+        self.assertEqual(donnees["date_debut"], datetime.date(2026, 11, 1))
+        self.assertEqual(donnees["date_fin"], datetime.date(2027, 3, 31))
+
+    def test_regle_vide_et_frequence_inconnue_sont_refusees(self):
+        with self.assertRaises(ValueError):
+            docs.RegleCalendrierMiseADisposition(
+                appliquer_scolaire=False,
+                appliquer_vacances=False,
+            )
+        with self.assertRaises(ValueError):
+            docs.RegleCalendrierMiseADisposition(frequence=99)
+
+    def test_annexe_appelle_le_calculateur_historique_sans_recalculer_le_calendrier(self):
+        _, _, relation = self._relation()
+        programmation, _ = self._programmation(relation)
+        appels = []
+
+        def calculateur(parametres):
+            appels.append(dict(parametres))
+            return [
+                {
+                    "date_debut": datetime.datetime(2026, 9, 2, 10, 30),
+                    "date_fin": datetime.datetime(2026, 9, 2, 11, 15),
+                },
+                {
+                    "date_debut": datetime.datetime(2026, 9, 9, 10, 30),
+                    "date_fin": datetime.datetime(2026, 9, 9, 11, 15),
+                },
+            ]
+
+        annexe = docs.GenererAnnexeDepuisProgrammation(
+            programmation,
+            "2026-09-01",
+            "2026-09-30",
+            calculateur_occurences=calculateur,
+        )
+        self.assertEqual(len(appels), 1)
+        self.assertEqual(len(annexe.occurrences), 2)
+        self.assertEqual(annexe.GetLignes()[0]["jour"], "mercredi")
+        self.assertEqual(annexe.GetLignes()[0]["duree"], "0h45")
+
+    def test_occurrences_et_annexe_ont_des_identifiants_deterministes(self):
+        _, _, relation = self._relation()
+        programmation, _ = self._programmation(relation)
+
+        def calculateur(parametres):
+            return [
+                {
+                    "date_debut": datetime.datetime(2026, 9, 2, 10, 30),
+                    "date_fin": datetime.datetime(2026, 9, 2, 11, 15),
+                }
+            ]
+
+        annexe1 = docs.GenererAnnexeDepuisProgrammation(
+            programmation, "2026-09-01", "2026-09-30", calculateur
+        )
+        annexe2 = docs.GenererAnnexeDepuisProgrammation(
+            programmation, "2026-09-01", "2026-09-30", calculateur
+        )
+        self.assertEqual(annexe1.identifiant_stable, annexe2.identifiant_stable)
+        self.assertEqual(
+            annexe1.occurrences[0].identifiant_stable,
+            annexe2.occurrences[0].identifiant_stable,
+        )
+
+    def test_annexe_trie_les_dates_et_totalise_les_heures(self):
+        _, _, relation = self._relation()
+        programmation, _ = self._programmation(relation)
+
+        def calculateur(parametres):
+            return [
+                {
+                    "date_debut": datetime.datetime(2026, 9, 9, 10, 30),
+                    "date_fin": datetime.datetime(2026, 9, 9, 11, 15),
+                },
+                {
+                    "date_debut": datetime.datetime(2026, 9, 2, 10, 30),
+                    "date_fin": datetime.datetime(2026, 9, 2, 11, 15),
+                },
+            ]
+
+        annexe = docs.GenererAnnexeDepuisProgrammation(
+            programmation, "2026-09-01", "2026-09-30", calculateur
+        )
+        lignes = annexe.GetLignes()
+        self.assertEqual(lignes[0]["date"], "02/09/2026")
+        self.assertEqual(lignes[1]["date"], "09/09/2026")
+        self.assertEqual(annexe.DureeTotaleMinutes(), 90)
+        self.assertEqual(
+            annexe.GetChampsFusion()["{ANNEXE_DUREE_TOTALE}"], "1h30"
+        )
+
+    def test_occurrences_dupliquees_du_moteur_ne_doublent_pas_annexe(self):
+        _, _, relation = self._relation()
+        programmation, _ = self._programmation(relation)
+        occurrence = {
+            "date_debut": datetime.datetime(2026, 9, 2, 10, 30),
+            "date_fin": datetime.datetime(2026, 9, 2, 11, 15),
+        }
+        annexe = docs.GenererAnnexeDepuisProgrammation(
+            programmation,
+            "2026-09-01",
+            "2026-09-30",
+            lambda parametres: [occurrence, dict(occurrence)],
+        )
+        self.assertEqual(len(annexe.occurrences), 1)
+
+    def test_dossier_fusionne_convention_relation_tiers_contact_programmation_annexe(self):
+        beneficiaire, payeur, relation = self._relation()
+        programmation, _ = self._programmation(relation)
+        convention = mad.ConventionMiseADisposition(
+            "2026-09-01",
+            "2027-06-30",
+            reference="MAD-2026-001",
+            statut=mad.STATUT_VALIDEE,
+            mode_facturation=mad.FACTURATION_TRIMESTRIELLE,
+            identifiant_relation=relation.identifiant_stable,
+        )
+        contact = mad.ContactStructure(
+            identifiant_structure=beneficiaire.identifiant_stable,
+            nom="Martin",
+            prenom="Alice",
+            roles=[mad.ROLE_CONTACT_CONVENTION],
+            fonction="Présidente",
+            mail="alice@example.test",
+        )
+        annexe = docs.GenererAnnexeDepuisProgrammation(
+            programmation,
+            "2026-09-01",
+            "2026-09-30",
+            lambda parametres: [],
+        )
+        dossier = docs.DossierDocumentaireMiseADisposition(
+            convention,
+            relation,
+            beneficiaire,
+            payeur,
+            programmation,
+            annexe,
+            contact_convention=contact,
+        )
+        champs = dossier.GetChampsFusion()
+        self.assertEqual(champs["{CONVENTION_REFERENCE}"], "MAD-2026-001")
+        self.assertEqual(champs["{BENEFICIAIRE_NOM}"], "Club Test")
+        self.assertEqual(champs["{PAYEUR_NOM}"], "Mairie Test")
+        self.assertEqual(champs["{CONTACT_CONVENTION_NOM_COMPLET}"], "Alice Martin")
+        self.assertEqual(champs["{DOCUMENT_TYPE}"], docs.DOCUMENT_CONVENTION)
+
+    def test_absence_contact_produit_des_champs_vides_stables(self):
+        beneficiaire, payeur, relation = self._relation()
+        programmation, _ = self._programmation(relation)
+        convention = mad.ConventionMiseADisposition(
+            "2026-09-01",
+            identifiant_relation=relation.identifiant_stable,
+        )
+        annexe = docs.GenererAnnexeDepuisProgrammation(
+            programmation,
+            "2026-09-01",
+            "2026-09-30",
+            lambda parametres: [],
+        )
+        dossier = docs.DossierDocumentaireMiseADisposition(
+            convention,
+            relation,
+            beneficiaire,
+            payeur,
+            programmation,
+            annexe,
+        )
+        champs = dossier.GetChampsFusion()
+        self.assertIn("{CONTACT_CONVENTION_NOM}", champs)
+        self.assertEqual(champs["{CONTACT_CONVENTION_NOM}"], "")
+
+    def test_avenant_est_identifie_sans_ecraser_la_convention_parent(self):
+        beneficiaire, payeur, relation = self._relation()
+        programmation, _ = self._programmation(relation)
+        parent = mad.ConventionMiseADisposition(
+            "2026-09-01",
+            identifiant_relation=relation.identifiant_stable,
+        )
+        avenant = mad.ConventionMiseADisposition(
+            "2027-01-01",
+            version=2,
+            identifiant_parent=parent.identifiant_stable,
+            identifiant_relation=relation.identifiant_stable,
+        )
+        annexe = docs.GenererAnnexeDepuisProgrammation(
+            programmation,
+            "2027-01-01",
+            "2027-06-30",
+            lambda parametres: [],
+        )
+        dossier = docs.DossierDocumentaireMiseADisposition(
+            avenant,
+            relation,
+            beneficiaire,
+            payeur,
+            programmation,
+            annexe,
+        )
+        self.assertEqual(dossier.GetTypeDocument(), docs.DOCUMENT_AVENANT)
+        self.assertEqual(
+            dossier.GetChampsFusion()["{CONVENTION_PARENT_ID_STABLE}"],
+            parent.identifiant_stable,
+        )
+
+    def test_snapshot_officiel_est_hashable_et_detecte_une_mutation(self):
+        beneficiaire, payeur, relation = self._relation()
+        programmation, _ = self._programmation(relation)
+        convention = mad.ConventionMiseADisposition(
+            "2026-09-01",
+            identifiant_relation=relation.identifiant_stable,
+        )
+        annexe = docs.GenererAnnexeDepuisProgrammation(
+            programmation,
+            "2026-09-01",
+            "2026-09-30",
+            lambda parametres: [],
+        )
+        dossier = docs.DossierDocumentaireMiseADisposition(
+            convention,
+            relation,
+            beneficiaire,
+            payeur,
+            programmation,
+            annexe,
+        )
+        snapshot = dossier.Figer(
+            date_generation=datetime.datetime(2026, 8, 21, 0, 30)
+        )
+        self.assertTrue(snapshot.VerifierIntegrite())
+        snapshot.paquet_modele["champs"]["{BENEFICIAIRE_NOM}"] = "Altéré"
+        self.assertFalse(snapshot.VerifierIntegrite())
+
+    def test_dossier_refuse_les_relations_incoherentes(self):
+        beneficiaire, payeur, relation = self._relation()
+        programmation, _ = self._programmation(relation)
+        autre_relation = str(uuid.uuid4())
+        convention = mad.ConventionMiseADisposition(
+            "2026-09-01",
+            identifiant_relation=autre_relation,
+        )
+        annexe = docs.GenererAnnexeDepuisProgrammation(
+            programmation,
+            "2026-09-01",
+            "2026-09-30",
+            lambda parametres: [],
+        )
+        with self.assertRaises(ValueError):
+            docs.DossierDocumentaireMiseADisposition(
+                convention,
+                relation,
+                beneficiaire,
+                payeur,
+                programmation,
+                annexe,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_noe_062_mises_a_disposition.py
+++ b/tests/test_noe_062_mises_a_disposition.py
@@ -73,6 +73,7 @@ class ConventionMiseADispositionTests(unittest.TestCase):
 
     def test_champs_fusion_sont_stables_et_documentaires(self):
         parent = str(uuid.uuid4())
+        relation = str(uuid.uuid4())
         convention = mad.ConventionMiseADisposition(
             "2026-09-01",
             "2027-06-30",
@@ -81,6 +82,7 @@ class ConventionMiseADispositionTests(unittest.TestCase):
             mode_facturation=mad.FACTURATION_TRIMESTRIELLE,
             version=2,
             identifiant_parent=parent,
+            identifiant_relation=relation,
         )
         champs = convention.GetChampsFusion()
         self.assertEqual(champs["{CONVENTION_REFERENCE}"], "MAD-2026-001")
@@ -89,6 +91,7 @@ class ConventionMiseADispositionTests(unittest.TestCase):
         self.assertEqual(champs["{CONVENTION_DATE_FIN}"], "30/06/2027")
         self.assertEqual(champs["{CONVENTION_MODE_FACTURATION}"], "trimestrielle")
         self.assertEqual(champs["{CONVENTION_PARENT_ID_STABLE}"], parent)
+        self.assertEqual(champs["{CONVENTION_RELATION_ID_STABLE}"], relation)
         self.assertEqual(champs["{CONVENTION_EST_AVENANT}"], "1")
 
     def test_donnees_sont_serialisables_sans_objets_date(self):
@@ -96,6 +99,135 @@ class ConventionMiseADispositionTests(unittest.TestCase):
         donnees = convention.GetDonnees()
         self.assertEqual(donnees["date_debut"], "2026-09-01")
         self.assertEqual(donnees["date_fin"], "2027-06-30")
+
+
+class StructureMiseADispositionTests(unittest.TestCase):
+    def test_identifiants_administratifs_sont_facultatifs(self):
+        structure = mad.StructureMiseADisposition(
+            "Les Jongleurs Gym",
+            type_structure=mad.TYPE_ASSOCIATION,
+        )
+        self.assertEqual(structure.siret, "")
+        self.assertEqual(structure.rna, "")
+        self.assertEqual(structure.nom, "Les Jongleurs Gym")
+
+    def test_type_inconnu_et_nom_vide_sont_refuses(self):
+        with self.assertRaises(ValueError):
+            mad.StructureMiseADisposition("", mad.TYPE_ASSOCIATION)
+        with self.assertRaises(ValueError):
+            mad.StructureMiseADisposition("Test", "cabane")
+
+    def test_structure_operationnelle_et_payeur_restent_distincts(self):
+        ecole = mad.StructureMiseADisposition("École Saint-Test", mad.TYPE_ECOLE)
+        mairie = mad.StructureMiseADisposition("Mairie de Test", mad.TYPE_COLLECTIVITE)
+        relation = mad.RelationContractuelleMiseADisposition(
+            ecole.identifiant_stable,
+            "2026-2027",
+            "EPS",
+            identifiant_payeur=mairie.identifiant_stable,
+            tarif_unitaire="23.00",
+        )
+        self.assertTrue(relation.EstPayeurDistinct())
+        self.assertEqual(relation.identifiant_beneficiaire, ecole.identifiant_stable)
+        self.assertEqual(relation.identifiant_payeur, mairie.identifiant_stable)
+
+
+class ContactStructureTests(unittest.TestCase):
+    def test_contact_peut_cumuler_plusieurs_roles_sans_doublon(self):
+        structure = mad.StructureMiseADisposition("Dynamic Gym")
+        contact = mad.ContactStructure(
+            structure.identifiant_stable,
+            "Martin",
+            "Camille",
+            roles=[
+                mad.ROLE_CONTACT_PLANNING,
+                mad.ROLE_CONTACT_CONVENTION,
+                mad.ROLE_CONTACT_PLANNING,
+            ],
+        )
+        self.assertEqual(
+            contact.roles,
+            (mad.ROLE_CONTACT_PLANNING, mad.ROLE_CONTACT_CONVENTION),
+        )
+        self.assertTrue(contact.ALeRole(mad.ROLE_CONTACT_PLANNING))
+
+    def test_role_inconnu_est_refuse(self):
+        structure = mad.StructureMiseADisposition("Dynamic Gym")
+        with self.assertRaises(ValueError):
+            mad.ContactStructure(
+                structure.identifiant_stable,
+                "Martin",
+                roles=["roi_du_planning"],
+            )
+
+
+class RelationContractuelleTests(unittest.TestCase):
+    def test_adhesion_est_portee_par_relation_pas_par_type_structure(self):
+        mairie = mad.StructureMiseADisposition(
+            "Mairie partenaire ALSH",
+            mad.TYPE_COLLECTIVITE,
+        )
+        financement = mad.RelationContractuelleMiseADisposition(
+            mairie.identifiant_stable,
+            "2026-2027",
+            "Partenariat ALSH",
+            regle_adhesion=mad.ADHESION_NON_APPLICABLE,
+        )
+        mise_a_disposition = mad.RelationContractuelleMiseADisposition(
+            mairie.identifiant_stable,
+            "2026-2027",
+            "Intervention sportive",
+            regle_adhesion=mad.ADHESION_REQUISE,
+            tarif_unitaire="44",
+        )
+        self.assertEqual(financement.regle_adhesion, mad.ADHESION_NON_APPLICABLE)
+        self.assertEqual(mise_a_disposition.regle_adhesion, mad.ADHESION_REQUISE)
+
+    def test_tarif_decimal_est_serialise_sans_float(self):
+        structure = mad.StructureMiseADisposition("Atout Sport")
+        relation = mad.RelationContractuelleMiseADisposition(
+            structure.identifiant_stable,
+            "2026-2027",
+            "Fitness",
+            tarif_unitaire="33.50",
+            unite_tarif=mad.UNITE_HEURE,
+            mode_facturation=mad.FACTURATION_TRIMESTRIELLE,
+        )
+        self.assertEqual(relation.GetDonnees()["tarif_unitaire"], "33.50")
+        self.assertEqual(
+            relation.GetChampsFusion()["{RELATION_TARIF_UNITAIRE}"],
+            "33.50",
+        )
+
+    def test_tarif_negatif_et_regles_inconnues_sont_refuses(self):
+        structure = mad.StructureMiseADisposition("Atout Sport")
+        with self.assertRaises(ValueError):
+            mad.RelationContractuelleMiseADisposition(
+                structure.identifiant_stable,
+                "2026-2027",
+                "Fitness",
+                tarif_unitaire="-1",
+            )
+        with self.assertRaises(ValueError):
+            mad.RelationContractuelleMiseADisposition(
+                structure.identifiant_stable,
+                "2026-2027",
+                "Fitness",
+                regle_adhesion="toujours",
+            )
+
+    def test_payeur_par_defaut_est_le_beneficiaire(self):
+        structure = mad.StructureMiseADisposition("Cap Loisirs")
+        relation = mad.RelationContractuelleMiseADisposition(
+            structure.identifiant_stable,
+            "2026-2027",
+            "Gym",
+        )
+        self.assertFalse(relation.EstPayeurDistinct())
+        self.assertEqual(
+            relation.identifiant_payeur,
+            structure.identifiant_stable,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_noe_062_mises_a_disposition.py
+++ b/tests/test_noe_062_mises_a_disposition.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+import datetime
+import importlib.util
+import unittest
+import uuid
+from pathlib import Path
+
+
+MODULE = (
+    Path(__file__).resolve().parents[1]
+    / "noethys"
+    / "Utils"
+    / "UTILS_Mises_a_disposition.py"
+)
+spec = importlib.util.spec_from_file_location("UTILS_Mises_a_disposition", str(MODULE))
+mad = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mad)
+
+
+class ConventionMiseADispositionTests(unittest.TestCase):
+    def test_creation_genere_un_identifiant_stable_uuid(self):
+        convention = mad.ConventionMiseADisposition("2026-09-01", "2027-06-30")
+        self.assertEqual(str(uuid.UUID(convention.identifiant_stable)), convention.identifiant_stable)
+        self.assertFalse(convention.EstAvenant())
+
+    def test_dates_acceptent_date_datetime_et_iso(self):
+        convention = mad.ConventionMiseADisposition(
+            datetime.datetime(2026, 9, 1, 10, 30),
+            datetime.date(2027, 6, 30),
+        )
+        self.assertEqual(convention.date_debut, datetime.date(2026, 9, 1))
+        self.assertEqual(convention.date_fin, datetime.date(2027, 6, 30))
+
+    def test_periode_inversee_est_refusee(self):
+        with self.assertRaises(ValueError):
+            mad.ConventionMiseADisposition("2027-06-30", "2026-09-01")
+
+    def test_statut_et_facturation_sont_controles(self):
+        with self.assertRaises(ValueError):
+            mad.ConventionMiseADisposition("2026-09-01", statut="inconnu")
+        with self.assertRaises(ValueError):
+            mad.ConventionMiseADisposition(
+                "2026-09-01", mode_facturation="au_pif"
+            )
+
+    def test_avenant_garde_un_parent_stable_et_exige_une_version(self):
+        parent = mad.ConventionMiseADisposition("2026-09-01")
+        avenant = mad.ConventionMiseADisposition(
+            "2027-01-01",
+            version=2,
+            identifiant_parent=parent.identifiant_stable,
+        )
+        self.assertTrue(avenant.EstAvenant())
+        self.assertEqual(avenant.identifiant_parent, parent.identifiant_stable)
+
+        with self.assertRaises(ValueError):
+            mad.ConventionMiseADisposition(
+                "2027-01-01",
+                version=1,
+                identifiant_parent=parent.identifiant_stable,
+            )
+
+    def test_activation_est_fondee_sur_la_periode_pas_sur_le_statut(self):
+        convention = mad.ConventionMiseADisposition(
+            "2026-09-01",
+            "2027-06-30",
+            statut=mad.STATUT_BROUILLON,
+        )
+        self.assertFalse(convention.EstActiveA("2026-08-31"))
+        self.assertTrue(convention.EstActiveA("2026-09-01"))
+        self.assertTrue(convention.EstActiveA("2027-06-30"))
+        self.assertFalse(convention.EstActiveA("2027-07-01"))
+
+    def test_champs_fusion_sont_stables_et_documentaires(self):
+        parent = str(uuid.uuid4())
+        convention = mad.ConventionMiseADisposition(
+            "2026-09-01",
+            "2027-06-30",
+            reference="MAD-2026-001",
+            statut=mad.STATUT_VALIDEE,
+            mode_facturation=mad.FACTURATION_TRIMESTRIELLE,
+            version=2,
+            identifiant_parent=parent,
+        )
+        champs = convention.GetChampsFusion()
+        self.assertEqual(champs["{CONVENTION_REFERENCE}"], "MAD-2026-001")
+        self.assertEqual(champs["{CONVENTION_VERSION}"], "2")
+        self.assertEqual(champs["{CONVENTION_DATE_DEBUT}"], "01/09/2026")
+        self.assertEqual(champs["{CONVENTION_DATE_FIN}"], "30/06/2027")
+        self.assertEqual(champs["{CONVENTION_MODE_FACTURATION}"], "trimestrielle")
+        self.assertEqual(champs["{CONVENTION_PARENT_ID_STABLE}"], parent)
+        self.assertEqual(champs["{CONVENTION_EST_AVENANT}"], "1")
+
+    def test_donnees_sont_serialisables_sans_objets_date(self):
+        convention = mad.ConventionMiseADisposition("2026-09-01", "2027-06-30")
+        donnees = convention.GetDonnees()
+        self.assertEqual(donnees["date_debut"], "2026-09-01")
+        self.assertEqual(donnees["date_fin"], "2027-06-30")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_noe_062_programmation.py
+++ b/tests/test_noe_062_programmation.py
@@ -1,0 +1,198 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import unittest
+import uuid
+from pathlib import Path
+
+
+MODULE = (
+    Path(__file__).resolve().parents[1]
+    / "noethys"
+    / "Utils"
+    / "UTILS_Mises_a_disposition_programmation.py"
+)
+spec = importlib.util.spec_from_file_location(
+    "UTILS_Mises_a_disposition_programmation", str(MODULE)
+)
+prog = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(prog)
+
+
+class CreneauProgrammationTests(unittest.TestCase):
+    def setUp(self):
+        self.relation = str(uuid.uuid4())
+
+    def test_creneau_valide_jour_horaires_et_duree(self):
+        creneau = prog.CreneauProgrammation(
+            self.relation,
+            2,
+            "10:30",
+            "11:15",
+            groupe="Groupe 1",
+        )
+        self.assertEqual(creneau.DureePrevueMinutes(), 45)
+        self.assertEqual(creneau.GetChampsFusion()["{CRENEAU_JOUR}"], "mercredi")
+        self.assertEqual(creneau.GetChampsFusion()["{CRENEAU_HEURE_DEBUT}"], "10:30")
+
+    def test_jour_et_horaires_invalides_sont_refuses(self):
+        with self.assertRaises(ValueError):
+            prog.CreneauProgrammation(self.relation, 7, "10:00", "11:00")
+        with self.assertRaises(ValueError):
+            prog.CreneauProgrammation(self.relation, 2, "11:00", "10:00")
+        with self.assertRaises(ValueError):
+            prog.CreneauProgrammation(self.relation, 2, "10:00", "10:00")
+
+    def test_renouvellement_cree_une_nouvelle_identite_et_garde_la_source(self):
+        ancien = prog.CreneauProgrammation(
+            self.relation,
+            3,
+            "16:55",
+            "17:40",
+            groupe="Éveils Gym",
+            lieu="Salle des sports",
+        )
+        nouvelle_relation = str(uuid.uuid4())
+        nouveau = ancien.Renouveler(
+            nouvelle_relation,
+            date_debut="2026-09-01",
+            date_fin="2027-06-30",
+        )
+        self.assertNotEqual(nouveau.identifiant_stable, ancien.identifiant_stable)
+        self.assertEqual(nouveau.identifiant_source, ancien.identifiant_stable)
+        self.assertEqual(nouveau.identifiant_relation, nouvelle_relation)
+        self.assertEqual(nouveau.etat_renouvellement, prog.RENOUVELLEMENT_INCHANGE)
+        self.assertEqual(nouveau.groupe, "Éveils Gym")
+
+    def test_dates_anciennes_ne_sont_pas_reprises_implicitement(self):
+        ancien = prog.CreneauProgrammation(
+            self.relation,
+            1,
+            "18:00",
+            "19:00",
+            date_debut="2025-09-01",
+            date_fin="2026-06-30",
+        )
+        nouveau = ancien.Renouveler(str(uuid.uuid4()))
+        self.assertIsNone(nouveau.date_debut)
+        self.assertIsNone(nouveau.date_fin)
+
+    def test_modification_d_un_creneau_renouvele_est_tracee(self):
+        ancien = prog.CreneauProgrammation(self.relation, 0, "14:00", "15:00")
+        nouveau = ancien.Renouveler(str(uuid.uuid4()))
+        modifie = nouveau.AvecModifications(heure_fin="15:30", lieu="Gymnase")
+        self.assertEqual(modifie.identifiant_stable, nouveau.identifiant_stable)
+        self.assertEqual(modifie.identifiant_source, ancien.identifiant_stable)
+        self.assertEqual(modifie.etat_renouvellement, prog.RENOUVELLEMENT_MODIFIE)
+        self.assertEqual(modifie.DureePrevueMinutes(), 90)
+
+
+class ProgrammationAnnuelleTests(unittest.TestCase):
+    def setUp(self):
+        self.relation = str(uuid.uuid4())
+        self.programmation = prog.ProgrammationAnnuelle(
+            self.relation,
+            "2025-2026",
+            statut=prog.STATUT_PROGRAMMATION_VALIDEE,
+        )
+
+    def test_un_creneau_d_une_autre_relation_est_refuse(self):
+        autre = prog.CreneauProgrammation(
+            str(uuid.uuid4()), 2, "10:00", "11:00"
+        )
+        with self.assertRaises(ValueError):
+            self.programmation.AjouterCreneau(autre)
+
+    def test_renouveler_copie_uniquement_les_creneaux_conserves(self):
+        ancien_1 = prog.CreneauProgrammation(
+            self.relation, 2, "10:00", "11:00", groupe="Groupe A"
+        )
+        ancien_2_source = prog.CreneauProgrammation(
+            str(uuid.uuid4()), 3, "17:00", "18:00"
+        )
+        ancien_2 = ancien_2_source.Renouveler(self.relation)
+        ancien_2 = ancien_2.MarquerSupprime()
+        self.programmation.AjouterCreneau(ancien_1)
+        self.programmation.AjouterCreneau(ancien_2)
+
+        nouvelle_relation = str(uuid.uuid4())
+        suivante = self.programmation.Renouveler(
+            nouvelle_relation,
+            "2026-2027",
+            date_debut="2026-09-01",
+            date_fin="2027-06-30",
+        )
+        self.assertEqual(suivante.statut, prog.STATUT_PROGRAMMATION_BROUILLON)
+        self.assertEqual(suivante.identifiant_source, self.programmation.identifiant_stable)
+        self.assertEqual(len(suivante.creneaux), 1)
+        self.assertEqual(suivante.creneaux[0].groupe, "Groupe A")
+        self.assertEqual(
+            suivante.creneaux[0].etat_renouvellement,
+            prog.RENOUVELLEMENT_INCHANGE,
+        )
+
+    def test_modification_et_suppression_conservent_la_filiation_n_moins_1(self):
+        ancien = prog.CreneauProgrammation(self.relation, 4, "14:30", "15:30")
+        suivante = prog.ProgrammationAnnuelle(
+            str(uuid.uuid4()), "2026-2027"
+        )
+        herite = ancien.Renouveler(suivante.identifiant_relation)
+        suivante.AjouterCreneau(herite)
+
+        modifie = suivante.ModifierCreneau(
+            herite.identifiant_stable, heure_debut="15:00", heure_fin="16:00"
+        )
+        self.assertEqual(modifie.etat_renouvellement, prog.RENOUVELLEMENT_MODIFIE)
+        self.assertEqual(modifie.identifiant_source, ancien.identifiant_stable)
+
+        supprime = suivante.SupprimerCreneau(herite.identifiant_stable)
+        self.assertEqual(supprime.etat_renouvellement, prog.RENOUVELLEMENT_SUPPRIME)
+        self.assertEqual(len(suivante.GetCreneauxConserves()), 0)
+
+    def test_un_creneau_ajoute_puis_supprime_disparait_sans_fausse_trace(self):
+        ajoute = prog.CreneauProgrammation(self.relation, 1, "17:00", "18:00")
+        self.programmation.AjouterCreneau(ajoute)
+        resultat = self.programmation.SupprimerCreneau(ajoute.identifiant_stable)
+        self.assertIsNone(resultat)
+        self.assertEqual(self.programmation.creneaux, [])
+
+    def test_synthese_distingue_inchange_modifie_supprime_et_ajoute(self):
+        nouvelle_relation = str(uuid.uuid4())
+        source = prog.CreneauProgrammation(self.relation, 0, "10:00", "11:00")
+        source2 = prog.CreneauProgrammation(self.relation, 1, "10:00", "11:00")
+        source3 = prog.CreneauProgrammation(self.relation, 2, "10:00", "11:00")
+        programmation = prog.ProgrammationAnnuelle(nouvelle_relation, "2026-2027")
+        inchange = source.Renouveler(nouvelle_relation)
+        modifie = source2.Renouveler(nouvelle_relation).AvecModifications(lieu="Salle A")
+        supprime = source3.Renouveler(nouvelle_relation).MarquerSupprime()
+        ajoute = prog.CreneauProgrammation(nouvelle_relation, 3, "10:00", "11:00")
+        for creneau in (inchange, modifie, supprime, ajoute):
+            programmation.AjouterCreneau(creneau)
+
+        synthese = programmation.GetSyntheseRenouvellement()
+        self.assertEqual(synthese[prog.RENOUVELLEMENT_INCHANGE], 1)
+        self.assertEqual(synthese[prog.RENOUVELLEMENT_MODIFIE], 1)
+        self.assertEqual(synthese[prog.RENOUVELLEMENT_SUPPRIME], 1)
+        self.assertEqual(synthese[prog.RENOUVELLEMENT_AJOUTE], 1)
+        self.assertEqual(
+            programmation.GetChampsFusion()["{PROGRAMMATION_NB_CRENEAUX}"],
+            "3",
+        )
+
+    def test_donnees_sont_entierement_serialisables(self):
+        creneau = prog.CreneauProgrammation(
+            self.relation,
+            5,
+            "09h30",
+            "12h05",
+            date_debut="2026-09-01",
+            date_fin="2027-06-30",
+        )
+        self.programmation.AjouterCreneau(creneau)
+        donnees = self.programmation.GetDonnees()
+        self.assertEqual(donnees["saison"], "2025-2026")
+        self.assertEqual(donnees["creneaux"][0]["heure_debut"], "09:30")
+        self.assertEqual(donnees["creneaux"][0]["date_debut"], "2026-09-01")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #60 à terme (PR laissée en draft pendant la construction du chantier).

## Lots présents

### Socle convention / avenant
- noyau métier pur `ConventionMiseADisposition`, sans wxPython ni accès DB ;
- période, statut, mode de facturation, version et filiation des avenants ;
- UUID stable partageable avec PMSL-Équipe ;
- champs de fusion canoniques.

### Noe-062A — Structures et contacts
- `StructureMiseADisposition` : association, école, collectivité, organisme, entreprise ou autre ;
- aucun SIRET/SIREN/RNA obligatoire ;
- `ContactStructure` avec rôles cumulables : planning, facturation, convention, direction, présidence, trésorerie, APEL, section, administratif, urgence ;
- champs de fusion et sérialisation stables.

### Noe-062B — Relation contractuelle
- bénéficiaire et payeur peuvent être distincts ;
- saison, activité et groupe/section libre ;
- tarif en `Decimal`, unité heure/séance/forfait/journée ;
- adhésion portée par la relation (`requise`, `non_requise`, `non_applicable`, `exoneree`) et jamais déduite du type de structure ;
- mode de facturation porté par la relation ;
- liaison optionnelle convention → relation contractuelle.

### Noe-062C — Programmation annuelle et renouvellement N-1
- module pur dédié `UTILS_Mises_a_disposition_programmation.py` ;
- créneaux avec jour, horaires, période, groupe, lieu et durée prévisionnelle ;
- UUID stable par programmation et par créneau ;
- renouvellement N-1 avec filiation explicite ;
- comparaison `inchange` / `modifie` / `supprime` / `ajoute` ;
- une ligne ajoutée puis retirée dans la même préparation ne crée pas de fausse suppression ;
- les dates exactes N-1 ne sont jamais transposées implicitement ;
- synthèse de renouvellement et champs de fusion canoniques.

### Noe-062D — Convention, annexe et avenants
- `RegleCalendrierMiseADisposition` traduit les créneaux vers le contrat exact de `DLG_Saisie_location.Calcule_occurences()` ;
- aucun second calcul vacances / fériés / fréquence n'est introduit ;
- annexe prévisionnelle générée date par date via un calculateur de récurrence injecté ;
- lignes triées, durées totalisées et doublons d'occurrences neutralisés ;
- UUID5 déterministes pour les occurrences et l'annexe ;
- paquet de champs fusionnant convention, relation, bénéficiaire, payeur, contact, programmation et annexe ;
- distinction automatique convention / avenant par filiation ;
- `SnapshotDocumentContractuel` avec empreinte SHA-256 pour empêcher un recalcul silencieux d'un document officiel.

Le paquet documentaire est destiné au moteur de modèles Noethys existant : il ne crée pas un second moteur PDF et ne modifie pas la structure du modèle PMSL.

## Choix d'architecture

Le module historique Locations sait déjà gérer récurrence, prestations, questionnaires, historique, champs de fusion, PDF et e-mail. On réutilise ces moteurs mais on ne détourne pas `IDfamille + IDproduit` pour représenter durablement une convention avec une personne morale.

Le calcul historique de récurrence est encore physiquement dans `DLG_Saisie_location.py`. L'étape de raccord desktop restante consiste à l'extraire sans changement fonctionnel vers une fonction commune appelée à la fois par Locations et Noe-062D. Aucune copie concurrente de cet algorithme n'est introduite dans cette PR.

## Compatibilité

- aucune migration ;
- aucune table modifiée ;
- aucune donnée historique modifiée ;
- aucune dépendance Internet ;
- les locations existantes continuent à fonctionner sans changement.

Le stockage des structures/contacts/relations/programmations/snapshots sera introduit uniquement après cartographie des usages historiques et validation d'une migration additive sur copie de base réelle.

## Suite dans cette branche

1. extraction technique du calculateur de récurrence hors du dialogue historique, sans changement de comportement ;
2. raccord du paquet documentaire au modèle PMSL réel ;
3. Noe-062E : réalisé, facturation et reporting depuis les mêmes données.