### PR TITLE
Ajoute un socle minimal d’extensions

### DIFF
--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -1,0 +1,66 @@
+# Extensions Noethys Desktop
+
+## Objectif
+
+Permettre d'étendre progressivement Noethys Desktop sans transformer chaque intégration ou besoin local en dépendance du cœur historique.
+
+Le socle initial est volontairement minimal : un registre explicite d'extensions et de capacités. Aucun chargement automatique de code tiers n'est activé.
+
+## Principes
+
+- le cœur reste fonctionnel sans extension ;
+- une extension s'enregistre explicitement ;
+- aucun parcours automatique de dossiers ni import arbitraire n'est réalisé ;
+- les capacités servent à rechercher un service sans dépendre de son fournisseur ;
+- une extension ne doit pas modifier directement une autre extension ;
+- les dépendances entre extensions doivent rester exceptionnelles et explicites ;
+- les migrations de base éventuelles doivent être versionnées et réversibles lorsque raisonnable ;
+- les données métier existantes restent sous l'autorité du moteur Noethys concerné.
+
+## Exemple
+
+```python
+from Extensions import Extension, get_registry
+
+registry = get_registry()
+registry.register(
+    Extension(
+        "communication.sms.example",
+        "Passerelle SMS exemple",
+        version="1.0",
+        capabilities=("sms.send", "sms.status"),
+        factory=build_sms_provider,
+    )
+)
+```
+
+Le consommateur recherche ensuite une capacité plutôt qu'un fournisseur codé en dur :
+
+```python
+providers = get_registry().by_capability("sms.send")
+```
+
+## Capacités envisagées
+
+La liste n'est pas encore un contrat stable. Les premiers domaines candidats sont :
+
+- `email.send` / `email.status` ;
+- `sms.send` / `sms.status` ;
+- `export.*` pour les exports spécifiques ;
+- `report.*` pour les statistiques et rapports ;
+- `integration.dolibarr` ;
+- `integration.helloasso` ;
+- `integration.piwigo` ;
+- connecteurs et synchronisations externes.
+
+## Ce que ce socle ne fait pas encore
+
+- découverte automatique de plugins ;
+- installation/désinstallation depuis l'interface ;
+- téléchargement de code ;
+- permissions propres aux extensions ;
+- migrations de schéma pilotées par extension ;
+- hooks UI ;
+- hooks métier génériques.
+
+Ces fonctions ne seront ajoutées qu'en réponse à des besoins concrets. Le registre sert d'abord à découpler proprement les futurs fournisseurs et intégrations du cœur de Noethys.

--- a/noethys/Extensions/__init__.py
+++ b/noethys/Extensions/__init__.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+"""Infrastructure légère pour les extensions de Noethys Desktop.
+
+Le chargement automatique de code tiers n'est volontairement pas activé ici.
+Les extensions doivent être enregistrées explicitement afin de préserver la
+stabilité, la sécurité et la compatibilité historique de l'application.
+"""
+
+from .registry import Extension, ExtensionRegistry, get_registry
+
+__all__ = ["Extension", "ExtensionRegistry", "get_registry"]

--- a/noethys/Extensions/registry.py
+++ b/noethys/Extensions/registry.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+
+"""Registre minimal d'extensions pour Noethys Desktop.
+
+Ce module fournit un contrat simple et testable. Il ne réalise aucune
+Découverte automatique dans le système de fichiers et n'importe aucun code
+externe de manière implicite.
+"""
+
+
+class Extension(object):
+    """Description d'une extension enregistrable dans Noethys."""
+
+    def __init__(self, extension_id, name, version="", capabilities=None, factory=None):
+        extension_id = (extension_id or "").strip()
+        name = (name or "").strip()
+
+        if not extension_id:
+            raise ValueError("extension_id est obligatoire")
+        if not name:
+            raise ValueError("name est obligatoire")
+        if factory is not None and not callable(factory):
+            raise TypeError("factory doit être appelable ou None")
+
+        self.extension_id = extension_id
+        self.name = name
+        self.version = (version or "").strip()
+        self.capabilities = tuple(sorted(set(capabilities or ())))
+        self.factory = factory
+
+    def supports(self, capability):
+        return capability in self.capabilities
+
+    def create(self, *args, **kwargs):
+        if self.factory is None:
+            return None
+        return self.factory(*args, **kwargs)
+
+
+class ExtensionRegistry(object):
+    """Registre explicite, déterministe et sans chargement dynamique implicite."""
+
+    def __init__(self):
+        self._extensions = {}
+
+    def register(self, extension):
+        if not isinstance(extension, Extension):
+            raise TypeError("extension doit être une instance de Extension")
+        if extension.extension_id in self._extensions:
+            raise ValueError("Extension déjà enregistrée : %s" % extension.extension_id)
+        self._extensions[extension.extension_id] = extension
+        return extension
+
+    def unregister(self, extension_id):
+        return self._extensions.pop(extension_id, None)
+
+    def get(self, extension_id, default=None):
+        return self._extensions.get(extension_id, default)
+
+    def all(self):
+        return tuple(self._extensions[key] for key in sorted(self._extensions))
+
+    def by_capability(self, capability):
+        return tuple(
+            extension
+            for extension in self.all()
+            if extension.supports(capability)
+        )
+
+    def clear(self):
+        self._extensions.clear()
+
+
+_REGISTRY = ExtensionRegistry()
+
+
+def get_registry():
+    """Retourne le registre global de l'application."""
+    return _REGISTRY

--- a/tests/test_extensions_registry.py
+++ b/tests/test_extensions_registry.py
@@ -1,0 +1,52 @@
+from noethys.Extensions import Extension, ExtensionRegistry
+
+
+def test_register_and_lookup_extension():
+    registry = ExtensionRegistry()
+    extension = Extension(
+        "communication.sms.demo",
+        "Fournisseur SMS de démonstration",
+        version="1.0",
+        capabilities=("sms.send", "sms.status"),
+    )
+
+    registry.register(extension)
+
+    assert registry.get("communication.sms.demo") is extension
+    assert registry.all() == (extension,)
+    assert registry.by_capability("sms.send") == (extension,)
+    assert registry.by_capability("email.send") == ()
+
+
+def test_duplicate_extension_is_rejected():
+    registry = ExtensionRegistry()
+    registry.register(Extension("demo", "Démo"))
+
+    try:
+        registry.register(Extension("demo", "Autre démo"))
+    except ValueError as exc:
+        assert "déjà enregistrée" in str(exc)
+    else:
+        raise AssertionError("Une extension dupliquée doit être refusée")
+
+
+def test_factory_is_explicit_and_optional():
+    registry = ExtensionRegistry()
+    extension = registry.register(
+        Extension("demo.factory", "Démo factory", factory=lambda value: {"value": value})
+    )
+
+    assert extension.create(42) == {"value": 42}
+    assert Extension("demo.none", "Sans factory").create() is None
+
+
+def test_unregister_and_clear():
+    registry = ExtensionRegistry()
+    registry.register(Extension("a", "A"))
+    registry.register(Extension("b", "B"))
+
+    assert registry.unregister("a").extension_id == "a"
+    assert registry.get("a") is None
+
+    registry.clear()
+    assert registry.all() == ()


### PR DESCRIPTION
## Besoin
Préparer Noethys Desktop à accueillir des intégrations et modules optionnels sans ajouter chaque fournisseur ou besoin local directement dans le cœur historique.

## Solution
- ajoute `noethys/Extensions` avec un registre explicite ;
- définit un contrat minimal `Extension` : identifiant, nom, version, capacités, factory optionnelle ;
- interdit volontairement tout chargement automatique/arbitraire à ce stade ;
- ajoute des tests unitaires du registre ;
- documente le périmètre et les capacités envisagées.

## Compatibilité
Aucun comportement existant n’est modifié. Le registre n’est pas encore branché au démarrage de Noethys et reste totalement opt-in.

## Vérifications
Tests unitaires ajoutés dans `tests/test_extensions_registry.py`. La CI doit confirmer leur exécution dans l’environnement du dépôt.

## Limites
Cette PR ne fournit ni interface d’installation, ni découverte automatique, ni hooks UI/métier, ni migration de base propre aux extensions. Ces éléments seront ajoutés uniquement lorsque des besoins concrets le justifieront.

## Suite envisagée
Le premier usage réel pourra être l’abstraction des fournisseurs de communication (email/SMS), puis des exports/reportings ou connecteurs externes.