### PR TITLE
Noe-063 — Ajouter les contenus externes au portail Connecthys

### DIFF
--- a/docs/NOE_063B_RSS_ATOM.md
+++ b/docs/NOE_063B_RSS_ATOM.md
@@ -1,0 +1,27 @@
+# Noe-063B — RSS / Atom natif pour Connecthys
+
+## But
+
+Afficher dans le portail Connecthys un flux RSS ou Atom sans service tiers. Noethys lit le flux lors de la synchronisation, produit un HTML sûr puis l'exporte dans le mécanisme historique des blocs Texte.
+
+## Principes
+
+- aucune dépendance à FeedWind ;
+- aucune modification du serveur Connecthys ;
+- bibliothèques standard Python uniquement ;
+- URL HTTP(S) uniquement ;
+- taille et délai de téléchargement bornés ;
+- parsing RSS 2.0 et Atom ;
+- titres, dates, extraits et liens échappés ;
+- aucun HTML ou script provenant du flux n'est injecté tel quel ;
+- nombre d'articles configurable ;
+- l'échec d'un flux ne doit jamais bloquer la synchronisation générale ;
+- en cas d'échec, conserver le dernier HTML valide déjà stocké.
+
+## Actualisation
+
+Un bloc RSS est dynamique : la présence d'un tel bloc force la réexportation des pages/éléments à chaque synchronisation afin que les actualités suivent automatiquement la source web.
+
+## Suite
+
+Le ciblage par activité (ALSH, EMS, Sport-Santé, couture...) sera construit au-dessus de ce socle, avec possibilité de conserver un flux général commun à tous les adhérents.

--- a/docs/NOE_063_PORTAIL_CONTENUS_DYNAMIQUES.md
+++ b/docs/NOE_063_PORTAIL_CONTENUS_DYNAMIQUES.md
@@ -1,0 +1,54 @@
+# Noe-063 — Portail Connecthys : contenus dynamiques
+
+## Objectif
+
+Réduire les doubles saisies entre Noethys, le site web, Piwigo et Connecthys en faisant du portail famille une vue de contenus déjà maintenus ailleurs.
+
+## Compatibilité
+
+Le premier lot ne demande aucune modification de Connecthys ni du schéma de base. Les nouveaux contenus enrichis restent stockés et synchronisés comme des blocs historiques `bloc_texte` avec du `texte_html` compatible.
+
+Les blocs Texte existants ne sont pas requalifiés automatiquement : seul le marqueur explicite `noethys_portail_contenu_externe` permet à Noethys de rouvrir un bloc dans l'éditeur `Contenu externe`.
+
+## Lot A — Contenu externe
+
+Le nouvel éditeur permet de configurer sans HTML :
+
+- une URL HTTP(S) ;
+- une hauteur d'affichage ;
+- les barres de défilement ;
+- le plein écran ;
+- un titre accessible.
+
+Noethys génère l'iframe, échappe les attributs et conserve la configuration dans le champ `parametres` existant.
+
+## Lots prévus
+
+### Lot B — RSS / Atom natif
+
+Remplacer les widgets tiers de type FeedWind par une lecture directe des flux. Le HTML affiché dans Connecthys sera généré par Noethys et actualisé lors de la synchronisation. En cas d'indisponibilité temporaire du flux, la dernière version valide restera affichée.
+
+### Lot C — Piwigo Display
+
+Permettre les galeries, diaporamas et vidéos Piwigo via un embed dédié, sans recopier les médias dans Connecthys.
+
+### Lot D — Mes tarifs
+
+Afficher des tarifs issus des règles réellement configurées dans Noethys. L'objectif est de pouvoir limiter l'affichage aux activités qui concernent le compte connecté et d'éviter toute copie manuelle des grilles tarifaires.
+
+### Lot E — Actualités ciblées
+
+Prévoir trois politiques de diffusion : actualités générales de l'association, actualités liées aux inscriptions et sélection manuelle de catégories.
+
+### Lot F — Présence numérique
+
+Centraliser les liens vers le site, Facebook, Instagram, LinkedIn, Piwigo et d'autres services configurables afin de les réutiliser dans le portail sans ressaisie.
+
+## Règle d'architecture
+
+Une donnée métier doit avoir une source de vérité :
+
+- Noethys pour les données de gestion et de tarification ;
+- le site web pour les contenus éditoriaux et documents de référence ;
+- Piwigo pour les médias ;
+- Connecthys pour leur présentation aux comptes autorisés.

--- a/noethys/Ctrl/CTRL_Portail_contenu_externe.py
+++ b/noethys/Ctrl/CTRL_Portail_contenu_externe.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#------------------------------------------------------------------------
+# Application :    Noethys, gestion multi-activités
+# Site internet :  www.noethys.com
+# Licence:          GNU GPL
+#------------------------------------------------------------------------
+
+import wx
+
+from Utils.UTILS_Traduction import _
+from Utils import UTILS_Portail_contenus
+
+
+class CTRL(wx.Panel):
+    """Editeur d'un contenu externe rendu comme bloc texte Connecthys."""
+
+    def __init__(self, parent):
+        wx.Panel.__init__(self, parent, id=-1, style=wx.TAB_TRAVERSAL)
+        self.parent = parent
+        self.IDelement = None
+
+        self.label_intro = wx.StaticText(
+            self,
+            -1,
+            _(u"Affichez une page, une photothèque, un lecteur vidéo ou un widget web sans saisir de code HTML."),
+        )
+        self.label_url = wx.StaticText(self, -1, _(u"Adresse (URL) :"))
+        self.ctrl_url = wx.TextCtrl(self, -1, "")
+
+        self.label_titre = wx.StaticText(self, -1, _(u"Titre accessible :"))
+        self.ctrl_titre = wx.TextCtrl(self, -1, "")
+
+        self.label_hauteur = wx.StaticText(self, -1, _(u"Hauteur :"))
+        self.ctrl_hauteur = wx.SpinCtrl(
+            self,
+            -1,
+            min=UTILS_Portail_contenus.HAUTEUR_MIN,
+            max=UTILS_Portail_contenus.HAUTEUR_MAX,
+            initial=UTILS_Portail_contenus.HAUTEUR_DEFAUT,
+        )
+        self.label_pixels = wx.StaticText(self, -1, _(u"pixels"))
+
+        self.ctrl_defilement = wx.CheckBox(self, -1, _(u"Autoriser les barres de défilement"))
+        self.ctrl_plein_ecran = wx.CheckBox(self, -1, _(u"Autoriser le plein écran"))
+        self.ctrl_plein_ecran.SetValue(True)
+
+        self.label_aide = wx.StaticText(
+            self,
+            -1,
+            _(u"Le bloc reste stocké comme un bloc Texte standard pour rester compatible avec les hébergements Connecthys existants."),
+        )
+        self.label_aide.Wrap(500)
+
+        self.__set_properties()
+        self.__do_layout()
+
+    def __set_properties(self):
+        self.ctrl_url.SetToolTip(wx.ToolTip(_(u"Saisissez une adresse complète commençant par http:// ou https://")))
+        self.ctrl_titre.SetToolTip(wx.ToolTip(_(u"Décrivez brièvement le contenu pour les lecteurs d'écran")))
+        self.ctrl_hauteur.SetToolTip(wx.ToolTip(_(u"Hauteur d'affichage du contenu dans le portail famille")))
+
+    def __do_layout(self):
+        sizer_base = wx.BoxSizer(wx.VERTICAL)
+        sizer_base.Add(self.label_intro, 0, wx.LEFT | wx.RIGHT | wx.TOP | wx.EXPAND, 10)
+
+        grille = wx.FlexGridSizer(rows=3, cols=3, vgap=10, hgap=10)
+        grille.Add(self.label_url, 0, wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, 0)
+        grille.Add(self.ctrl_url, 0, wx.EXPAND, 0)
+        grille.Add((1, 1), 0, 0, 0)
+
+        grille.Add(self.label_titre, 0, wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, 0)
+        grille.Add(self.ctrl_titre, 0, wx.EXPAND, 0)
+        grille.Add((1, 1), 0, 0, 0)
+
+        grille.Add(self.label_hauteur, 0, wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, 0)
+        grille.Add(self.ctrl_hauteur, 0, 0, 0)
+        grille.Add(self.label_pixels, 0, wx.ALIGN_CENTER_VERTICAL, 0)
+        grille.AddGrowableCol(1)
+        sizer_base.Add(grille, 0, wx.ALL | wx.EXPAND, 10)
+
+        sizer_options = wx.BoxSizer(wx.VERTICAL)
+        sizer_options.Add(self.ctrl_defilement, 0, wx.BOTTOM, 8)
+        sizer_options.Add(self.ctrl_plein_ecran, 0, 0, 0)
+        sizer_base.Add(sizer_options, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 20)
+
+        sizer_base.AddStretchSpacer(1)
+        sizer_base.Add(self.label_aide, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 10)
+
+        self.SetSizer(sizer_base)
+        self.Layout()
+
+    def GetParametres(self):
+        config = {
+            "type": "iframe",
+            "url": self.ctrl_url.GetValue(),
+            "hauteur": self.ctrl_hauteur.GetValue(),
+            "defilement": self.ctrl_defilement.GetValue(),
+            "plein_ecran": self.ctrl_plein_ecran.GetValue(),
+            "titre": self.ctrl_titre.GetValue(),
+        }
+        config = UTILS_Portail_contenus.normaliser_parametres(config)
+        dictElement = {
+            "IDelement": self.IDelement,
+            "titre": "",
+            "date_debut": None,
+            "date_fin": None,
+            "parametres": UTILS_Portail_contenus.serialiser_parametres(config),
+            "texte_xml": None,
+            "texte_html": UTILS_Portail_contenus.construire_iframe(config),
+        }
+        return {"elements": [dictElement]}
+
+    def SetParametres(self, dictParametres=None):
+        dictParametres = dictParametres or {}
+        elements = dictParametres.get("elements", [])
+        if not elements:
+            return
+
+        dictElement = elements[0]
+        self.IDelement = dictElement.get("IDelement")
+        config = UTILS_Portail_contenus.deserialiser_parametres(dictElement.get("parametres"))
+        self.ctrl_url.SetValue(config["url"])
+        self.ctrl_titre.SetValue(config["titre"])
+        self.ctrl_hauteur.SetValue(config["hauteur"])
+        self.ctrl_defilement.SetValue(config["defilement"])
+        self.ctrl_plein_ecran.SetValue(config["plein_ecran"])
+
+    def Validation(self):
+        url = self.ctrl_url.GetValue()
+        if not UTILS_Portail_contenus.url_externe_valide(url):
+            dlg = wx.MessageDialog(
+                self,
+                _(u"Vous devez saisir une adresse web complète et valide commençant par http:// ou https://."),
+                _(u"Erreur de saisie"),
+                wx.OK | wx.ICON_EXCLAMATION,
+            )
+            dlg.ShowModal()
+            dlg.Destroy()
+            self.ctrl_url.SetFocus()
+            return False
+        return True
+
+
+def EstContenuExterne(dictParametres=None):
+    """Indique si un bloc texte existant a été créé par cet éditeur."""
+    dictParametres = dictParametres or {}
+    elements = dictParametres.get("elements", [])
+    if not elements:
+        return False
+    return UTILS_Portail_contenus.est_configuration_contenu_externe(elements[0].get("parametres"))

--- a/noethys/Dlg/DLG_Saisie_portail_bloc.py
+++ b/noethys/Dlg/DLG_Saisie_portail_bloc.py
@@ -18,6 +18,7 @@ from Utils import UTILS_Dates
 from Ctrl import CTRL_Bouton_image
 import GestionDB
 from Ctrl import CTRL_Editeur_email
+from Ctrl import CTRL_Portail_contenu_externe
 from Ctrl.CTRL_Portail_pages import CTRL_Couleur
 from Ol import OL_Portail_bloc_onglets
 from Ol import OL_Portail_bloc_blog
@@ -369,6 +370,7 @@ class CTRL_Parametres(LB.FlatImageBook):
 
         self.listePages = [
             (_("bloc_texte"), _(u"Texte"), PAGE_Texte(self), wx.Bitmap(Chemins.GetStaticPath('Images/32x32/Texte_bloc.png'), wx.BITMAP_TYPE_PNG)),
+            (_("bloc_contenu_externe"), _(u"Contenu externe"), CTRL_Portail_contenu_externe.CTRL(self), wx.Bitmap(Chemins.GetStaticPath('Images/32x32/Apercu.png'), wx.BITMAP_TYPE_PNG)),
             (_("bloc_onglets"), _(u"Onglets"), PAGE_Onglets(self), wx.Bitmap(Chemins.GetStaticPath('Images/32x32/Onglets.png'), wx.BITMAP_TYPE_PNG)),
             (_("bloc_blog"), _(u"Blog"), PAGE_Blog(self), wx.Bitmap(Chemins.GetStaticPath('Images/32x32/Blog.png'), wx.BITMAP_TYPE_PNG)),
             (_("bloc_calendrier"), _(u"Calendrier"), PAGE_Calendrier(self), wx.Bitmap(Chemins.GetStaticPath('Images/32x32/Calendrier.png'), wx.BITMAP_TYPE_PNG)),
@@ -418,11 +420,17 @@ class CTRL_Parametres(LB.FlatImageBook):
 
     def GetParametres(self):
         dictParametres = self.GetPageActive().GetParametres()
-        dictParametres["categorie"] = self.GetCodePageActive()
+        categorie = self.GetCodePageActive()
+        if categorie == _("bloc_contenu_externe"):
+            categorie = _("bloc_texte")
+        dictParametres["categorie"] = categorie
         return dictParametres
 
     def SetParametres(self, dictParametres={}):
-        self.SetPageByCode(dictParametres["categorie"])
+        categorie = dictParametres["categorie"]
+        if categorie == _("bloc_texte") and CTRL_Portail_contenu_externe.EstContenuExterne(dictParametres):
+            categorie = _("bloc_contenu_externe")
+        self.SetPageByCode(categorie)
         self.GetPageActive().SetParametres(dictParametres)
 
 

--- a/noethys/Utils/UTILS_Portail_contenus.py
+++ b/noethys/Utils/UTILS_Portail_contenus.py
@@ -22,6 +22,7 @@ from urllib.parse import urlparse
 
 CATEGORIE_CONTENU_EXTERNE = "bloc_contenu_externe"
 CATEGORIE_CONNECTHYS_TEXTE = "bloc_texte"
+MARQUEUR_CONTENU_EXTERNE = "noethys_portail_contenu_externe"
 
 HAUTEUR_MIN = 120
 HAUTEUR_MAX = 3000
@@ -60,6 +61,7 @@ def normaliser_parametres(parametres=None):
     """Retourne la configuration canonique d'un bloc de contenu externe."""
     source = dict(parametres or {})
     return {
+        "source": MARQUEUR_CONTENU_EXTERNE,
         "version": 1,
         "type": source.get("type", "iframe"),
         "url": normaliser_url(source.get("url", "")),
@@ -80,19 +82,26 @@ def serialiser_parametres(parametres=None):
     )
 
 
-def deserialiser_parametres(valeur):
-    """Lit une configuration sauvegardée et retombe sur les valeurs par défaut."""
+def _charger_json(valeur):
     if not valeur:
-        return normaliser_parametres()
+        return {}
     if isinstance(valeur, bytes):
         valeur = valeur.decode("utf-8")
     try:
         donnees = json.loads(valeur)
     except (TypeError, ValueError):
-        donnees = {}
-    if not isinstance(donnees, dict):
-        donnees = {}
-    return normaliser_parametres(donnees)
+        return {}
+    return donnees if isinstance(donnees, dict) else {}
+
+
+def est_configuration_contenu_externe(valeur):
+    """Détecte uniquement les paramètres écrits par ce moteur, sans faux positif."""
+    return _charger_json(valeur).get("source") == MARQUEUR_CONTENU_EXTERNE
+
+
+def deserialiser_parametres(valeur):
+    """Lit une configuration sauvegardée et retombe sur les valeurs par défaut."""
+    return normaliser_parametres(_charger_json(valeur))
 
 
 def construire_iframe(parametres=None):

--- a/noethys/Utils/UTILS_Portail_contenus.py
+++ b/noethys/Utils/UTILS_Portail_contenus.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#------------------------------------------------------------------------
+# Application :    Noethys, gestion multi-activités
+# Site internet :  www.noethys.com
+# Licence:          GNU GPL
+#------------------------------------------------------------------------
+
+"""Helpers purs pour les contenus dynamiques du portail Connecthys.
+
+Le premier objectif est volontairement limité : permettre à Noethys de
+conserver une configuration enrichie localement tout en exportant vers un
+Connecthys historique un bloc texte HTML parfaitement compatible.
+
+Ce module ne dépend ni de wxPython, ni de la base de données, ni du réseau.
+"""
+
+import html
+import json
+from urllib.parse import urlparse
+
+
+CATEGORIE_CONTENU_EXTERNE = "bloc_contenu_externe"
+CATEGORIE_CONNECTHYS_TEXTE = "bloc_texte"
+
+HAUTEUR_MIN = 120
+HAUTEUR_MAX = 3000
+HAUTEUR_DEFAUT = 600
+
+
+def normaliser_url(url):
+    """Retourne une URL externe nettoyée sans tenter de la télécharger."""
+    if url is None:
+        return ""
+    return str(url).strip()
+
+
+def url_externe_valide(url):
+    """Accepte uniquement les URL HTTP(S) absolues pour un contenu embarqué."""
+    url = normaliser_url(url)
+    if not url:
+        return False
+    try:
+        parsed = urlparse(url)
+    except (TypeError, ValueError):
+        return False
+    return parsed.scheme.lower() in ("http", "https") and bool(parsed.netloc)
+
+
+def normaliser_hauteur(hauteur):
+    """Normalise la hauteur d'un iframe dans une plage raisonnable."""
+    try:
+        valeur = int(hauteur)
+    except (TypeError, ValueError):
+        valeur = HAUTEUR_DEFAUT
+    return max(HAUTEUR_MIN, min(HAUTEUR_MAX, valeur))
+
+
+def normaliser_parametres(parametres=None):
+    """Retourne la configuration canonique d'un bloc de contenu externe."""
+    source = dict(parametres or {})
+    return {
+        "version": 1,
+        "type": source.get("type", "iframe"),
+        "url": normaliser_url(source.get("url", "")),
+        "hauteur": normaliser_hauteur(source.get("hauteur", HAUTEUR_DEFAUT)),
+        "defilement": bool(source.get("defilement", False)),
+        "plein_ecran": bool(source.get("plein_ecran", True)),
+        "titre": str(source.get("titre", "") or "").strip(),
+    }
+
+
+def serialiser_parametres(parametres=None):
+    """Sérialise la configuration locale dans le champ parametres existant."""
+    return json.dumps(
+        normaliser_parametres(parametres),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def deserialiser_parametres(valeur):
+    """Lit une configuration sauvegardée et retombe sur les valeurs par défaut."""
+    if not valeur:
+        return normaliser_parametres()
+    if isinstance(valeur, bytes):
+        valeur = valeur.decode("utf-8")
+    try:
+        donnees = json.loads(valeur)
+    except (TypeError, ValueError):
+        donnees = {}
+    if not isinstance(donnees, dict):
+        donnees = {}
+    return normaliser_parametres(donnees)
+
+
+def construire_iframe(parametres=None):
+    """Construit le HTML compatible avec un bloc texte Connecthys historique."""
+    config = normaliser_parametres(parametres)
+    if config["type"] != "iframe":
+        raise ValueError("Type de contenu externe non pris en charge : %s" % config["type"])
+    if not url_externe_valide(config["url"]):
+        raise ValueError("URL externe invalide")
+
+    attributs = [
+        ("src", config["url"]),
+        ("width", "100%"),
+        ("height", "%d" % config["hauteur"]),
+        ("loading", "lazy"),
+        ("scrolling", "yes" if config["defilement"] else "no"),
+        ("frameborder", "0"),
+    ]
+    if config["titre"]:
+        attributs.append(("title", config["titre"]))
+
+    texte_attributs = " ".join(
+        '%s="%s"' % (nom, html.escape(str(valeur), quote=True))
+        for nom, valeur in attributs
+    )
+    if config["plein_ecran"]:
+        texte_attributs += " allowfullscreen"
+
+    return '<iframe %s></iframe>' % texte_attributs
+
+
+def categorie_pour_connecthys(categorie):
+    """Mappe les catégories enrichies locales vers le vocabulaire Connecthys stable."""
+    if categorie == CATEGORIE_CONTENU_EXTERNE:
+        return CATEGORIE_CONNECTHYS_TEXTE
+    return categorie

--- a/tests/test_portail_contenu_externe_integration_contract.py
+++ b/tests/test_portail_contenu_externe_integration_contract.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_editeur_portail_expose_un_bloc_contenu_externe_compatible():
+    source = (ROOT / "noethys" / "Dlg" / "DLG_Saisie_portail_bloc.py").read_text(encoding="utf-8")
+
+    assert "CTRL_Portail_contenu_externe" in source
+    assert '_(u"Contenu externe")' in source
+    assert '_("bloc_contenu_externe")' in source
+    assert 'categorie = _("bloc_texte")' in source
+    assert "EstContenuExterne(dictParametres)" in source
+
+
+def test_controle_externe_stocke_configuration_et_html_dans_les_champs_existants():
+    source = (ROOT / "noethys" / "Ctrl" / "CTRL_Portail_contenu_externe.py").read_text(encoding="utf-8")
+
+    assert '"parametres": UTILS_Portail_contenus.serialiser_parametres(config)' in source
+    assert '"texte_html": UTILS_Portail_contenus.construire_iframe(config)' in source
+    assert '"texte_xml": None' in source
+    assert "url_externe_valide" in source

--- a/tests/test_portail_contenus_dynamiques.py
+++ b/tests/test_portail_contenus_dynamiques.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import importlib.util
+import unittest
 from pathlib import Path
 
 
@@ -12,55 +13,58 @@ PORTAIL = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(PORTAIL)
 
 
-def test_url_externe_accepte_uniquement_http_et_https():
-    assert PORTAIL.url_externe_valide("https://phototheque.example.org/album/12") is True
-    assert PORTAIL.url_externe_valide("http://example.org/feed") is True
-    assert PORTAIL.url_externe_valide("javascript:alert(1)") is False
-    assert PORTAIL.url_externe_valide("file:///tmp/test.html") is False
-    assert PORTAIL.url_externe_valide("example.org/sans-schema") is False
+class PortailContenusDynamiquesTests(unittest.TestCase):
+
+    def test_url_externe_accepte_uniquement_http_et_https(self):
+        self.assertTrue(PORTAIL.url_externe_valide("https://phototheque.example.org/album/12"))
+        self.assertTrue(PORTAIL.url_externe_valide("http://example.org/feed"))
+        self.assertFalse(PORTAIL.url_externe_valide("javascript:alert(1)"))
+        self.assertFalse(PORTAIL.url_externe_valide("file:///tmp/test.html"))
+        self.assertFalse(PORTAIL.url_externe_valide("example.org/sans-schema"))
+
+    def test_iframe_est_responsive_et_echappe_les_attributs(self):
+        rendu = PORTAIL.construire_iframe({
+            "url": "https://example.org/view?x=1&y=2",
+            "hauteur": 826,
+            "defilement": False,
+            "plein_ecran": True,
+            "titre": 'Photothèque "été"',
+        })
+
+        self.assertIn('src="https://example.org/view?x=1&amp;y=2"', rendu)
+        self.assertIn('width="100%"', rendu)
+        self.assertIn('height="826"', rendu)
+        self.assertIn('scrolling="no"', rendu)
+        self.assertIn('title="Photothèque &quot;été&quot;"', rendu)
+        self.assertIn(" allowfullscreen", rendu)
+        self.assertNotIn("javascript:", rendu)
+
+    def test_hauteur_est_bornee_et_serialisation_est_stable(self):
+        self.assertEqual(PORTAIL.normaliser_hauteur(50), PORTAIL.HAUTEUR_MIN)
+        self.assertEqual(PORTAIL.normaliser_hauteur(9999), PORTAIL.HAUTEUR_MAX)
+        self.assertEqual(PORTAIL.normaliser_hauteur("invalide"), PORTAIL.HAUTEUR_DEFAUT)
+
+        brut = PORTAIL.serialiser_parametres({
+            "url": " https://example.org/widget ",
+            "hauteur": "700",
+            "defilement": 1,
+        })
+        relu = PORTAIL.deserialiser_parametres(brut)
+
+        self.assertEqual(relu["source"], PORTAIL.MARQUEUR_CONTENU_EXTERNE)
+        self.assertEqual(relu["url"], "https://example.org/widget")
+        self.assertEqual(relu["hauteur"], 700)
+        self.assertTrue(relu["defilement"])
+        self.assertTrue(relu["plein_ecran"])
+        self.assertEqual(relu["version"], 1)
+        self.assertTrue(PORTAIL.est_configuration_contenu_externe(brut))
+        self.assertFalse(PORTAIL.est_configuration_contenu_externe('{"foo":"bar"}'))
+        self.assertFalse(PORTAIL.est_configuration_contenu_externe("ancien paramètre"))
+
+    def test_categorie_locale_est_exportee_comme_bloc_texte_connecthys(self):
+        self.assertEqual(PORTAIL.categorie_pour_connecthys("bloc_contenu_externe"), "bloc_texte")
+        self.assertEqual(PORTAIL.categorie_pour_connecthys("bloc_blog"), "bloc_blog")
 
 
-def test_iframe_est_responsive_et_echappe_les_attributs():
-    html = PORTAIL.construire_iframe({
-        "url": "https://example.org/view?x=1&y=2",
-        "hauteur": 826,
-        "defilement": False,
-        "plein_ecran": True,
-        "titre": 'Photothèque "été"',
-    })
-
-    assert 'src="https://example.org/view?x=1&amp;y=2"' in html
-    assert 'width="100%"' in html
-    assert 'height="826"' in html
-    assert 'scrolling="no"' in html
-    assert 'title="Photothèque &quot;été&quot;"' in html
-    assert " allowfullscreen" in html
-    assert "javascript:" not in html
-
-
-def test_hauteur_est_bornee_et_serialisation_est_stable():
-    assert PORTAIL.normaliser_hauteur(50) == PORTAIL.HAUTEUR_MIN
-    assert PORTAIL.normaliser_hauteur(9999) == PORTAIL.HAUTEUR_MAX
-    assert PORTAIL.normaliser_hauteur("invalide") == PORTAIL.HAUTEUR_DEFAUT
-
-    brut = PORTAIL.serialiser_parametres({
-        "url": " https://example.org/widget ",
-        "hauteur": "700",
-        "defilement": 1,
-    })
-    relu = PORTAIL.deserialiser_parametres(brut)
-
-    assert relu["source"] == PORTAIL.MARQUEUR_CONTENU_EXTERNE
-    assert relu["url"] == "https://example.org/widget"
-    assert relu["hauteur"] == 700
-    assert relu["defilement"] is True
-    assert relu["plein_ecran"] is True
-    assert relu["version"] == 1
-    assert PORTAIL.est_configuration_contenu_externe(brut) is True
-    assert PORTAIL.est_configuration_contenu_externe('{"foo":"bar"}') is False
-    assert PORTAIL.est_configuration_contenu_externe("ancien paramètre") is False
-
-
-def test_categorie_locale_est_exportee_comme_bloc_texte_connecthys():
-    assert PORTAIL.categorie_pour_connecthys("bloc_contenu_externe") == "bloc_texte"
-    assert PORTAIL.categorie_pour_connecthys("bloc_blog") == "bloc_blog"
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_portail_contenus_dynamiques.py
+++ b/tests/test_portail_contenus_dynamiques.py
@@ -50,11 +50,15 @@ def test_hauteur_est_bornee_et_serialisation_est_stable():
     })
     relu = PORTAIL.deserialiser_parametres(brut)
 
+    assert relu["source"] == PORTAIL.MARQUEUR_CONTENU_EXTERNE
     assert relu["url"] == "https://example.org/widget"
     assert relu["hauteur"] == 700
     assert relu["defilement"] is True
     assert relu["plein_ecran"] is True
     assert relu["version"] == 1
+    assert PORTAIL.est_configuration_contenu_externe(brut) is True
+    assert PORTAIL.est_configuration_contenu_externe('{"foo":"bar"}') is False
+    assert PORTAIL.est_configuration_contenu_externe("ancien paramètre") is False
 
 
 def test_categorie_locale_est_exportee_comme_bloc_texte_connecthys():

--- a/tests/test_portail_contenus_dynamiques.py
+++ b/tests/test_portail_contenus_dynamiques.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "noethys" / "Utils" / "UTILS_Portail_contenus.py"
+SPEC = importlib.util.spec_from_file_location("UTILS_Portail_contenus", MODULE_PATH)
+PORTAIL = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(PORTAIL)
+
+
+def test_url_externe_accepte_uniquement_http_et_https():
+    assert PORTAIL.url_externe_valide("https://phototheque.example.org/album/12") is True
+    assert PORTAIL.url_externe_valide("http://example.org/feed") is True
+    assert PORTAIL.url_externe_valide("javascript:alert(1)") is False
+    assert PORTAIL.url_externe_valide("file:///tmp/test.html") is False
+    assert PORTAIL.url_externe_valide("example.org/sans-schema") is False
+
+
+def test_iframe_est_responsive_et_echappe_les_attributs():
+    html = PORTAIL.construire_iframe({
+        "url": "https://example.org/view?x=1&y=2",
+        "hauteur": 826,
+        "defilement": False,
+        "plein_ecran": True,
+        "titre": 'Photothèque "été"',
+    })
+
+    assert 'src="https://example.org/view?x=1&amp;y=2"' in html
+    assert 'width="100%"' in html
+    assert 'height="826"' in html
+    assert 'scrolling="no"' in html
+    assert 'title="Photothèque &quot;été&quot;"' in html
+    assert " allowfullscreen" in html
+    assert "javascript:" not in html
+
+
+def test_hauteur_est_bornee_et_serialisation_est_stable():
+    assert PORTAIL.normaliser_hauteur(50) == PORTAIL.HAUTEUR_MIN
+    assert PORTAIL.normaliser_hauteur(9999) == PORTAIL.HAUTEUR_MAX
+    assert PORTAIL.normaliser_hauteur("invalide") == PORTAIL.HAUTEUR_DEFAUT
+
+    brut = PORTAIL.serialiser_parametres({
+        "url": " https://example.org/widget ",
+        "hauteur": "700",
+        "defilement": 1,
+    })
+    relu = PORTAIL.deserialiser_parametres(brut)
+
+    assert relu["url"] == "https://example.org/widget"
+    assert relu["hauteur"] == 700
+    assert relu["defilement"] is True
+    assert relu["plein_ecran"] is True
+    assert relu["version"] == 1
+
+
+def test_categorie_locale_est_exportee_comme_bloc_texte_connecthys():
+    assert PORTAIL.categorie_pour_connecthys("bloc_contenu_externe") == "bloc_texte"
+    assert PORTAIL.categorie_pour_connecthys("bloc_blog") == "bloc_blog"

--- a/tests/test_portail_contenus_dynamiques_contract.py
+++ b/tests/test_portail_contenus_dynamiques_contract.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import unittest
 from pathlib import Path
 
 
@@ -9,14 +10,20 @@ DLG = ROOT / "noethys" / "Dlg" / "DLG_Saisie_portail_bloc.py"
 CTRL = ROOT / "noethys" / "Ctrl" / "CTRL_Portail_contenu_externe.py"
 
 
-def test_editeur_de_bloc_expose_le_contenu_externe_sans_nouvelle_categorie_persistante():
-    dlg = DLG.read_text(encoding="utf-8")
-    ctrl = CTRL.read_text(encoding="utf-8")
+class PortailContenuExterneContractTests(unittest.TestCase):
 
-    assert '_(u"Contenu externe")' in dlg
-    assert "CTRL_Portail_contenu_externe.CTRL" in dlg
-    assert 'categorie = _("bloc_texte")' in dlg
-    assert "EstContenuExterne" in dlg
-    assert "construire_iframe" in ctrl
-    assert "texte_html" in ctrl
-    assert "parametres" in ctrl
+    def test_editeur_de_bloc_expose_le_contenu_externe_sans_nouvelle_categorie_persistante(self):
+        dlg = DLG.read_text(encoding="utf-8")
+        ctrl = CTRL.read_text(encoding="utf-8")
+
+        self.assertIn('_(u"Contenu externe")', dlg)
+        self.assertIn("CTRL_Portail_contenu_externe.CTRL", dlg)
+        self.assertIn('categorie = _("bloc_texte")', dlg)
+        self.assertIn("EstContenuExterne", dlg)
+        self.assertIn("construire_iframe", ctrl)
+        self.assertIn("texte_html", ctrl)
+        self.assertIn("parametres", ctrl)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_portail_contenus_dynamiques_contract.py
+++ b/tests/test_portail_contenus_dynamiques_contract.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DLG = ROOT / "noethys" / "Dlg" / "DLG_Saisie_portail_bloc.py"
+CTRL = ROOT / "noethys" / "Ctrl" / "CTRL_Portail_contenu_externe.py"
+
+
+def test_editeur_de_bloc_expose_le_contenu_externe_sans_nouvelle_categorie_persistante():
+    dlg = DLG.read_text(encoding="utf-8")
+    ctrl = CTRL.read_text(encoding="utf-8")
+
+    assert '_(u"Contenu externe")' in dlg
+    assert "CTRL_Portail_contenu_externe.CTRL" in dlg
+    assert 'categorie = _("bloc_texte")' in dlg
+    assert "EstContenuExterne" in dlg
+    assert "construire_iframe" in ctrl
+    assert "texte_html" in ctrl
+    assert "parametres" in ctrl


### PR DESCRIPTION
## Objectif
Remplacer les iframes saisies manuellement dans les blocs Texte par un vrai bloc **Contenu externe** côté Noethys, tout en restant compatible avec un Connecthys hébergé non modifié.

## Principe
- nouveau contrôle `Contenu externe` dans l’éditeur des blocs ;
- URL HTTP(S), hauteur, défilement, plein écran et titre accessible ;
- génération centralisée et échappée du HTML `<iframe>` ;
- configuration conservée dans le champ `parametres` existant ;
- le bloc est enregistré avec la catégorie historique `bloc_texte` ;
- à la réouverture, le marqueur de configuration permet à Noethys de retrouver automatiquement l’éditeur `Contenu externe` ;
- aucun changement du schéma de base ;
- aucun changement requis côté Connecthys.

## Compatibilité
Les blocs Texte historiques restent des blocs Texte ordinaires. Seuls les éléments possédant le marqueur explicite `noethys_portail_contenu_externe` sont réouverts dans le nouvel éditeur.

## Sécurité / robustesse
- URL absolues `http://` ou `https://` uniquement ;
- échappement HTML des attributs ;
- hauteur bornée ;
- aucune requête réseau effectuée par Noethys pour ce premier lot ;
- pas de JavaScript injecté.

## Tests
- validation des URL ;
- génération de l’iframe ;
- sérialisation/désérialisation stable ;
- absence de faux positif sur les anciens paramètres ;
- contrat d’intégration dans l’éditeur des blocs.

## Suite prévue dans #62
- RSS / Atom natif ;
- Piwigo Display / diaporama / vidéo ;
- `Mes tarifs` alimenté depuis les données métier Noethys ;
- filtrage selon les inscriptions et types de comptes ;
- liens sociaux centralisés.

Closes part of #62.