### PR TITLE
Noe-063B — Ajouter RSS / Atom natif au portail Connecthys

### DIFF
--- a/noethys/Ctrl/CTRL_Portail_contenu_externe.py
+++ b/noethys/Ctrl/CTRL_Portail_contenu_externe.py
@@ -19,15 +19,25 @@ class CTRL(wx.Panel):
         wx.Panel.__init__(self, parent, id=-1, style=wx.TAB_TRAVERSAL)
         self.parent = parent
         self.IDelement = None
+        self.texte_html_precedent = None
 
         self.label_intro = wx.StaticText(
             self,
             -1,
-            _(u"Affichez une page, une photothèque, un lecteur vidéo ou un widget web sans saisir de code HTML."),
+            _(u"Affichez une page, une photothèque, un lecteur vidéo ou un flux d'actualités sans saisir de code HTML."),
         )
+
+        self.label_type = wx.StaticText(self, -1, _(u"Type de contenu :"))
+        self.ctrl_type = wx.Choice(self, -1, choices=[
+            _(u"Page / widget web"),
+            _(u"Flux RSS / Atom"),
+        ])
+        self.ctrl_type.SetSelection(0)
+
         self.label_url = wx.StaticText(self, -1, _(u"Adresse (URL) :"))
         self.ctrl_url = wx.TextCtrl(self, -1, "")
 
+        # Options iframe
         self.label_titre = wx.StaticText(self, -1, _(u"Titre accessible :"))
         self.ctrl_titre = wx.TextCtrl(self, -1, "")
 
@@ -40,49 +50,82 @@ class CTRL(wx.Panel):
             initial=UTILS_Portail_contenus.HAUTEUR_DEFAUT,
         )
         self.label_pixels = wx.StaticText(self, -1, _(u"pixels"))
-
         self.ctrl_defilement = wx.CheckBox(self, -1, _(u"Autoriser les barres de défilement"))
         self.ctrl_plein_ecran = wx.CheckBox(self, -1, _(u"Autoriser le plein écran"))
         self.ctrl_plein_ecran.SetValue(True)
 
+        # Options RSS / Atom
+        self.label_nombre_articles = wx.StaticText(self, -1, _(u"Nombre d'actualités :"))
+        self.ctrl_nombre_articles = wx.SpinCtrl(
+            self,
+            -1,
+            min=UTILS_Portail_contenus.RSS_NOMBRE_MIN,
+            max=UTILS_Portail_contenus.RSS_NOMBRE_MAX,
+            initial=UTILS_Portail_contenus.RSS_NOMBRE_DEFAUT,
+        )
+        self.ctrl_afficher_date = wx.CheckBox(self, -1, _(u"Afficher la date"))
+        self.ctrl_afficher_date.SetValue(True)
+        self.ctrl_afficher_extrait = wx.CheckBox(self, -1, _(u"Afficher l'extrait"))
+        self.ctrl_afficher_extrait.SetValue(True)
+        self.ctrl_liens_nouvel_onglet = wx.CheckBox(self, -1, _(u"Ouvrir les articles dans un nouvel onglet"))
+        self.ctrl_liens_nouvel_onglet.SetValue(True)
+
         self.label_aide = wx.StaticText(
             self,
             -1,
-            _(u"Le bloc reste stocké comme un bloc Texte standard pour rester compatible avec les hébergements Connecthys existants."),
+            _(u"Le bloc reste compatible avec les hébergements Connecthys existants. Les flux RSS/Atom sont actualisés par Noethys lors de la synchronisation."),
         )
         self.label_aide.Wrap(500)
 
         self.__set_properties()
         self.__do_layout()
+        self.Bind(wx.EVT_CHOICE, self.OnChoixType, self.ctrl_type)
+        self.MAJAffichage()
 
     def __set_properties(self):
+        self.ctrl_type.SetToolTip(wx.ToolTip(_(u"Choisissez une page embarquée ou un flux d'actualités RSS/Atom")))
         self.ctrl_url.SetToolTip(wx.ToolTip(_(u"Saisissez une adresse complète commençant par http:// ou https://")))
-        self.ctrl_titre.SetToolTip(wx.ToolTip(_(u"Décrivez brièvement le contenu pour les lecteurs d'écran")))
+        self.ctrl_titre.SetToolTip(wx.ToolTip(_(u"Décrivez brièvement le contenu embarqué pour les lecteurs d'écran")))
         self.ctrl_hauteur.SetToolTip(wx.ToolTip(_(u"Hauteur d'affichage du contenu dans le portail famille")))
+        self.ctrl_nombre_articles.SetToolTip(wx.ToolTip(_(u"Nombre maximum d'actualités affichées dans le portail")))
 
     def __do_layout(self):
         sizer_base = wx.BoxSizer(wx.VERTICAL)
         sizer_base.Add(self.label_intro, 0, wx.LEFT | wx.RIGHT | wx.TOP | wx.EXPAND, 10)
 
-        grille = wx.FlexGridSizer(rows=3, cols=3, vgap=10, hgap=10)
-        grille.Add(self.label_url, 0, wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, 0)
-        grille.Add(self.ctrl_url, 0, wx.EXPAND, 0)
-        grille.Add((1, 1), 0, 0, 0)
+        grille_commune = wx.FlexGridSizer(rows=2, cols=2, vgap=10, hgap=10)
+        grille_commune.Add(self.label_type, 0, wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, 0)
+        grille_commune.Add(self.ctrl_type, 0, wx.EXPAND, 0)
+        grille_commune.Add(self.label_url, 0, wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, 0)
+        grille_commune.Add(self.ctrl_url, 0, wx.EXPAND, 0)
+        grille_commune.AddGrowableCol(1)
+        sizer_base.Add(grille_commune, 0, wx.ALL | wx.EXPAND, 10)
 
-        grille.Add(self.label_titre, 0, wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, 0)
-        grille.Add(self.ctrl_titre, 0, wx.EXPAND, 0)
-        grille.Add((1, 1), 0, 0, 0)
+        # Zone iframe
+        self.sizer_iframe = wx.BoxSizer(wx.VERTICAL)
+        grille_iframe = wx.FlexGridSizer(rows=2, cols=3, vgap=10, hgap=10)
+        grille_iframe.Add(self.label_titre, 0, wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, 0)
+        grille_iframe.Add(self.ctrl_titre, 0, wx.EXPAND, 0)
+        grille_iframe.Add((1, 1), 0, 0, 0)
+        grille_iframe.Add(self.label_hauteur, 0, wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, 0)
+        grille_iframe.Add(self.ctrl_hauteur, 0, 0, 0)
+        grille_iframe.Add(self.label_pixels, 0, wx.ALIGN_CENTER_VERTICAL, 0)
+        grille_iframe.AddGrowableCol(1)
+        self.sizer_iframe.Add(grille_iframe, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 10)
+        self.sizer_iframe.Add(self.ctrl_defilement, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 20)
+        self.sizer_iframe.Add(self.ctrl_plein_ecran, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 20)
+        sizer_base.Add(self.sizer_iframe, 0, wx.EXPAND, 0)
 
-        grille.Add(self.label_hauteur, 0, wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, 0)
-        grille.Add(self.ctrl_hauteur, 0, 0, 0)
-        grille.Add(self.label_pixels, 0, wx.ALIGN_CENTER_VERTICAL, 0)
-        grille.AddGrowableCol(1)
-        sizer_base.Add(grille, 0, wx.ALL | wx.EXPAND, 10)
-
-        sizer_options = wx.BoxSizer(wx.VERTICAL)
-        sizer_options.Add(self.ctrl_defilement, 0, wx.BOTTOM, 8)
-        sizer_options.Add(self.ctrl_plein_ecran, 0, 0, 0)
-        sizer_base.Add(sizer_options, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 20)
+        # Zone RSS
+        self.sizer_rss = wx.BoxSizer(wx.VERTICAL)
+        grille_rss = wx.FlexGridSizer(rows=1, cols=2, vgap=10, hgap=10)
+        grille_rss.Add(self.label_nombre_articles, 0, wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, 0)
+        grille_rss.Add(self.ctrl_nombre_articles, 0, 0, 0)
+        self.sizer_rss.Add(grille_rss, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 10)
+        self.sizer_rss.Add(self.ctrl_afficher_date, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 20)
+        self.sizer_rss.Add(self.ctrl_afficher_extrait, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 20)
+        self.sizer_rss.Add(self.ctrl_liens_nouvel_onglet, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 20)
+        sizer_base.Add(self.sizer_rss, 0, wx.EXPAND, 0)
 
         sizer_base.AddStretchSpacer(1)
         sizer_base.Add(self.label_aide, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 10)
@@ -90,16 +133,56 @@ class CTRL(wx.Panel):
         self.SetSizer(sizer_base)
         self.Layout()
 
+    def OnChoixType(self, event):
+        self.MAJAffichage()
+
+    def GetType(self):
+        if self.ctrl_type.GetSelection() == 1:
+            return UTILS_Portail_contenus.TYPE_RSS
+        return UTILS_Portail_contenus.TYPE_IFRAME
+
+    def SetType(self, type_contenu):
+        self.ctrl_type.SetSelection(1 if type_contenu == UTILS_Portail_contenus.TYPE_RSS else 0)
+        self.MAJAffichage()
+
+    def MAJAffichage(self):
+        rss = self.GetType() == UTILS_Portail_contenus.TYPE_RSS
+        for controle in (
+            self.label_titre, self.ctrl_titre,
+            self.label_hauteur, self.ctrl_hauteur, self.label_pixels,
+            self.ctrl_defilement, self.ctrl_plein_ecran,
+        ):
+            controle.Show(not rss)
+        for controle in (
+            self.label_nombre_articles, self.ctrl_nombre_articles,
+            self.ctrl_afficher_date, self.ctrl_afficher_extrait,
+            self.ctrl_liens_nouvel_onglet,
+        ):
+            controle.Show(rss)
+        self.Layout()
+
     def GetParametres(self):
         config = {
-            "type": "iframe",
+            "type": self.GetType(),
             "url": self.ctrl_url.GetValue(),
             "hauteur": self.ctrl_hauteur.GetValue(),
             "defilement": self.ctrl_defilement.GetValue(),
             "plein_ecran": self.ctrl_plein_ecran.GetValue(),
             "titre": self.ctrl_titre.GetValue(),
+            "nombre_articles": self.ctrl_nombre_articles.GetValue(),
+            "afficher_date": self.ctrl_afficher_date.GetValue(),
+            "afficher_extrait": self.ctrl_afficher_extrait.GetValue(),
+            "liens_nouvel_onglet": self.ctrl_liens_nouvel_onglet.GetValue(),
         }
         config = UTILS_Portail_contenus.normaliser_parametres(config)
+
+        if config["type"] == UTILS_Portail_contenus.TYPE_IFRAME:
+            texte_html = UTILS_Portail_contenus.construire_iframe(config)
+        else:
+            # Ne déclenche aucune requête réseau depuis la fenêtre de saisie.
+            # La synchronisation actualisera le flux et remplacera ce cache.
+            texte_html = self.texte_html_precedent or UTILS_Portail_contenus.construire_placeholder_flux()
+
         dictElement = {
             "IDelement": self.IDelement,
             "titre": "",
@@ -107,7 +190,7 @@ class CTRL(wx.Panel):
             "date_fin": None,
             "parametres": UTILS_Portail_contenus.serialiser_parametres(config),
             "texte_xml": None,
-            "texte_html": UTILS_Portail_contenus.construire_iframe(config),
+            "texte_html": texte_html,
         }
         return {"elements": [dictElement]}
 
@@ -119,12 +202,19 @@ class CTRL(wx.Panel):
 
         dictElement = elements[0]
         self.IDelement = dictElement.get("IDelement")
+        self.texte_html_precedent = dictElement.get("texte_html")
         config = UTILS_Portail_contenus.deserialiser_parametres(dictElement.get("parametres"))
+        self.SetType(config["type"])
         self.ctrl_url.SetValue(config["url"])
         self.ctrl_titre.SetValue(config["titre"])
         self.ctrl_hauteur.SetValue(config["hauteur"])
         self.ctrl_defilement.SetValue(config["defilement"])
         self.ctrl_plein_ecran.SetValue(config["plein_ecran"])
+        self.ctrl_nombre_articles.SetValue(config["nombre_articles"])
+        self.ctrl_afficher_date.SetValue(config["afficher_date"])
+        self.ctrl_afficher_extrait.SetValue(config["afficher_extrait"])
+        self.ctrl_liens_nouvel_onglet.SetValue(config["liens_nouvel_onglet"])
+        self.MAJAffichage()
 
     def Validation(self):
         url = self.ctrl_url.GetValue()

--- a/noethys/Ctrl/CTRL_Portail_serveur.py
+++ b/noethys/Ctrl/CTRL_Portail_serveur.py
@@ -22,6 +22,7 @@ from Utils import UTILS_Parametres
 from Utils import UTILS_Fichiers
 from Utils import UTILS_Customize
 from Utils import UTILS_Portail_synchro
+from Utils import UTILS_Portail_contenus_synchro
 from Dlg.DLG_Portail_config import LISTE_DELAIS_SYNCHRO
 import six
 CUSTOMIZE = UTILS_Customize.Customize()
@@ -98,6 +99,15 @@ class Serveur(Thread):
                         # Effectue la synchro
                         self.parent.SetImage("upload")
                         self.synchro_en_cours = True
+
+                        # Actualise les contenus dynamiques avant le moteur de
+                        # synchro historique. Une panne RSS ne doit jamais
+                        # empêcher le reste de Connecthys de se synchroniser.
+                        try:
+                            UTILS_Portail_contenus_synchro.preparer_avant_synchro(log=self.parent)
+                        except Exception as err:
+                            self.parent.EcritLog(_(u"[AVERTISSEMENT] Actualisation des contenus dynamiques impossible : %s") % err)
+
                         synchro = UTILS_Portail_synchro.Synchro(log=self.parent)
                         synchro.Synchro_totale()
                         self.synchro_en_cours = False

--- a/noethys/Utils/UTILS_Portail_contenus.py
+++ b/noethys/Utils/UTILS_Portail_contenus.py
@@ -8,25 +8,65 @@
 
 """Helpers purs pour les contenus dynamiques du portail Connecthys.
 
-Le premier objectif est volontairement limité : permettre à Noethys de
-conserver une configuration enrichie localement tout en exportant vers un
-Connecthys historique un bloc texte HTML parfaitement compatible.
-
-Ce module ne dépend ni de wxPython, ni de la base de données, ni du réseau.
+Noethys conserve une configuration enrichie localement mais exporte vers un
+Connecthys historique un bloc texte HTML compatible. Les contenus RSS/Atom
+sont transformés en HTML sûr par Noethys : aucun HTML provenant du flux n'est
+injecté tel quel dans le portail.
 """
 
+import datetime
 import html
 import json
+from email.utils import parsedate_to_datetime
+from html.parser import HTMLParser
 from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+import xml.etree.ElementTree as ET
 
 
 CATEGORIE_CONTENU_EXTERNE = "bloc_contenu_externe"
 CATEGORIE_CONNECTHYS_TEXTE = "bloc_texte"
 MARQUEUR_CONTENU_EXTERNE = "noethys_portail_contenu_externe"
 
+TYPE_IFRAME = "iframe"
+TYPE_RSS = "rss"
+
 HAUTEUR_MIN = 120
 HAUTEUR_MAX = 3000
 HAUTEUR_DEFAUT = 600
+
+RSS_NOMBRE_MIN = 1
+RSS_NOMBRE_MAX = 20
+RSS_NOMBRE_DEFAUT = 5
+RSS_TIMEOUT_DEFAUT = 5
+RSS_TAILLE_MAX = 2 * 1024 * 1024
+RSS_EXTRAIT_MAX = 600
+
+
+class _TexteHTMLParser(HTMLParser):
+    def __init__(self):
+        HTMLParser.__init__(self)
+        self.fragments = []
+
+    def handle_data(self, data):
+        if data:
+            self.fragments.append(data)
+
+    def texte(self):
+        return " ".join(" ".join(self.fragments).split())
+
+
+def texte_sans_html(valeur):
+    """Convertit un fragment HTML/XML externe en texte brut compact."""
+    if valeur is None:
+        return ""
+    parser = _TexteHTMLParser()
+    try:
+        parser.feed(str(valeur))
+        parser.close()
+        return html.unescape(parser.texte())
+    except Exception:
+        return " ".join(str(valeur).split())
 
 
 def normaliser_url(url):
@@ -37,7 +77,7 @@ def normaliser_url(url):
 
 
 def url_externe_valide(url):
-    """Accepte uniquement les URL HTTP(S) absolues pour un contenu embarqué."""
+    """Accepte uniquement les URL HTTP(S) absolues."""
     url = normaliser_url(url)
     if not url:
         return False
@@ -57,18 +97,33 @@ def normaliser_hauteur(hauteur):
     return max(HAUTEUR_MIN, min(HAUTEUR_MAX, valeur))
 
 
+def normaliser_nombre_articles(nombre):
+    try:
+        valeur = int(nombre)
+    except (TypeError, ValueError):
+        valeur = RSS_NOMBRE_DEFAUT
+    return max(RSS_NOMBRE_MIN, min(RSS_NOMBRE_MAX, valeur))
+
+
 def normaliser_parametres(parametres=None):
     """Retourne la configuration canonique d'un bloc de contenu externe."""
     source = dict(parametres or {})
+    type_contenu = source.get("type", TYPE_IFRAME)
+    if type_contenu not in (TYPE_IFRAME, TYPE_RSS):
+        type_contenu = TYPE_IFRAME
     return {
         "source": MARQUEUR_CONTENU_EXTERNE,
         "version": 1,
-        "type": source.get("type", "iframe"),
+        "type": type_contenu,
         "url": normaliser_url(source.get("url", "")),
         "hauteur": normaliser_hauteur(source.get("hauteur", HAUTEUR_DEFAUT)),
         "defilement": bool(source.get("defilement", False)),
         "plein_ecran": bool(source.get("plein_ecran", True)),
         "titre": str(source.get("titre", "") or "").strip(),
+        "nombre_articles": normaliser_nombre_articles(source.get("nombre_articles", RSS_NOMBRE_DEFAUT)),
+        "afficher_date": bool(source.get("afficher_date", True)),
+        "afficher_extrait": bool(source.get("afficher_extrait", True)),
+        "liens_nouvel_onglet": bool(source.get("liens_nouvel_onglet", True)),
     }
 
 
@@ -99,6 +154,13 @@ def est_configuration_contenu_externe(valeur):
     return _charger_json(valeur).get("source") == MARQUEUR_CONTENU_EXTERNE
 
 
+def est_configuration_dynamique(valeur):
+    """Indique si le bloc doit être régénéré à chaque synchronisation."""
+    if not est_configuration_contenu_externe(valeur):
+        return False
+    return deserialiser_parametres(valeur)["type"] == TYPE_RSS
+
+
 def deserialiser_parametres(valeur):
     """Lit une configuration sauvegardée et retombe sur les valeurs par défaut."""
     return normaliser_parametres(_charger_json(valeur))
@@ -107,8 +169,8 @@ def deserialiser_parametres(valeur):
 def construire_iframe(parametres=None):
     """Construit le HTML compatible avec un bloc texte Connecthys historique."""
     config = normaliser_parametres(parametres)
-    if config["type"] != "iframe":
-        raise ValueError("Type de contenu externe non pris en charge : %s" % config["type"])
+    if config["type"] != TYPE_IFRAME:
+        raise ValueError("Type de contenu externe non pris en charge par l'iframe : %s" % config["type"])
     if not url_externe_valide(config["url"]):
         raise ValueError("URL externe invalide")
 
@@ -131,6 +193,178 @@ def construire_iframe(parametres=None):
         texte_attributs += " allowfullscreen"
 
     return '<iframe %s></iframe>' % texte_attributs
+
+
+def _nom_local(tag):
+    return str(tag).rsplit("}", 1)[-1].lower()
+
+
+def _enfant_texte(element, noms):
+    noms = set(x.lower() for x in noms)
+    for enfant in list(element):
+        if _nom_local(enfant.tag) in noms:
+            return "".join(enfant.itertext()).strip()
+    return ""
+
+
+def _lien_atom(entry):
+    repli = ""
+    for enfant in list(entry):
+        if _nom_local(enfant.tag) != "link":
+            continue
+        href = normaliser_url(enfant.attrib.get("href", ""))
+        rel = enfant.attrib.get("rel", "alternate").lower()
+        if href and rel in ("", "alternate"):
+            return href
+        if href and not repli:
+            repli = href
+    return repli
+
+
+def _date_affichable(valeur):
+    valeur = (valeur or "").strip()
+    if not valeur:
+        return ""
+    date = None
+    try:
+        date = parsedate_to_datetime(valeur)
+    except (TypeError, ValueError, OverflowError):
+        pass
+    if date is None:
+        try:
+            date = datetime.datetime.fromisoformat(valeur.replace("Z", "+00:00"))
+        except (TypeError, ValueError):
+            return ""
+    return date.strftime("%d/%m/%Y")
+
+
+def _article(titre="", lien="", extrait="", date=""):
+    titre = texte_sans_html(titre).strip() or "Actualité"
+    extrait = texte_sans_html(extrait).strip()
+    if len(extrait) > RSS_EXTRAIT_MAX:
+        extrait = extrait[:RSS_EXTRAIT_MAX].rstrip() + "…"
+    lien = normaliser_url(lien)
+    if not url_externe_valide(lien):
+        lien = ""
+    return {
+        "titre": titre,
+        "lien": lien,
+        "extrait": extrait,
+        "date": _date_affichable(date),
+    }
+
+
+def parser_flux_rss_atom(contenu):
+    """Parse RSS 2.0 ou Atom et retourne une liste d'articles normalisés."""
+    if isinstance(contenu, str):
+        contenu = contenu.encode("utf-8")
+    try:
+        racine = ET.fromstring(contenu)
+    except (ET.ParseError, TypeError, ValueError) as err:
+        raise ValueError("Flux XML invalide : %s" % err)
+
+    nom_racine = _nom_local(racine.tag)
+    articles = []
+
+    if nom_racine == "rss":
+        channel = None
+        for enfant in list(racine):
+            if _nom_local(enfant.tag) == "channel":
+                channel = enfant
+                break
+        if channel is None:
+            raise ValueError("Flux RSS sans canal")
+        for item in list(channel):
+            if _nom_local(item.tag) != "item":
+                continue
+            articles.append(_article(
+                titre=_enfant_texte(item, ("title",)),
+                lien=_enfant_texte(item, ("link",)),
+                extrait=_enfant_texte(item, ("description", "summary", "content")),
+                date=_enfant_texte(item, ("pubdate", "date", "updated", "published")),
+            ))
+
+    elif nom_racine == "feed":
+        for entry in list(racine):
+            if _nom_local(entry.tag) != "entry":
+                continue
+            articles.append(_article(
+                titre=_enfant_texte(entry, ("title",)),
+                lien=_lien_atom(entry),
+                extrait=_enfant_texte(entry, ("summary", "content", "description")),
+                date=_enfant_texte(entry, ("updated", "published", "date")),
+            ))
+    else:
+        raise ValueError("Format de flux non pris en charge")
+
+    if not articles:
+        raise ValueError("Le flux ne contient aucune actualité exploitable")
+    return articles
+
+
+def telecharger_flux(url, timeout=RSS_TIMEOUT_DEFAUT, taille_max=RSS_TAILLE_MAX, ouvreur=None):
+    """Télécharge un flux avec délai et taille bornés."""
+    if not url_externe_valide(url):
+        raise ValueError("URL de flux invalide")
+    ouvreur = ouvreur or urlopen
+    requete = Request(url, headers={"User-Agent": "Noethys/Connecthys RSS"})
+    reponse = ouvreur(requete, timeout=timeout)
+    try:
+        contenu = reponse.read(taille_max + 1)
+    finally:
+        try:
+            reponse.close()
+        except Exception:
+            pass
+    if len(contenu) > taille_max:
+        raise ValueError("Flux trop volumineux")
+    return contenu
+
+
+def construire_flux_html(parametres=None, contenu=None, ouvreur=None):
+    """Construit un rendu HTML sûr à partir d'un flux RSS/Atom."""
+    config = normaliser_parametres(parametres)
+    if config["type"] != TYPE_RSS:
+        raise ValueError("Ce bloc n'est pas un flux RSS/Atom")
+    if not url_externe_valide(config["url"]):
+        raise ValueError("URL de flux invalide")
+
+    if contenu is None:
+        contenu = telecharger_flux(config["url"], ouvreur=ouvreur)
+    articles = parser_flux_rss_atom(contenu)[:config["nombre_articles"]]
+
+    rendu = ['<div class="noethys-rss">']
+    for article in articles:
+        rendu.append('<article style="padding:10px 0;border-bottom:1px solid #ddd;">')
+        titre = html.escape(article["titre"], quote=True)
+        if article["lien"]:
+            cible = ' target="_blank" rel="noopener noreferrer"' if config["liens_nouvel_onglet"] else ""
+            rendu.append('<div style="font-weight:600;"><a href="%s"%s>%s</a></div>' % (
+                html.escape(article["lien"], quote=True), cible, titre))
+        else:
+            rendu.append('<div style="font-weight:600;">%s</div>' % titre)
+
+        if config["afficher_date"] and article["date"]:
+            rendu.append('<div style="font-size:0.9em;opacity:0.75;">%s</div>' % html.escape(article["date"], quote=True))
+        if config["afficher_extrait"] and article["extrait"]:
+            rendu.append('<div style="margin-top:4px;">%s</div>' % html.escape(article["extrait"], quote=True))
+        rendu.append('</article>')
+    rendu.append('</div>')
+    return "".join(rendu)
+
+
+def construire_placeholder_flux():
+    return '<div class="noethys-rss"><p>Le flux d’actualités sera chargé lors de la prochaine synchronisation.</p></div>'
+
+
+def construire_html(parametres=None, contenu=None, ouvreur=None):
+    """Point d'entrée commun pour fabriquer le HTML d'un contenu externe."""
+    config = normaliser_parametres(parametres)
+    if config["type"] == TYPE_IFRAME:
+        return construire_iframe(config)
+    if config["type"] == TYPE_RSS:
+        return construire_flux_html(config, contenu=contenu, ouvreur=ouvreur)
+    raise ValueError("Type de contenu externe non pris en charge")
 
 
 def categorie_pour_connecthys(categorie):

--- a/noethys/Utils/UTILS_Portail_contenus_synchro.py
+++ b/noethys/Utils/UTILS_Portail_contenus_synchro.py
@@ -13,6 +13,8 @@ politique de cache et de panne réseau sans démarrer le moteur complet de
 synchronisation.
 """
 
+import datetime
+
 from Utils import UTILS_Portail_contenus
 
 
@@ -73,5 +75,60 @@ def actualiser(DB, log=None, constructeur=None):
             else:
                 etat["erreurs"] += 1
                 _log(log, u"[AVERTISSEMENT] Impossible de mettre à jour le cache du flux RSS/Atom %s." % IDelement)
+
+    return etat
+
+
+def preparer_avant_synchro(log=None, db_factory=None, parametre_setter=None,
+                            constructeur=None, maintenant=None):
+    """Prépare les contenus dynamiques avant le moteur Connecthys historique.
+
+    Cette fonction est volontairement appelée *avant* ``Synchro_totale`` :
+    elle actualise le cache local puis marque les pages comme modifiées afin
+    que le moteur historique les réexporte normalement. On évite ainsi toute
+    modification du protocole Connecthys ou de son schéma de données.
+    """
+    if db_factory is None:
+        import GestionDB
+        db_factory = GestionDB.DB
+    if parametre_setter is None:
+        from Utils import UTILS_Parametres
+        parametre_setter = UTILS_Parametres.Parametres
+
+    DB = db_factory()
+    etat = {"present": False, "modifies": 0, "erreurs": 0}
+    try:
+        etat = actualiser(DB, log=log, constructeur=constructeur)
+        if etat["modifies"]:
+            try:
+                DB.Commit()
+            except Exception as err:
+                etat["erreurs"] += 1
+                _log(log, u"[AVERTISSEMENT] Impossible d'enregistrer le cache RSS/Atom (%s)." % err)
+                try:
+                    DB.connexion.rollback()
+                except Exception:
+                    pass
+    finally:
+        try:
+            DB.Close()
+        except Exception:
+            pass
+
+    # Le moteur historique n'exporte les pages que si last_update_pages est
+    # postérieur à last_synchro. Un flux dynamique doit donc marquer les pages
+    # à chaque passage, même si son contenu n'a finalement pas changé.
+    if etat["present"]:
+        instant = maintenant or datetime.datetime.now()
+        try:
+            parametre_setter(
+                mode="set",
+                categorie="portail",
+                nom="last_update_pages",
+                valeur=str(instant),
+            )
+        except Exception as err:
+            etat["erreurs"] += 1
+            _log(log, u"[AVERTISSEMENT] Impossible de forcer l'export du flux RSS/Atom (%s)." % err)
 
     return etat

--- a/noethys/Utils/UTILS_Portail_contenus_synchro.py
+++ b/noethys/Utils/UTILS_Portail_contenus_synchro.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#------------------------------------------------------------------------
+# Application :    Noethys, gestion multi-activités
+# Site internet :  www.noethys.com
+# Licence:          GNU GPL
+#------------------------------------------------------------------------
+
+"""Actualisation des contenus dynamiques avant export Connecthys.
+
+Le module reste séparé de ``UTILS_Portail_synchro`` afin de pouvoir tester la
+politique de cache et de panne réseau sans démarrer le moteur complet de
+synchronisation.
+"""
+
+from Utils import UTILS_Portail_contenus
+
+
+def _log(log, message):
+    try:
+        log.EcritLog(message)
+    except Exception:
+        pass
+
+
+def actualiser(DB, log=None, constructeur=None):
+    """Actualise les blocs dynamiques et leur cache HTML local.
+
+    Le commit reste volontairement à la charge de l'appelant. En cas d'échec
+    d'un flux, le ``texte_html`` existant n'est jamais modifié : le dernier
+    rendu valide reste donc disponible pour l'export suivant.
+
+    Retourne un état exploitable par le moteur principal : ``present`` permet
+    de forcer l'export des pages à chaque synchronisation.
+    """
+    constructeur = constructeur or UTILS_Portail_contenus.construire_html
+    etat = {"present": False, "modifies": 0, "erreurs": 0}
+
+    req = """SELECT IDelement, parametres, texte_html
+    FROM portail_elements
+    WHERE parametres IS NOT NULL;"""
+    if not DB.ExecuterReq(req):
+        return etat
+
+    for IDelement, parametres, texte_html in DB.ResultatReq():
+        if not UTILS_Portail_contenus.est_configuration_dynamique(parametres):
+            continue
+
+        etat["present"] = True
+        config = UTILS_Portail_contenus.deserialiser_parametres(parametres)
+        try:
+            nouveau_html = constructeur(config)
+        except Exception as err:
+            etat["erreurs"] += 1
+            _log(log, u"[AVERTISSEMENT] Flux RSS/Atom indisponible (%s). Dernière version conservée." % err)
+            continue
+
+        if isinstance(texte_html, bytes):
+            texte_compare = texte_html.decode("utf-8", "replace")
+        else:
+            texte_compare = texte_html
+
+        if nouveau_html != texte_compare:
+            succes = DB.ReqMAJ(
+                "portail_elements",
+                [("texte_html", nouveau_html)],
+                "IDelement",
+                IDelement,
+                commit=False,
+            )
+            if succes:
+                etat["modifies"] += 1
+            else:
+                etat["erreurs"] += 1
+                _log(log, u"[AVERTISSEMENT] Impossible de mettre à jour le cache du flux RSS/Atom %s." % IDelement)
+
+    return etat

--- a/tests/test_portail_contenus_dynamiques.py
+++ b/tests/test_portail_contenus_dynamiques.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import importlib.util
+import unittest
 from pathlib import Path
 
 
@@ -42,131 +43,119 @@ ATOM_EXEMPLE = b'''<?xml version="1.0" encoding="utf-8"?>
 </feed>'''
 
 
-def test_url_externe_accepte_uniquement_http_et_https():
-    assert PORTAIL.url_externe_valide("https://phototheque.example.org/album/12") is True
-    assert PORTAIL.url_externe_valide("http://example.org/feed") is True
-    assert PORTAIL.url_externe_valide("javascript:alert(1)") is False
-    assert PORTAIL.url_externe_valide("file:///tmp/test.html") is False
-    assert PORTAIL.url_externe_valide("example.org/sans-schema") is False
+class PortailContenusDynamiquesTests(unittest.TestCase):
+
+    def test_url_externe_accepte_uniquement_http_et_https(self):
+        self.assertTrue(PORTAIL.url_externe_valide("https://phototheque.example.org/album/12"))
+        self.assertTrue(PORTAIL.url_externe_valide("http://example.org/feed"))
+        self.assertFalse(PORTAIL.url_externe_valide("javascript:alert(1)"))
+        self.assertFalse(PORTAIL.url_externe_valide("file:///tmp/test.html"))
+        self.assertFalse(PORTAIL.url_externe_valide("example.org/sans-schema"))
+
+    def test_iframe_est_responsive_et_echappe_les_attributs(self):
+        rendu = PORTAIL.construire_iframe({
+            "url": "https://example.org/view?x=1&y=2",
+            "hauteur": 826,
+            "defilement": False,
+            "plein_ecran": True,
+            "titre": 'Photothèque "été"',
+        })
+        self.assertIn('src="https://example.org/view?x=1&amp;y=2"', rendu)
+        self.assertIn('width="100%"', rendu)
+        self.assertIn('height="826"', rendu)
+        self.assertIn('scrolling="no"', rendu)
+        self.assertIn('title="Photothèque &quot;été&quot;"', rendu)
+        self.assertIn(" allowfullscreen", rendu)
+        self.assertNotIn("javascript:", rendu)
+
+    def test_hauteur_est_bornee_et_serialisation_est_stable(self):
+        self.assertEqual(PORTAIL.normaliser_hauteur(50), PORTAIL.HAUTEUR_MIN)
+        self.assertEqual(PORTAIL.normaliser_hauteur(9999), PORTAIL.HAUTEUR_MAX)
+        self.assertEqual(PORTAIL.normaliser_hauteur("invalide"), PORTAIL.HAUTEUR_DEFAUT)
+        brut = PORTAIL.serialiser_parametres({
+            "url": " https://example.org/widget ",
+            "hauteur": "700",
+            "defilement": 1,
+        })
+        relu = PORTAIL.deserialiser_parametres(brut)
+        self.assertEqual(relu["source"], PORTAIL.MARQUEUR_CONTENU_EXTERNE)
+        self.assertEqual(relu["url"], "https://example.org/widget")
+        self.assertEqual(relu["hauteur"], 700)
+        self.assertTrue(relu["defilement"])
+        self.assertTrue(relu["plein_ecran"])
+        self.assertEqual(relu["version"], 1)
+        self.assertTrue(PORTAIL.est_configuration_contenu_externe(brut))
+        self.assertFalse(PORTAIL.est_configuration_contenu_externe('{"foo":"bar"}'))
+        self.assertFalse(PORTAIL.est_configuration_contenu_externe("ancien paramètre"))
+
+    def test_categorie_locale_est_exportee_comme_bloc_texte_connecthys(self):
+        self.assertEqual(PORTAIL.categorie_pour_connecthys("bloc_contenu_externe"), "bloc_texte")
+        self.assertEqual(PORTAIL.categorie_pour_connecthys("bloc_blog"), "bloc_blog")
+
+    def test_rss_est_parse_en_texte_sur_et_limite(self):
+        articles = PORTAIL.parser_flux_rss_atom(RSS_EXEMPLE)
+        self.assertEqual(len(articles), 2)
+        self.assertEqual(articles[0]["titre"], "Stage & vacances")
+        self.assertEqual(articles[0]["lien"], "https://example.org/stage?x=1&y=2")
+        self.assertEqual(articles[0]["date"], "20/08/2026")
+        self.assertNotIn("<strong>", articles[0]["extrait"])
+        self.assertNotIn("<script>", articles[0]["extrait"])
+        self.assertIn("stage", articles[0]["extrait"])
+        self.assertEqual(articles[1]["lien"], "")
+
+        rendu = PORTAIL.construire_flux_html({
+            "type": "rss",
+            "url": "https://example.org/feed",
+            "nombre_articles": 1,
+            "afficher_date": True,
+            "afficher_extrait": True,
+            "liens_nouvel_onglet": True,
+        }, contenu=RSS_EXEMPLE)
+        self.assertIn("Stage &amp; vacances", rendu)
+        self.assertNotIn("Deuxieme actualite", rendu)
+        self.assertIn('href="https://example.org/stage?x=1&amp;y=2"', rendu)
+        self.assertIn('target="_blank"', rendu)
+        self.assertIn("20/08/2026", rendu)
+        self.assertNotIn("<script>", rendu)
+
+    def test_atom_est_parse_et_rendu_sans_html_externe(self):
+        articles = PORTAIL.parser_flux_rss_atom(ATOM_EXEMPLE)
+        self.assertEqual(articles, [{
+            "titre": "Actualite Atom",
+            "lien": "https://example.org/atom",
+            "extrait": "Resume Atom",
+            "date": "20/08/2026",
+        }])
+        rendu = PORTAIL.construire_flux_html({
+            "type": "rss",
+            "url": "https://example.org/atom.xml",
+            "afficher_date": False,
+            "afficher_extrait": False,
+        }, contenu=ATOM_EXEMPLE)
+        self.assertIn("Actualite Atom", rendu)
+        self.assertNotIn("Resume Atom", rendu)
+        self.assertNotIn("20/08/2026", rendu)
+
+    def test_configuration_rss_est_dynamique_et_bornee(self):
+        brut = PORTAIL.serialiser_parametres({
+            "type": "rss",
+            "url": "https://example.org/feed",
+            "nombre_articles": 999,
+        })
+        config = PORTAIL.deserialiser_parametres(brut)
+        self.assertEqual(config["type"], PORTAIL.TYPE_RSS)
+        self.assertEqual(config["nombre_articles"], PORTAIL.RSS_NOMBRE_MAX)
+        self.assertTrue(PORTAIL.est_configuration_dynamique(brut))
+        iframe = PORTAIL.serialiser_parametres({
+            "type": "iframe",
+            "url": "https://example.org/widget",
+        })
+        self.assertFalse(PORTAIL.est_configuration_dynamique(iframe))
+
+    def test_flux_invalide_est_refuse(self):
+        with self.assertRaisesRegex(ValueError, "non pris en charge"):
+            PORTAIL.parser_flux_rss_atom(b"<html><body>pas un flux</body></html>")
 
 
-def test_iframe_est_responsive_et_echappe_les_attributs():
-    rendu = PORTAIL.construire_iframe({
-        "url": "https://example.org/view?x=1&y=2",
-        "hauteur": 826,
-        "defilement": False,
-        "plein_ecran": True,
-        "titre": 'Photothèque "été"',
-    })
-
-    assert 'src="https://example.org/view?x=1&amp;y=2"' in rendu
-    assert 'width="100%"' in rendu
-    assert 'height="826"' in rendu
-    assert 'scrolling="no"' in rendu
-    assert 'title="Photothèque &quot;été&quot;"' in rendu
-    assert " allowfullscreen" in rendu
-    assert "javascript:" not in rendu
-
-
-def test_hauteur_est_bornee_et_serialisation_est_stable():
-    assert PORTAIL.normaliser_hauteur(50) == PORTAIL.HAUTEUR_MIN
-    assert PORTAIL.normaliser_hauteur(9999) == PORTAIL.HAUTEUR_MAX
-    assert PORTAIL.normaliser_hauteur("invalide") == PORTAIL.HAUTEUR_DEFAUT
-
-    brut = PORTAIL.serialiser_parametres({
-        "url": " https://example.org/widget ",
-        "hauteur": "700",
-        "defilement": 1,
-    })
-    relu = PORTAIL.deserialiser_parametres(brut)
-
-    assert relu["source"] == PORTAIL.MARQUEUR_CONTENU_EXTERNE
-    assert relu["url"] == "https://example.org/widget"
-    assert relu["hauteur"] == 700
-    assert relu["defilement"] is True
-    assert relu["plein_ecran"] is True
-    assert relu["version"] == 1
-    assert PORTAIL.est_configuration_contenu_externe(brut) is True
-    assert PORTAIL.est_configuration_contenu_externe('{"foo":"bar"}') is False
-    assert PORTAIL.est_configuration_contenu_externe("ancien paramètre") is False
-
-
-def test_categorie_locale_est_exportee_comme_bloc_texte_connecthys():
-    assert PORTAIL.categorie_pour_connecthys("bloc_contenu_externe") == "bloc_texte"
-    assert PORTAIL.categorie_pour_connecthys("bloc_blog") == "bloc_blog"
-
-
-def test_rss_est_parse_en_texte_sur_et_limite():
-    articles = PORTAIL.parser_flux_rss_atom(RSS_EXEMPLE)
-    assert len(articles) == 2
-    assert articles[0]["titre"] == "Stage & vacances"
-    assert articles[0]["lien"] == "https://example.org/stage?x=1&y=2"
-    assert articles[0]["date"] == "20/08/2026"
-    assert "<strong>" not in articles[0]["extrait"]
-    assert "<script>" not in articles[0]["extrait"]
-    assert "stage" in articles[0]["extrait"]
-    assert articles[1]["lien"] == ""
-
-    rendu = PORTAIL.construire_flux_html({
-        "type": "rss",
-        "url": "https://example.org/feed",
-        "nombre_articles": 1,
-        "afficher_date": True,
-        "afficher_extrait": True,
-        "liens_nouvel_onglet": True,
-    }, contenu=RSS_EXEMPLE)
-
-    assert "Stage &amp; vacances" in rendu
-    assert "Deuxieme actualite" not in rendu
-    assert 'href="https://example.org/stage?x=1&amp;y=2"' in rendu
-    assert 'target="_blank"' in rendu
-    assert "20/08/2026" in rendu
-    assert "<script>" not in rendu
-    assert "alert(1)" in rendu  # contenu traité comme texte, jamais comme script
-
-
-def test_atom_est_parse_et_rendu_sans_html_externe():
-    articles = PORTAIL.parser_flux_rss_atom(ATOM_EXEMPLE)
-    assert articles == [{
-        "titre": "Actualite Atom",
-        "lien": "https://example.org/atom",
-        "extrait": "Resume Atom",
-        "date": "20/08/2026",
-    }]
-
-    rendu = PORTAIL.construire_flux_html({
-        "type": "rss",
-        "url": "https://example.org/atom.xml",
-        "afficher_date": False,
-        "afficher_extrait": False,
-    }, contenu=ATOM_EXEMPLE)
-    assert "Actualite Atom" in rendu
-    assert "Resume Atom" not in rendu
-    assert "20/08/2026" not in rendu
-
-
-def test_configuration_rss_est_dynamique_et_bornee():
-    brut = PORTAIL.serialiser_parametres({
-        "type": "rss",
-        "url": "https://example.org/feed",
-        "nombre_articles": 999,
-    })
-    config = PORTAIL.deserialiser_parametres(brut)
-    assert config["type"] == PORTAIL.TYPE_RSS
-    assert config["nombre_articles"] == PORTAIL.RSS_NOMBRE_MAX
-    assert PORTAIL.est_configuration_dynamique(brut) is True
-
-    iframe = PORTAIL.serialiser_parametres({
-        "type": "iframe",
-        "url": "https://example.org/widget",
-    })
-    assert PORTAIL.est_configuration_dynamique(iframe) is False
-
-
-def test_flux_invalide_est_refuse():
-    try:
-        PORTAIL.parser_flux_rss_atom(b"<html><body>pas un flux</body></html>")
-    except ValueError as err:
-        assert "non pris en charge" in str(err)
-    else:
-        raise AssertionError("Un document HTML ne doit pas être accepté comme RSS/Atom")
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_portail_contenus_dynamiques.py
+++ b/tests/test_portail_contenus_dynamiques.py
@@ -12,6 +12,36 @@ PORTAIL = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(PORTAIL)
 
 
+RSS_EXEMPLE = b'''<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Pele-Mele</title>
+    <item>
+      <title>Stage &amp; vacances</title>
+      <link>https://example.org/stage?x=1&amp;y=2</link>
+      <description><![CDATA[<p>Un <strong>stage</strong> pour les enfants.</p><script>alert(1)</script>]]></description>
+      <pubDate>Thu, 20 Aug 2026 12:30:00 +0200</pubDate>
+    </item>
+    <item>
+      <title>Deuxieme actualite</title>
+      <link>javascript:alert(1)</link>
+      <description>Texte simple</description>
+    </item>
+  </channel>
+</rss>'''
+
+ATOM_EXEMPLE = b'''<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Pele-Mele</title>
+  <entry>
+    <title>Actualite Atom</title>
+    <link href="https://example.org/atom" rel="alternate" />
+    <updated>2026-08-20T12:30:00+02:00</updated>
+    <summary type="html">&lt;p&gt;Resume Atom&lt;/p&gt;</summary>
+  </entry>
+</feed>'''
+
+
 def test_url_externe_accepte_uniquement_http_et_https():
     assert PORTAIL.url_externe_valide("https://phototheque.example.org/album/12") is True
     assert PORTAIL.url_externe_valide("http://example.org/feed") is True
@@ -21,7 +51,7 @@ def test_url_externe_accepte_uniquement_http_et_https():
 
 
 def test_iframe_est_responsive_et_echappe_les_attributs():
-    html = PORTAIL.construire_iframe({
+    rendu = PORTAIL.construire_iframe({
         "url": "https://example.org/view?x=1&y=2",
         "hauteur": 826,
         "defilement": False,
@@ -29,13 +59,13 @@ def test_iframe_est_responsive_et_echappe_les_attributs():
         "titre": 'Photothèque "été"',
     })
 
-    assert 'src="https://example.org/view?x=1&amp;y=2"' in html
-    assert 'width="100%"' in html
-    assert 'height="826"' in html
-    assert 'scrolling="no"' in html
-    assert 'title="Photothèque &quot;été&quot;"' in html
-    assert " allowfullscreen" in html
-    assert "javascript:" not in html
+    assert 'src="https://example.org/view?x=1&amp;y=2"' in rendu
+    assert 'width="100%"' in rendu
+    assert 'height="826"' in rendu
+    assert 'scrolling="no"' in rendu
+    assert 'title="Photothèque &quot;été&quot;"' in rendu
+    assert " allowfullscreen" in rendu
+    assert "javascript:" not in rendu
 
 
 def test_hauteur_est_bornee_et_serialisation_est_stable():
@@ -64,3 +94,79 @@ def test_hauteur_est_bornee_et_serialisation_est_stable():
 def test_categorie_locale_est_exportee_comme_bloc_texte_connecthys():
     assert PORTAIL.categorie_pour_connecthys("bloc_contenu_externe") == "bloc_texte"
     assert PORTAIL.categorie_pour_connecthys("bloc_blog") == "bloc_blog"
+
+
+def test_rss_est_parse_en_texte_sur_et_limite():
+    articles = PORTAIL.parser_flux_rss_atom(RSS_EXEMPLE)
+    assert len(articles) == 2
+    assert articles[0]["titre"] == "Stage & vacances"
+    assert articles[0]["lien"] == "https://example.org/stage?x=1&y=2"
+    assert articles[0]["date"] == "20/08/2026"
+    assert "<strong>" not in articles[0]["extrait"]
+    assert "<script>" not in articles[0]["extrait"]
+    assert "stage" in articles[0]["extrait"]
+    assert articles[1]["lien"] == ""
+
+    rendu = PORTAIL.construire_flux_html({
+        "type": "rss",
+        "url": "https://example.org/feed",
+        "nombre_articles": 1,
+        "afficher_date": True,
+        "afficher_extrait": True,
+        "liens_nouvel_onglet": True,
+    }, contenu=RSS_EXEMPLE)
+
+    assert "Stage &amp; vacances" in rendu
+    assert "Deuxieme actualite" not in rendu
+    assert 'href="https://example.org/stage?x=1&amp;y=2"' in rendu
+    assert 'target="_blank"' in rendu
+    assert "20/08/2026" in rendu
+    assert "<script>" not in rendu
+    assert "alert(1)" in rendu  # contenu traité comme texte, jamais comme script
+
+
+def test_atom_est_parse_et_rendu_sans_html_externe():
+    articles = PORTAIL.parser_flux_rss_atom(ATOM_EXEMPLE)
+    assert articles == [{
+        "titre": "Actualite Atom",
+        "lien": "https://example.org/atom",
+        "extrait": "Resume Atom",
+        "date": "20/08/2026",
+    }]
+
+    rendu = PORTAIL.construire_flux_html({
+        "type": "rss",
+        "url": "https://example.org/atom.xml",
+        "afficher_date": False,
+        "afficher_extrait": False,
+    }, contenu=ATOM_EXEMPLE)
+    assert "Actualite Atom" in rendu
+    assert "Resume Atom" not in rendu
+    assert "20/08/2026" not in rendu
+
+
+def test_configuration_rss_est_dynamique_et_bornee():
+    brut = PORTAIL.serialiser_parametres({
+        "type": "rss",
+        "url": "https://example.org/feed",
+        "nombre_articles": 999,
+    })
+    config = PORTAIL.deserialiser_parametres(brut)
+    assert config["type"] == PORTAIL.TYPE_RSS
+    assert config["nombre_articles"] == PORTAIL.RSS_NOMBRE_MAX
+    assert PORTAIL.est_configuration_dynamique(brut) is True
+
+    iframe = PORTAIL.serialiser_parametres({
+        "type": "iframe",
+        "url": "https://example.org/widget",
+    })
+    assert PORTAIL.est_configuration_dynamique(iframe) is False
+
+
+def test_flux_invalide_est_refuse():
+    try:
+        PORTAIL.parser_flux_rss_atom(b"<html><body>pas un flux</body></html>")
+    except ValueError as err:
+        assert "non pris en charge" in str(err)
+    else:
+        raise AssertionError("Un document HTML ne doit pas être accepté comme RSS/Atom")

--- a/tests/test_portail_contenus_dynamiques_contract.py
+++ b/tests/test_portail_contenus_dynamiques_contract.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import unittest
 from pathlib import Path
 
 
@@ -9,14 +10,20 @@ DLG = ROOT / "noethys" / "Dlg" / "DLG_Saisie_portail_bloc.py"
 CTRL = ROOT / "noethys" / "Ctrl" / "CTRL_Portail_contenu_externe.py"
 
 
-def test_editeur_de_bloc_expose_le_contenu_externe_sans_nouvelle_categorie_persistante():
-    dlg = DLG.read_text(encoding="utf-8")
-    ctrl = CTRL.read_text(encoding="utf-8")
+class PortailContenuExterneContractTests(unittest.TestCase):
 
-    assert '_(u"Contenu externe")' in dlg
-    assert "CTRL_Portail_contenu_externe.CTRL" in dlg
-    assert 'categorie = _("bloc_texte")' in dlg
-    assert "EstContenuExterne" in dlg
-    assert "construire_iframe" in ctrl
-    assert "texte_html" in ctrl
-    assert "parametres" in ctrl
+    def test_editeur_de_bloc_expose_le_contenu_externe_sans_nouvelle_categorie_persistante(self):
+        dlg = DLG.read_text(encoding="utf-8")
+        ctrl = CTRL.read_text(encoding="utf-8")
+
+        self.assertIn('_(u"Contenu externe")', dlg)
+        self.assertIn("CTRL_Portail_contenu_externe.CTRL", dlg)
+        self.assertIn('categorie = _("bloc_texte")', dlg)
+        self.assertIn("EstContenuExterne", dlg)
+        self.assertIn("construire_iframe", ctrl)
+        self.assertIn("texte_html", ctrl)
+        self.assertIn("parametres", ctrl)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_portail_contenus_synchro.py
+++ b/tests/test_portail_contenus_synchro.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import datetime
 import sys
 from pathlib import Path
 
@@ -18,6 +19,8 @@ class FakeDB(object):
     def __init__(self, lignes):
         self.lignes = list(lignes)
         self.maj = []
+        self.commits = 0
+        self.closed = False
 
     def ExecuterReq(self, req):
         return True
@@ -28,6 +31,12 @@ class FakeDB(object):
     def ReqMAJ(self, table, donnees, cle, valeur, commit=False):
         self.maj.append((table, donnees, cle, valeur, commit))
         return True
+
+    def Commit(self):
+        self.commits += 1
+
+    def Close(self):
+        self.closed = True
 
 
 class FakeLog(object):
@@ -94,3 +103,45 @@ def test_flux_inchange_ne_declenche_pas_ecriture():
     )
     assert etat == {"present": True, "modifies": 0, "erreurs": 0}
     assert db.maj == []
+
+
+def test_preparation_commit_le_cache_et_force_export_des_pages():
+    db = FakeDB([(2, config_rss(), "rss ancien")])
+    appels_parametres = []
+    instant = datetime.datetime(2026, 8, 21, 1, 30, 0)
+
+    def setter(**kwargs):
+        appels_parametres.append(kwargs)
+
+    etat = UTILS_Portail_contenus_synchro.preparer_avant_synchro(
+        db_factory=lambda: db,
+        parametre_setter=setter,
+        constructeur=lambda config: "rss nouveau",
+        maintenant=instant,
+    )
+
+    assert etat == {"present": True, "modifies": 1, "erreurs": 0}
+    assert db.commits == 1
+    assert db.closed is True
+    assert appels_parametres == [{
+        "mode": "set",
+        "categorie": "portail",
+        "nom": "last_update_pages",
+        "valeur": "2026-08-21 01:30:00",
+    }]
+
+
+def test_preparation_sans_flux_ne_force_pas_export():
+    db = FakeDB([(1, config_iframe(), "iframe")])
+    appels_parametres = []
+
+    etat = UTILS_Portail_contenus_synchro.preparer_avant_synchro(
+        db_factory=lambda: db,
+        parametre_setter=lambda **kwargs: appels_parametres.append(kwargs),
+        constructeur=lambda config: "inutile",
+    )
+
+    assert etat == {"present": False, "modifies": 0, "erreurs": 0}
+    assert db.commits == 0
+    assert db.closed is True
+    assert appels_parametres == []

--- a/tests/test_portail_contenus_synchro.py
+++ b/tests/test_portail_contenus_synchro.py
@@ -3,6 +3,7 @@
 
 import datetime
 import sys
+import unittest
 from pathlib import Path
 
 
@@ -48,100 +49,84 @@ class FakeLog(object):
 
 
 def config_rss():
-    return UTILS_Portail_contenus.serialiser_parametres({
-        "type": "rss",
-        "url": "https://example.org/feed",
-    })
+    return UTILS_Portail_contenus.serialiser_parametres({"type": "rss", "url": "https://example.org/feed"})
 
 
 def config_iframe():
-    return UTILS_Portail_contenus.serialiser_parametres({
-        "type": "iframe",
-        "url": "https://example.org/widget",
-    })
+    return UTILS_Portail_contenus.serialiser_parametres({"type": "iframe", "url": "https://example.org/widget"})
 
 
-def test_actualisation_ne_touche_que_les_blocs_dynamiques():
-    db = FakeDB([
-        (1, config_iframe(), "iframe ancien"),
-        (2, config_rss(), "rss ancien"),
-        (3, "ancien parametre", "texte libre"),
-    ])
+class PortailContenusSynchroTests(unittest.TestCase):
 
-    etat = UTILS_Portail_contenus_synchro.actualiser(
-        db,
-        constructeur=lambda config: "rss nouveau",
-    )
+    def test_actualisation_ne_touche_que_les_blocs_dynamiques(self):
+        db = FakeDB([
+            (1, config_iframe(), "iframe ancien"),
+            (2, config_rss(), "rss ancien"),
+            (3, "ancien parametre", "texte libre"),
+        ])
+        etat = UTILS_Portail_contenus_synchro.actualiser(db, constructeur=lambda config: "rss nouveau")
+        self.assertEqual(etat, {"present": True, "modifies": 1, "erreurs": 0})
+        self.assertEqual(len(db.maj), 1)
+        self.assertEqual(db.maj[0][2:4], ("IDelement", 2))
+        self.assertEqual(db.maj[0][1], [("texte_html", "rss nouveau")])
+        self.assertFalse(db.maj[0][4])
 
-    assert etat == {"present": True, "modifies": 1, "erreurs": 0}
-    assert len(db.maj) == 1
-    assert db.maj[0][2:4] == ("IDelement", 2)
-    assert db.maj[0][1] == [("texte_html", "rss nouveau")]
-    assert db.maj[0][4] is False
+    def test_panne_flux_conserve_le_cache_existant_et_ne_bloque_pas(self):
+        db = FakeDB([(9, config_rss(), "derniere version valide")])
+        log = FakeLog()
+
+        def panne(config):
+            raise OSError("serveur indisponible")
+
+        etat = UTILS_Portail_contenus_synchro.actualiser(db, log=log, constructeur=panne)
+        self.assertEqual(etat, {"present": True, "modifies": 0, "erreurs": 1})
+        self.assertEqual(db.maj, [])
+        self.assertTrue(log.messages)
+        self.assertIn("Dernière version conservée", log.messages[0])
+
+    def test_flux_inchange_ne_declenche_pas_ecriture(self):
+        db = FakeDB([(4, config_rss(), "identique")])
+        etat = UTILS_Portail_contenus_synchro.actualiser(db, constructeur=lambda config: "identique")
+        self.assertEqual(etat, {"present": True, "modifies": 0, "erreurs": 0})
+        self.assertEqual(db.maj, [])
+
+    def test_preparation_commit_le_cache_et_force_export_des_pages(self):
+        db = FakeDB([(2, config_rss(), "rss ancien")])
+        appels_parametres = []
+        instant = datetime.datetime(2026, 8, 21, 1, 30, 0)
+
+        def setter(**kwargs):
+            appels_parametres.append(kwargs)
+
+        etat = UTILS_Portail_contenus_synchro.preparer_avant_synchro(
+            db_factory=lambda: db,
+            parametre_setter=setter,
+            constructeur=lambda config: "rss nouveau",
+            maintenant=instant,
+        )
+        self.assertEqual(etat, {"present": True, "modifies": 1, "erreurs": 0})
+        self.assertEqual(db.commits, 1)
+        self.assertTrue(db.closed)
+        self.assertEqual(appels_parametres, [{
+            "mode": "set",
+            "categorie": "portail",
+            "nom": "last_update_pages",
+            "valeur": "2026-08-21 01:30:00",
+        }])
+
+    def test_preparation_sans_flux_ne_force_pas_export(self):
+        db = FakeDB([(1, config_iframe(), "iframe")])
+        appels_parametres = []
+        etat = UTILS_Portail_contenus_synchro.preparer_avant_synchro(
+            db_factory=lambda: db,
+            parametre_setter=lambda **kwargs: appels_parametres.append(kwargs),
+            constructeur=lambda config: "inutile",
+        )
+        self.assertEqual(etat, {"present": False, "modifies": 0, "erreurs": 0})
+        self.assertEqual(db.commits, 0)
+        self.assertTrue(db.closed)
+        self.assertEqual(appels_parametres, [])
 
 
-def test_panne_flux_conserve_le_cache_existant_et_ne_bloque_pas():
-    db = FakeDB([(9, config_rss(), "derniere version valide")])
-    log = FakeLog()
-
-    def panne(config):
-        raise OSError("serveur indisponible")
-
-    etat = UTILS_Portail_contenus_synchro.actualiser(db, log=log, constructeur=panne)
-
-    assert etat == {"present": True, "modifies": 0, "erreurs": 1}
-    assert db.maj == []
-    assert log.messages
-    assert "Dernière version conservée" in log.messages[0]
-
-
-def test_flux_inchange_ne_declenche_pas_ecriture():
-    db = FakeDB([(4, config_rss(), "identique")])
-    etat = UTILS_Portail_contenus_synchro.actualiser(
-        db,
-        constructeur=lambda config: "identique",
-    )
-    assert etat == {"present": True, "modifies": 0, "erreurs": 0}
-    assert db.maj == []
-
-
-def test_preparation_commit_le_cache_et_force_export_des_pages():
-    db = FakeDB([(2, config_rss(), "rss ancien")])
-    appels_parametres = []
-    instant = datetime.datetime(2026, 8, 21, 1, 30, 0)
-
-    def setter(**kwargs):
-        appels_parametres.append(kwargs)
-
-    etat = UTILS_Portail_contenus_synchro.preparer_avant_synchro(
-        db_factory=lambda: db,
-        parametre_setter=setter,
-        constructeur=lambda config: "rss nouveau",
-        maintenant=instant,
-    )
-
-    assert etat == {"present": True, "modifies": 1, "erreurs": 0}
-    assert db.commits == 1
-    assert db.closed is True
-    assert appels_parametres == [{
-        "mode": "set",
-        "categorie": "portail",
-        "nom": "last_update_pages",
-        "valeur": "2026-08-21 01:30:00",
-    }]
-
-
-def test_preparation_sans_flux_ne_force_pas_export():
-    db = FakeDB([(1, config_iframe(), "iframe")])
-    appels_parametres = []
-
-    etat = UTILS_Portail_contenus_synchro.preparer_avant_synchro(
-        db_factory=lambda: db,
-        parametre_setter=lambda **kwargs: appels_parametres.append(kwargs),
-        constructeur=lambda config: "inutile",
-    )
-
-    assert etat == {"present": False, "modifies": 0, "erreurs": 0}
-    assert db.commits == 0
-    assert db.closed is True
-    assert appels_parametres == []
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_portail_contenus_synchro.py
+++ b/tests/test_portail_contenus_synchro.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOETHYS = ROOT / "noethys"
+if str(NOETHYS) not in sys.path:
+    sys.path.insert(0, str(NOETHYS))
+
+from Utils import UTILS_Portail_contenus
+from Utils import UTILS_Portail_contenus_synchro
+
+
+class FakeDB(object):
+    def __init__(self, lignes):
+        self.lignes = list(lignes)
+        self.maj = []
+
+    def ExecuterReq(self, req):
+        return True
+
+    def ResultatReq(self):
+        return self.lignes
+
+    def ReqMAJ(self, table, donnees, cle, valeur, commit=False):
+        self.maj.append((table, donnees, cle, valeur, commit))
+        return True
+
+
+class FakeLog(object):
+    def __init__(self):
+        self.messages = []
+
+    def EcritLog(self, message):
+        self.messages.append(message)
+
+
+def config_rss():
+    return UTILS_Portail_contenus.serialiser_parametres({
+        "type": "rss",
+        "url": "https://example.org/feed",
+    })
+
+
+def config_iframe():
+    return UTILS_Portail_contenus.serialiser_parametres({
+        "type": "iframe",
+        "url": "https://example.org/widget",
+    })
+
+
+def test_actualisation_ne_touche_que_les_blocs_dynamiques():
+    db = FakeDB([
+        (1, config_iframe(), "iframe ancien"),
+        (2, config_rss(), "rss ancien"),
+        (3, "ancien parametre", "texte libre"),
+    ])
+
+    etat = UTILS_Portail_contenus_synchro.actualiser(
+        db,
+        constructeur=lambda config: "rss nouveau",
+    )
+
+    assert etat == {"present": True, "modifies": 1, "erreurs": 0}
+    assert len(db.maj) == 1
+    assert db.maj[0][2:4] == ("IDelement", 2)
+    assert db.maj[0][1] == [("texte_html", "rss nouveau")]
+    assert db.maj[0][4] is False
+
+
+def test_panne_flux_conserve_le_cache_existant_et_ne_bloque_pas():
+    db = FakeDB([(9, config_rss(), "derniere version valide")])
+    log = FakeLog()
+
+    def panne(config):
+        raise OSError("serveur indisponible")
+
+    etat = UTILS_Portail_contenus_synchro.actualiser(db, log=log, constructeur=panne)
+
+    assert etat == {"present": True, "modifies": 0, "erreurs": 1}
+    assert db.maj == []
+    assert log.messages
+    assert "Dernière version conservée" in log.messages[0]
+
+
+def test_flux_inchange_ne_declenche_pas_ecriture():
+    db = FakeDB([(4, config_rss(), "identique")])
+    etat = UTILS_Portail_contenus_synchro.actualiser(
+        db,
+        constructeur=lambda config: "identique",
+    )
+    assert etat == {"present": True, "modifies": 0, "erreurs": 0}
+    assert db.maj == []

--- a/tests/test_portail_rss_integration_contract.py
+++ b/tests/test_portail_rss_integration_contract.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVEUR = ROOT / "noethys" / "Ctrl" / "CTRL_Portail_serveur.py"
+SYNC_HELPER = ROOT / "noethys" / "Utils" / "UTILS_Portail_contenus_synchro.py"
+
+
+def test_serveur_actualise_les_contenus_avant_la_synchro_historique():
+    serveur = SERVEUR.read_text(encoding="utf-8")
+    helper = SYNC_HELPER.read_text(encoding="utf-8")
+
+    assert "from Utils import UTILS_Portail_contenus_synchro" in serveur
+    appel_preparation = serveur.index("UTILS_Portail_contenus_synchro.preparer_avant_synchro")
+    appel_synchro = serveur.index("synchro.Synchro_totale()")
+    assert appel_preparation < appel_synchro
+
+    assert 'nom="last_update_pages"' in helper
+    assert "DB.Commit()" in helper
+    assert "Dernière version conservée" in helper
+    assert "WHERE parametres IS NOT NULL" in helper

--- a/tests/test_portail_rss_integration_contract.py
+++ b/tests/test_portail_rss_integration_contract.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import unittest
 from pathlib import Path
 
 
@@ -9,16 +10,21 @@ SERVEUR = ROOT / "noethys" / "Ctrl" / "CTRL_Portail_serveur.py"
 SYNC_HELPER = ROOT / "noethys" / "Utils" / "UTILS_Portail_contenus_synchro.py"
 
 
-def test_serveur_actualise_les_contenus_avant_la_synchro_historique():
-    serveur = SERVEUR.read_text(encoding="utf-8")
-    helper = SYNC_HELPER.read_text(encoding="utf-8")
+class PortailRSSIntegrationContractTests(unittest.TestCase):
 
-    assert "from Utils import UTILS_Portail_contenus_synchro" in serveur
-    appel_preparation = serveur.index("UTILS_Portail_contenus_synchro.preparer_avant_synchro")
-    appel_synchro = serveur.index("synchro.Synchro_totale()")
-    assert appel_preparation < appel_synchro
+    def test_serveur_actualise_les_contenus_avant_la_synchro_historique(self):
+        serveur = SERVEUR.read_text(encoding="utf-8")
+        helper = SYNC_HELPER.read_text(encoding="utf-8")
 
-    assert 'nom="last_update_pages"' in helper
-    assert "DB.Commit()" in helper
-    assert "Dernière version conservée" in helper
-    assert "WHERE parametres IS NOT NULL" in helper
+        self.assertIn("from Utils import UTILS_Portail_contenus_synchro", serveur)
+        appel_preparation = serveur.index("UTILS_Portail_contenus_synchro.preparer_avant_synchro")
+        appel_synchro = serveur.index("synchro.Synchro_totale()")
+        self.assertLess(appel_preparation, appel_synchro)
+        self.assertIn('nom="last_update_pages"', helper)
+        self.assertIn("DB.Commit()", helper)
+        self.assertIn("Dernière version conservée", helper)
+        self.assertIn("WHERE parametres IS NOT NULL", helper)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Objectif
Ajouter un mode **Flux RSS / Atom** au bloc `Contenu externe` de #63 afin de supprimer la dépendance aux widgets tiers de type FeedWind.

## Implémentation
- choix `Page / widget web` ou `Flux RSS / Atom` dans l'éditeur ;
- options nombre d'actualités, date, extrait et ouverture dans un nouvel onglet ;
- parsing RSS 2.0 et Atom en bibliothèque standard ;
- suppression du HTML externe avant rendu ;
- validation stricte des liens HTTP(S) ;
- rendu HTML échappé ;
- téléchargement borné par timeout et taille maximale ;
- cache HTML local : une panne de flux conserve la dernière version valide ;
- actualisation exécutée juste avant la synchronisation Connecthys historique ;
- présence d'un flux dynamique → mise à jour de `last_update_pages` afin de forcer la réexportation des pages/éléments ;
- une erreur RSS ne bloque jamais le reste de la synchronisation.

## Architecture
Le protocole Connecthys n'est pas modifié. Noethys met à jour le `texte_html` du bloc local puis laisse `UTILS_Portail_synchro` exporter les pages avec son mécanisme historique. Aucun changement de schéma et aucune modification du serveur Connecthys ne sont nécessaires.

Le moteur RSS et la politique de cache sont isolés dans des helpers testables sans wxPython ni serveur Connecthys.

## Tests
- RSS 2.0 ;
- Atom ;
- nettoyage du HTML ;
- liens non HTTP(S) refusés ;
- nombre d'articles borné ;
- cache conservé en cas de panne ;
- commit du nouveau cache ;
- forçage de `last_update_pages` ;
- contrat d'ordre : actualisation dynamique avant `Synchro_totale()`.

## Suite
Le ciblage selon les inscriptions (ALSH, EMS, Sport-Santé, couture...) sera construit au-dessus de ce moteur, tout en conservant la possibilité d'un flux associatif général commun à tous.

Dépend de #63. Avance #65 et #62.