### PR TITLE
Noe-063C — Décrire les barèmes Noethys pour le portail

### DIFF
--- a/docs/NOE_063C_TARIFS_PORTAIL.md
+++ b/docs/NOE_063C_TARIFS_PORTAIL.md
@@ -1,0 +1,54 @@
+# Noe-063C — Barèmes Noethys dans le portail Connecthys
+
+## Principe
+
+Noethys doit rester la source de vérité des tarifs. Le portail ne doit pas contenir une seconde copie manuelle des montants.
+
+Le premier composant technique est un **descripteur pur de barèmes** : il transforme les dictionnaires tarifaires déjà utilisés par le moteur de facturation en une représentation publiable, sans recalculer les factures.
+
+## Ce que le descripteur peut publier directement
+
+- montant fixe ;
+- tranches de quotient familial ;
+- montant par date ;
+- montant par date et quotient familial ;
+- options tarifaires au choix ;
+- dates de validité ;
+- tarifs futurs ;
+- catégorie tarifaire et activité lorsque ces libellés sont fournis par l'appelant.
+
+## Ce qu'il ne doit pas présenter comme un prix certain
+
+Les règles dépendant du contexte réel restent signalées comme telles :
+
+- horaires ou durée ;
+- quantité ;
+- nombre d'enfants présents ;
+- taux d'effort ;
+- événement ;
+- forfait/crédit disponible ;
+- groupe ;
+- étiquette de consommation ;
+- cotisation ;
+- caisse ;
+- période scolaire/vacances ;
+- filtre de questionnaire ;
+- autres conditions utilisées par le moteur de facturation.
+
+Le portail peut décrire ces règles, mais ne doit pas afficher « votre prix » tant que toutes les conditions nécessaires au calcul réel ne sont pas résolues.
+
+## Compatibilité Connecthys
+
+### V1
+
+Noethys générera un bloc **Tarifs des activités** à partir des barèmes configurés. Le rendu restera un `bloc_texte` historique et ne nécessitera aucune modification du Connecthys hébergé.
+
+### V2
+
+Un véritable bloc **Mes tarifs**, différent pour chaque famille connectée, ne peut pas être obtenu proprement par un bloc HTML global. Connecthys connaît bien `current_user.IDfamille`, mais ses pages personnalisées chargent aujourd'hui les mêmes blocs et éléments pour tous les comptes.
+
+La personnalisation fine nécessitera donc un point d'intégration authentifié côté Connecthys, notamment pour exploiter la catégorie tarifaire de l'inscription sans exposer d'identifiant familial dans une URL.
+
+## Règle de développement
+
+Le descripteur reste indépendant de wxPython et de la base. La lecture SQL et l'interface viendront dans des couches séparées afin que la logique de publication soit testable sans base réelle et puisse être réutilisée dans d'autres sorties (site, documents ou rapports).

--- a/docs/NOE_063C_TARIFS_PORTAIL.md
+++ b/docs/NOE_063C_TARIFS_PORTAIL.md
@@ -6,6 +6,16 @@ Noethys doit rester la source de vérité des tarifs. Le portail ne doit pas con
 
 Le premier composant technique est un **descripteur pur de barèmes** : il transforme les dictionnaires tarifaires déjà utilisés par le moteur de facturation en une représentation publiable, sans recalculer les factures.
 
+## Découverte automatique des activités
+
+La publication est **automatique par défaut**. Elle ne mémorise pas une liste figée d'IDs d'activités.
+
+Conséquence : si une nouvelle activité est créée ultérieurement dans Noethys et qu'elle possède un barème courant ou futur, elle est découverte au prochain rafraîchissement et prend automatiquement sa place dans la publication. Les tarifs expirés restent masqués par défaut.
+
+Une liste d'exclusions explicites reste possible pour les activités que l'on ne souhaite jamais publier. Un mode de sélection manuelle est également conservé pour les usages particuliers, mais il n'est pas le comportement par défaut.
+
+Cette règle évite un défaut classique des tableaux configurés « une fois pour toutes » : devoir penser à modifier le portail à chaque nouvelle activité ou nouvelle saison.
+
 ## Ce que le descripteur peut publier directement
 
 - montant fixe ;
@@ -32,6 +42,7 @@ Les règles dépendant du contexte réel restent signalées comme telles :
 - cotisation ;
 - caisse ;
 - période scolaire/vacances ;
+- état ou combinaison de consommations ;
 - filtre de questionnaire ;
 - autres conditions utilisées par le moteur de facturation.
 
@@ -51,4 +62,4 @@ La personnalisation fine nécessitera donc un point d'intégration authentifié 
 
 ## Règle de développement
 
-Le descripteur reste indépendant de wxPython et de la base. La lecture SQL et l'interface viendront dans des couches séparées afin que la logique de publication soit testable sans base réelle et puisse être réutilisée dans d'autres sorties (site, documents ou rapports).
+Le descripteur reste indépendant de wxPython et de la base. La lecture SQL et l'interface viennent dans des couches séparées afin que la logique de publication soit testable sans base réelle et puisse être réutilisée dans d'autres sorties (site, documents ou rapports).

--- a/noethys/Utils/UTILS_Portail_tarifs.py
+++ b/noethys/Utils/UTILS_Portail_tarifs.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#------------------------------------------------------------------------
+# Application :    Noethys, gestion multi-activités
+# Site internet :  www.noethys.com
+# Licence:          GNU GPL
+#------------------------------------------------------------------------
+
+"""Description sûre des barèmes Noethys pour les supports de publication.
+
+Ce module ne calcule pas une facture et ne dépend ni de wxPython, ni de la
+base de données. Il transforme les dictionnaires tarifaires déjà utilisés par
+le moteur Noethys en une représentation canonique publiable.
+
+Règle importante : un tarif qui dépend d'une consommation, d'un événement,
+d'une durée, d'un questionnaire ou d'une autre condition métier reste marqué
+comme contextuel. Le portail ne doit jamais présenter ce type de règle comme
+« votre prix ».
+"""
+
+import datetime
+import html
+
+
+METHODES_DESCRIPTIBLES = {
+    "montant_unique",
+    "qf",
+    "montant_unique_date",
+    "qf_date",
+    "choix",
+}
+
+LIBELLES_METHODES = {
+    "montant_unique": "Montant fixe",
+    "qf": "Selon le quotient familial",
+    "montant_unique_date": "Selon la date",
+    "qf_date": "Selon la date et le quotient familial",
+    "choix": "Selon l'option choisie",
+    "variable": "Montant saisi selon la situation",
+    "montant_evenement": "Selon l'événement",
+    "horaire_montant_unique": "Selon les horaires",
+    "horaire_qf": "Selon les horaires et le quotient familial",
+    "duree_montant_unique": "Selon la durée",
+    "duree_qf": "Selon la durée et le quotient familial",
+    "duree_coeff_montant_unique": "Au prorata de la durée",
+    "duree_coeff_qf": "Au prorata de la durée et du quotient familial",
+    "taux_montant_unique": "Selon un taux d'effort",
+    "taux_qf": "Selon un taux d'effort et le quotient familial",
+    "taux_date": "Selon un taux d'effort et la date",
+    "duree_taux_montant_unique": "Selon la durée et un taux d'effort",
+    "duree_taux_qf": "Selon la durée, le quotient familial et un taux d'effort",
+}
+
+
+CONDITIONS_CONTEXTUELLES = {
+    "groupes": "groupe de l'inscription",
+    "etiquettes": "étiquette de consommation",
+    "cotisations": "cotisation en cours de validité",
+    "caisses": "caisse de rattachement",
+    "filtres": "réponse à un questionnaire",
+    "jours_scolaires": "jour scolaire",
+    "jours_vacances": "période de vacances",
+}
+
+
+def _date(valeur):
+    if valeur in (None, ""):
+        return None
+    if isinstance(valeur, datetime.datetime):
+        return valeur.date()
+    if isinstance(valeur, datetime.date):
+        return valeur
+    texte = str(valeur).strip()
+    try:
+        return datetime.datetime.strptime(texte[:10], "%Y-%m-%d").date()
+    except (TypeError, ValueError):
+        return None
+
+
+def _nombre(valeur):
+    if valeur in (None, ""):
+        return None
+    try:
+        return float(valeur)
+    except (TypeError, ValueError):
+        return None
+
+
+def formater_montant(valeur):
+    montant = _nombre(valeur)
+    if montant is None:
+        return None
+    texte = ("%.2f" % montant).replace(".", ",")
+    return "%s €" % texte
+
+
+def formater_date(valeur):
+    valeur = _date(valeur)
+    if valeur is None:
+        return None
+    return valeur.strftime("%d/%m/%Y")
+
+
+def _statut_validite(date_debut, date_fin, date_reference=None):
+    reference = _date(date_reference) or datetime.date.today()
+    debut = _date(date_debut)
+    fin = _date(date_fin)
+    if debut and reference < debut:
+        return "futur"
+    if fin and reference > fin:
+        return "expire"
+    return "en_vigueur"
+
+
+def _condition_presente(valeur):
+    if valeur in (None, "", [], {}, ()):
+        return False
+    return True
+
+
+def _avertissements_contextuels(tarif):
+    avertissements = []
+    for cle, libelle in CONDITIONS_CONTEXTUELLES.items():
+        if _condition_presente(tarif.get(cle)):
+            avertissements.append("Applicable selon : %s." % libelle)
+
+    methode = str(tarif.get("methode") or "")
+    if methode and methode not in METHODES_DESCRIPTIBLES:
+        avertissements.append(
+            "Le montant exact dépend du contexte réel de réservation ou de facturation."
+        )
+
+    # Les forfaits crédit et autres types de tarifs peuvent nécessiter une
+    # consommation ou un stock de crédit déjà existant.
+    type_tarif = str(tarif.get("type") or "")
+    if type_tarif == "CREDIT":
+        avertissements.append(
+            "Ce tarif fonctionne avec un crédit/forfait ; le solde disponible n'est pas déduit ici."
+        )
+    return avertissements
+
+
+def _regle_montant_unique(lignes):
+    if not lignes:
+        return []
+    montant = formater_montant(lignes[0].get("montant_unique"))
+    if montant is None:
+        return []
+    return [{"type": "montant", "montant": montant}]
+
+
+def _regles_qf(lignes):
+    regles = []
+    for ligne in lignes:
+        minimum = _nombre(ligne.get("qf_min"))
+        maximum = _nombre(ligne.get("qf_max"))
+        montant = formater_montant(ligne.get("montant_unique"))
+        if montant is None:
+            continue
+        regles.append({
+            "type": "qf",
+            "qf_min": minimum,
+            "qf_max": maximum,
+            "montant": montant,
+        })
+    return regles
+
+
+def _regles_date(lignes, avec_qf=False):
+    regles = []
+    for ligne in lignes:
+        date_ligne = formater_date(ligne.get("date"))
+        montant = formater_montant(ligne.get("montant_unique"))
+        if not date_ligne or montant is None:
+            continue
+        regle = {
+            "type": "qf_date" if avec_qf else "date",
+            "date": date_ligne,
+            "montant": montant,
+        }
+        if avec_qf:
+            regle["qf_min"] = _nombre(ligne.get("qf_min"))
+            regle["qf_max"] = _nombre(ligne.get("qf_max"))
+        regles.append(regle)
+    return regles
+
+
+def _regles_choix(lignes):
+    regles = []
+    for ligne in lignes:
+        montant = formater_montant(ligne.get("montant_unique"))
+        label = str(ligne.get("label") or "").strip()
+        if montant is None and not label:
+            continue
+        regles.append({
+            "type": "choix",
+            "label": label or "Option",
+            "montant": montant,
+        })
+    return regles
+
+
+def decrire_tarif(tarif, date_reference=None):
+    """Retourne une description canonique d'un dictionnaire tarifaire Noethys."""
+    tarif = dict(tarif or {})
+    methode = str(tarif.get("methode") or "").strip()
+    lignes = list(tarif.get("lignes_calcul") or [])
+
+    if methode == "montant_unique":
+        regles = _regle_montant_unique(lignes)
+    elif methode == "qf":
+        regles = _regles_qf(lignes)
+    elif methode == "montant_unique_date":
+        regles = _regles_date(lignes, avec_qf=False)
+    elif methode == "qf_date":
+        regles = _regles_date(lignes, avec_qf=True)
+    elif methode == "choix":
+        regles = _regles_choix(lignes)
+    else:
+        regles = []
+
+    avertissements = _avertissements_contextuels(tarif)
+    descriptible = methode in METHODES_DESCRIPTIBLES and bool(regles)
+    exact_sans_contexte = (
+        methode == "montant_unique"
+        and bool(regles)
+        and not avertissements
+    )
+
+    return {
+        "IDtarif": tarif.get("IDtarif"),
+        "IDactivite": tarif.get("IDactivite"),
+        "activite": str(tarif.get("nom_activite") or tarif.get("activite") or "").strip(),
+        "nom": str(tarif.get("nom_tarif") or tarif.get("nom") or "Tarif").strip(),
+        "description": str(tarif.get("description_tarif") or tarif.get("description") or "").strip(),
+        "IDcategorie_tarif": tarif.get("IDcategorie_tarif"),
+        "categorie_tarif": str(tarif.get("nom_categorie_tarif") or "").strip(),
+        "date_debut": formater_date(tarif.get("date_debut")),
+        "date_fin": formater_date(tarif.get("date_fin")),
+        "statut": _statut_validite(tarif.get("date_debut"), tarif.get("date_fin"), date_reference),
+        "methode": methode,
+        "methode_label": LIBELLES_METHODES.get(methode, "Règle tarifaire contextuelle"),
+        "regles": regles,
+        "descriptible": descriptible,
+        "exact_sans_contexte": exact_sans_contexte,
+        "avertissements": avertissements,
+    }
+
+
+def decrire_tarifs(tarifs, date_reference=None, inclure_expires=False):
+    descriptions = []
+    for tarif in tarifs or []:
+        description = decrire_tarif(tarif, date_reference=date_reference)
+        if inclure_expires or description["statut"] != "expire":
+            descriptions.append(description)
+    descriptions.sort(key=lambda x: (
+        x.get("activite") or "",
+        x.get("nom") or "",
+        x.get("date_debut") or "",
+    ))
+    return descriptions
+
+
+def _qf_label(regle):
+    minimum = regle.get("qf_min")
+    maximum = regle.get("qf_max")
+    if minimum is None and maximum is None:
+        return "Quotient familial"
+    if minimum is None:
+        return "QF ≤ %g" % maximum
+    if maximum is None:
+        return "QF ≥ %g" % minimum
+    return "QF %g à %g" % (minimum, maximum)
+
+
+def construire_html(descriptions, titre=None):
+    """Génère un HTML autonome depuis des descriptions déjà normalisées."""
+    morceaux = ['<div class="noethys-tarifs">']
+    if titre:
+        morceaux.append("<h3>%s</h3>" % html.escape(str(titre)))
+
+    for tarif in descriptions or []:
+        morceaux.append('<section class="noethys-tarif" style="margin-bottom:18px;">')
+        morceaux.append("<h4>%s</h4>" % html.escape(tarif.get("nom") or "Tarif"))
+
+        meta = []
+        if tarif.get("activite"):
+            meta.append(tarif["activite"])
+        if tarif.get("categorie_tarif"):
+            meta.append(tarif["categorie_tarif"])
+        if tarif.get("date_debut") and tarif.get("date_fin"):
+            meta.append("du %s au %s" % (tarif["date_debut"], tarif["date_fin"]))
+        elif tarif.get("date_debut"):
+            meta.append("à partir du %s" % tarif["date_debut"])
+        elif tarif.get("date_fin"):
+            meta.append("jusqu'au %s" % tarif["date_fin"])
+        if tarif.get("statut") == "futur":
+            meta.append("tarif à venir")
+        if meta:
+            morceaux.append('<p style="opacity:0.8;">%s</p>' % html.escape(" · ".join(meta)))
+
+        if tarif.get("description"):
+            morceaux.append("<p>%s</p>" % html.escape(tarif["description"]))
+        morceaux.append("<p><strong>%s</strong></p>" % html.escape(tarif.get("methode_label") or "Tarification"))
+
+        regles = tarif.get("regles") or []
+        if regles:
+            morceaux.append('<table style="width:100%;border-collapse:collapse;">')
+            for regle in regles:
+                type_regle = regle.get("type")
+                if type_regle == "montant":
+                    libelle = "Tarif"
+                elif type_regle == "qf":
+                    libelle = _qf_label(regle)
+                elif type_regle == "date":
+                    libelle = regle.get("date") or "Date"
+                elif type_regle == "qf_date":
+                    libelle = "%s · %s" % (regle.get("date") or "Date", _qf_label(regle))
+                elif type_regle == "choix":
+                    libelle = regle.get("label") or "Option"
+                else:
+                    libelle = "Tarif"
+                morceaux.append(
+                    '<tr><td style="padding:4px 8px 4px 0;">%s</td>'
+                    '<td style="padding:4px 0;text-align:right;"><strong>%s</strong></td></tr>' % (
+                        html.escape(str(libelle)),
+                        html.escape(str(regle.get("montant") or "—")),
+                    )
+                )
+            morceaux.append("</table>")
+        else:
+            morceaux.append(
+                "<p>Le montant dépend de la réservation ou de la situation réelle.</p>"
+            )
+
+        avertissements = tarif.get("avertissements") or []
+        if avertissements:
+            morceaux.append('<ul style="margin-top:8px;">')
+            for avertissement in avertissements:
+                morceaux.append("<li>%s</li>" % html.escape(avertissement))
+            morceaux.append("</ul>")
+        morceaux.append("</section>")
+
+    morceaux.append("</div>")
+    return "".join(morceaux)

--- a/noethys/Utils/UTILS_Portail_tarifs.py
+++ b/noethys/Utils/UTILS_Portail_tarifs.py
@@ -42,6 +42,10 @@ LIBELLES_METHODES = {
     "horaire_qf": "Selon les horaires et le quotient familial",
     "duree_montant_unique": "Selon la durée",
     "duree_qf": "Selon la durée et le quotient familial",
+    "montant_unique_nbre_ind": "Selon le nombre de personnes présentes",
+    "qf_nbre_ind": "Selon le quotient familial et le nombre de personnes présentes",
+    "montant_unique_nbre_ind_degr": "Tarif dégressif selon le nombre de personnes présentes",
+    "qf_nbre_ind_degr": "Tarif dégressif selon le quotient familial et le nombre de personnes présentes",
     "duree_coeff_montant_unique": "Au prorata de la durée",
     "duree_coeff_qf": "Au prorata de la durée et du quotient familial",
     "taux_montant_unique": "Selon un taux d'effort",
@@ -49,6 +53,7 @@ LIBELLES_METHODES = {
     "taux_date": "Selon un taux d'effort et la date",
     "duree_taux_montant_unique": "Selon la durée et un taux d'effort",
     "duree_taux_qf": "Selon la durée, le quotient familial et un taux d'effort",
+    "forfait_contrat": "Selon le forfait contractuel",
 }
 
 
@@ -60,6 +65,14 @@ CONDITIONS_CONTEXTUELLES = {
     "filtres": "réponse à un questionnaire",
     "jours_scolaires": "jour scolaire",
     "jours_vacances": "période de vacances",
+    "combinaisons_unites": "combinaison d'unités consommées",
+    "condition_nbre_combi": "nombre de consommations combinées",
+    "condition_periode": "période de consommation",
+    "condition_nbre_jours": "nombre de jours consommés",
+    "condition_conso_facturees": "consommations déjà facturées",
+    "condition_dates_continues": "continuité des dates de consommation",
+    "etats": "état de la consommation",
+    "IDevenement": "événement associé",
 }
 
 
@@ -113,7 +126,7 @@ def _statut_validite(date_debut, date_fin, date_reference=None):
 
 
 def _condition_presente(valeur):
-    if valeur in (None, "", [], {}, ()):
+    if valeur in (None, "", False, 0, "0", [], {}, ()):
         return False
     return True
 
@@ -130,8 +143,14 @@ def _avertissements_contextuels(tarif):
             "Le montant exact dépend du contexte réel de réservation ou de facturation."
         )
 
-    # Les forfaits crédit et autres types de tarifs peuvent nécessiter une
-    # consommation ou un stock de crédit déjà existant.
+    # Certains champs d'options sont opaques sans le moteur métier qui les
+    # interprète. Leur seule présence suffit donc à empêcher l'affichage d'un
+    # faux prix certain.
+    if _condition_presente(tarif.get("options")):
+        avertissements.append("Ce tarif comporte des options métier supplémentaires.")
+
+    # Les forfaits crédit peuvent nécessiter une consommation ou un stock de
+    # crédit déjà existant.
     type_tarif = str(tarif.get("type") or "")
     if type_tarif == "CREDIT":
         avertissements.append(

--- a/noethys/Utils/UTILS_Portail_tarifs_donnees.py
+++ b/noethys/Utils/UTILS_Portail_tarifs_donnees.py
@@ -16,6 +16,7 @@ La connexion DB est fournie par l'appelant et n'est jamais fermée ici.
 """
 
 from Data.DATA_Tables import DB_DATA
+from Utils import UTILS_Portail_tarifs
 
 
 CHAMPS_TARIFS = (
@@ -156,7 +157,7 @@ def charger_baremes(DB, IDsactivites=None):
     filtres = _charger_filtres(DB)
     tarifs = _charger_tarifs(DB)
 
-    filtre_activites = set(IDsactivites) if IDsactivites else None
+    filtre_activites = set(IDsactivites) if IDsactivites is not None else None
     resultats = []
 
     for tarif in tarifs:
@@ -183,3 +184,23 @@ def charger_baremes(DB, IDsactivites=None):
             resultats.append(item)
 
     return resultats
+
+
+def construire_publication(DB, IDsactivites=None, date_reference=None,
+                            inclure_expires=False, titre="Tarifs des activités"):
+    """Construit la représentation et le HTML à partir de la base Noethys.
+
+    Cette fonction ne modifie aucune donnée. Elle est destinée à alimenter un
+    aperçu puis, dans un lot suivant, le cache HTML du bloc portail.
+    """
+    baremes = charger_baremes(DB, IDsactivites=IDsactivites)
+    descriptions = UTILS_Portail_tarifs.decrire_tarifs(
+        baremes,
+        date_reference=date_reference,
+        inclure_expires=inclure_expires,
+    )
+    return {
+        "baremes": baremes,
+        "descriptions": descriptions,
+        "html": UTILS_Portail_tarifs.construire_html(descriptions, titre=titre),
+    }

--- a/noethys/Utils/UTILS_Portail_tarifs_donnees.py
+++ b/noethys/Utils/UTILS_Portail_tarifs_donnees.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#------------------------------------------------------------------------
+# Application :    Noethys, gestion multi-activités
+# Site internet :  www.noethys.com
+# Licence:          GNU GPL
+#------------------------------------------------------------------------
+
+"""Lecture des barèmes Noethys pour publication.
+
+Cette couche lit les mêmes tables que le moteur historique de facturation mais
+ne calcule aucun prix. Elle produit les dictionnaires attendus par
+``UTILS_Portail_tarifs`` et garde l'accès SQL séparé du descripteur pur.
+
+La connexion DB est fournie par l'appelant et n'est jamais fermée ici.
+"""
+
+from Data.DATA_Tables import DB_DATA
+
+
+CHAMPS_TARIFS = (
+    "IDtarif", "IDactivite", "IDnom_tarif", "nom_tarif", "date_debut", "date_fin",
+    "condition_nbre_combi", "condition_periode", "condition_nbre_jours",
+    "condition_conso_facturees", "condition_dates_continues", "methode",
+    "categories_tarifs", "groupes", "etiquettes", "type", "forfait_duree",
+    "forfait_beneficiaire", "cotisations", "caisses", "jours_scolaires",
+    "jours_vacances", "code_compta", "code_produit_local", "tva",
+    "date_facturation", "etats", "IDtype_quotient", "description",
+    "label_prestation", "options", "IDevenement",
+)
+
+CHAMPS_LISTES_IDS = (
+    "categories_tarifs",
+    "groupes",
+    "etiquettes",
+    "cotisations",
+    "caisses",
+    "jours_scolaires",
+    "jours_vacances",
+)
+
+
+def convertir_liste_ids(valeur, type_texte=False):
+    """Reprend le format historique Noethys ``1;2;3`` sans dépendance GUI."""
+    if valeur in (None, ""):
+        return None
+    if isinstance(valeur, (list, tuple)):
+        return list(valeur)
+    if isinstance(valeur, int):
+        return [valeur]
+
+    resultats = []
+    for item in str(valeur).split(";"):
+        item = item.strip()
+        if not item:
+            continue
+        if type_texte:
+            resultats.append(item)
+        else:
+            try:
+                resultats.append(int(item))
+            except (TypeError, ValueError):
+                # Une donnée historique illisible ne doit pas faire échouer
+                # toute la publication ; elle est conservée comme texte afin
+                # d'être visible lors d'une recette réelle.
+                resultats.append(item)
+    return resultats or None
+
+
+def _executer(DB, requete):
+    if not DB.ExecuterReq(requete):
+        raise RuntimeError("Lecture des barèmes impossible")
+    return DB.ResultatReq()
+
+
+def _charger_activites(DB):
+    lignes = _executer(DB, """SELECT IDactivite, nom
+    FROM activites
+    ORDER BY nom;""")
+    return {IDactivite: nom for IDactivite, nom in lignes}
+
+
+def _charger_categories(DB):
+    lignes = _executer(DB, """SELECT IDcategorie_tarif, IDactivite, nom
+    FROM categories_tarifs
+    ORDER BY IDactivite, nom;""")
+    return {
+        IDcategorie_tarif: {"IDactivite": IDactivite, "nom": nom}
+        for IDcategorie_tarif, IDactivite, nom in lignes
+    }
+
+
+def _charger_lignes_calcul(DB):
+    champs = [champ[0] for champ in DB_DATA["tarifs_lignes"]]
+    requete = """SELECT %s
+    FROM tarifs_lignes
+    WHERE IDmodele IS NULL
+    ORDER BY IDtarif, num_ligne;""" % ", ".join(champs)
+    lignes = _executer(DB, requete)
+
+    resultats = {}
+    for valeurs in lignes:
+        ligne = {}
+        for index, valeur in enumerate(valeurs):
+            if valeur == "None":
+                valeur = None
+            ligne[champs[index]] = valeur
+        resultats.setdefault(ligne.get("IDtarif"), []).append(ligne)
+    return resultats
+
+
+def _charger_filtres(DB):
+    """La présence d'un filtre suffit pour classer le barème comme contextuel."""
+    lignes = _executer(DB, """SELECT IDfiltre, IDtarif
+    FROM questionnaire_filtres
+    WHERE IDtarif IS NOT NULL;""")
+    resultats = {}
+    for IDfiltre, IDtarif in lignes:
+        resultats.setdefault(IDtarif, []).append({"IDfiltre": IDfiltre})
+    return resultats
+
+
+def _charger_tarifs(DB):
+    lignes = _executer(DB, """SELECT
+    tarifs.IDtarif, tarifs.IDactivite, tarifs.IDnom_tarif, noms_tarifs.nom,
+    tarifs.date_debut, tarifs.date_fin,
+    tarifs.condition_nbre_combi, tarifs.condition_periode,
+    tarifs.condition_nbre_jours, tarifs.condition_conso_facturees,
+    tarifs.condition_dates_continues, tarifs.methode,
+    tarifs.categories_tarifs, tarifs.groupes, tarifs.etiquettes, tarifs.type,
+    tarifs.forfait_duree, tarifs.forfait_beneficiaire, tarifs.cotisations,
+    tarifs.caisses, tarifs.jours_scolaires, tarifs.jours_vacances,
+    tarifs.code_compta, tarifs.code_produit_local, tarifs.tva,
+    tarifs.date_facturation, tarifs.etats, tarifs.IDtype_quotient,
+    tarifs.description, tarifs.label_prestation, tarifs.options,
+    tarifs.IDevenement
+    FROM tarifs
+    LEFT JOIN noms_tarifs ON noms_tarifs.IDnom_tarif = tarifs.IDnom_tarif
+    ORDER BY tarifs.IDactivite, tarifs.date_debut, tarifs.IDtarif;""")
+
+    resultats = []
+    for valeurs in lignes:
+        tarif = dict(zip(CHAMPS_TARIFS, valeurs))
+        for champ in CHAMPS_LISTES_IDS:
+            tarif[champ] = convertir_liste_ids(tarif.get(champ))
+        tarif["etats"] = convertir_liste_ids(tarif.get("etats"), type_texte=True)
+        resultats.append(tarif)
+    return resultats
+
+
+def charger_baremes(DB, IDsactivites=None):
+    """Charge et enrichit les barèmes, puis les développe par catégorie tarifaire."""
+    activites = _charger_activites(DB)
+    categories = _charger_categories(DB)
+    lignes_calcul = _charger_lignes_calcul(DB)
+    filtres = _charger_filtres(DB)
+    tarifs = _charger_tarifs(DB)
+
+    filtre_activites = set(IDsactivites) if IDsactivites else None
+    resultats = []
+
+    for tarif in tarifs:
+        IDactivite = tarif.get("IDactivite")
+        if filtre_activites is not None and IDactivite not in filtre_activites:
+            continue
+
+        base = dict(tarif)
+        base["nom_activite"] = activites.get(IDactivite, "")
+        base["lignes_calcul"] = list(lignes_calcul.get(base.get("IDtarif"), []))
+        base["filtres"] = list(filtres.get(base.get("IDtarif"), []))
+
+        IDs_categories = base.get("categories_tarifs") or [None]
+        for IDcategorie_tarif in IDs_categories:
+            item = dict(base)
+            item["IDcategorie_tarif"] = IDcategorie_tarif
+            categorie = categories.get(IDcategorie_tarif, {})
+            if categorie and categorie.get("IDactivite") != IDactivite:
+                # Donnée historique incohérente : ne pas attribuer le nom d'une
+                # catégorie appartenant à une autre activité.
+                item["nom_categorie_tarif"] = ""
+            else:
+                item["nom_categorie_tarif"] = categorie.get("nom", "")
+            resultats.append(item)
+
+    return resultats

--- a/noethys/Utils/UTILS_Portail_tarifs_donnees.py
+++ b/noethys/Utils/UTILS_Portail_tarifs_donnees.py
@@ -40,6 +40,12 @@ CHAMPS_LISTES_IDS = (
     "jours_vacances",
 )
 
+POLITIQUE_DEFAUT = {
+    "mode": "automatique",
+    "IDsactivites": [],
+    "IDsactivites_exclues": [],
+}
+
 
 def convertir_liste_ids(valeur, type_texte=False):
     """Reprend le format historique Noethys ``1;2;3`` sans dépendance GUI."""
@@ -66,6 +72,45 @@ def convertir_liste_ids(valeur, type_texte=False):
                 # d'être visible lors d'une recette réelle.
                 resultats.append(item)
     return resultats or None
+
+
+def normaliser_politique(politique=None, IDsactivites=None):
+    """Normalise la politique de sélection des activités à publier.
+
+    Le mode ``automatique`` est volontairement le défaut : toute activité qui
+    reçoit plus tard un barème Noethys courant ou futur peut donc apparaître
+    sans qu'il soit nécessaire de revenir cocher son nouvel ID dans le bloc.
+
+    ``IDsactivites`` reste accepté pour compatibilité avec les premiers appels
+    du module et bascule alors en mode ``selection`` explicite.
+    """
+    if IDsactivites is not None:
+        return {
+            "mode": "selection",
+            "IDsactivites": list(IDsactivites),
+            "IDsactivites_exclues": [],
+        }
+
+    resultat = dict(POLITIQUE_DEFAUT)
+    if politique:
+        resultat.update(dict(politique))
+
+    mode = str(resultat.get("mode") or "automatique").strip().lower()
+    if mode not in ("automatique", "selection"):
+        mode = "automatique"
+    resultat["mode"] = mode
+    resultat["IDsactivites"] = list(resultat.get("IDsactivites") or [])
+    resultat["IDsactivites_exclues"] = list(resultat.get("IDsactivites_exclues") or [])
+    return resultat
+
+
+def activite_autorisee(IDactivite, politique):
+    politique = normaliser_politique(politique)
+    if IDactivite in set(politique["IDsactivites_exclues"]):
+        return False
+    if politique["mode"] == "selection":
+        return IDactivite in set(politique["IDsactivites"])
+    return True
 
 
 def _executer(DB, requete):
@@ -149,20 +194,25 @@ def _charger_tarifs(DB):
     return resultats
 
 
-def charger_baremes(DB, IDsactivites=None):
-    """Charge et enrichit les barèmes, puis les développe par catégorie tarifaire."""
+def charger_baremes(DB, IDsactivites=None, politique=None):
+    """Charge les barèmes et les développe par catégorie tarifaire.
+
+    En mode automatique, le filtre ne contient aucune liste figée d'activités :
+    une activité créée après la configuration du bloc sera donc découverte au
+    prochain rafraîchissement dès qu'elle possède un tarif publiable.
+    """
+    politique = normaliser_politique(politique=politique, IDsactivites=IDsactivites)
     activites = _charger_activites(DB)
     categories = _charger_categories(DB)
     lignes_calcul = _charger_lignes_calcul(DB)
     filtres = _charger_filtres(DB)
     tarifs = _charger_tarifs(DB)
 
-    filtre_activites = set(IDsactivites) if IDsactivites is not None else None
     resultats = []
 
     for tarif in tarifs:
         IDactivite = tarif.get("IDactivite")
-        if filtre_activites is not None and IDactivite not in filtre_activites:
+        if not activite_autorisee(IDactivite, politique):
             continue
 
         base = dict(tarif)
@@ -186,20 +236,29 @@ def charger_baremes(DB, IDsactivites=None):
     return resultats
 
 
-def construire_publication(DB, IDsactivites=None, date_reference=None,
-                            inclure_expires=False, titre="Tarifs des activités"):
+def construire_publication(DB, IDsactivites=None, politique=None,
+                            date_reference=None, inclure_expires=False,
+                            titre="Tarifs des activités"):
     """Construit la représentation et le HTML à partir de la base Noethys.
 
     Cette fonction ne modifie aucune donnée. Elle est destinée à alimenter un
     aperçu puis, dans un lot suivant, le cache HTML du bloc portail.
     """
-    baremes = charger_baremes(DB, IDsactivites=IDsactivites)
+    politique = normaliser_politique(politique=politique, IDsactivites=IDsactivites)
+    baremes = charger_baremes(DB, politique=politique)
     descriptions = UTILS_Portail_tarifs.decrire_tarifs(
         baremes,
         date_reference=date_reference,
         inclure_expires=inclure_expires,
     )
+    IDs_publies = sorted(set(
+        description.get("IDactivite")
+        for description in descriptions
+        if description.get("IDactivite") is not None
+    ))
     return {
+        "politique": politique,
+        "IDsactivites_publiees": IDs_publies,
         "baremes": baremes,
         "descriptions": descriptions,
         "html": UTILS_Portail_tarifs.construire_html(descriptions, titre=titre),

--- a/tests/test_portail_tarifs.py
+++ b/tests/test_portail_tarifs.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import datetime
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "noethys" / "Utils" / "UTILS_Portail_tarifs.py"
+SPEC = importlib.util.spec_from_file_location("UTILS_Portail_tarifs", MODULE_PATH)
+TARIFS = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(TARIFS)
+
+
+class PortailTarifsTests(unittest.TestCase):
+
+    def test_montant_unique_est_decrit_sans_inventer_de_contexte(self):
+        tarif = TARIFS.decrire_tarif({
+            "IDtarif": 10,
+            "IDactivite": 2,
+            "nom_activite": "École multisports",
+            "nom_tarif": "Licence annuelle",
+            "methode": "montant_unique",
+            "date_debut": "2026-09-01",
+            "date_fin": "2027-08-31",
+            "lignes_calcul": [{"montant_unique": 89}],
+        }, date_reference=datetime.date(2026, 9, 2))
+
+        self.assertEqual(tarif["statut"], "en_vigueur")
+        self.assertEqual(tarif["methode_label"], "Montant fixe")
+        self.assertEqual(tarif["regles"], [{"type": "montant", "montant": "89,00 €"}])
+        self.assertTrue(tarif["descriptible"])
+        self.assertTrue(tarif["exact_sans_contexte"])
+        self.assertEqual(tarif["avertissements"], [])
+
+    def test_qf_preserve_les_paliers_noethys(self):
+        tarif = TARIFS.decrire_tarif({
+            "nom_tarif": "Journée ALSH",
+            "methode": "qf",
+            "lignes_calcul": [
+                {"qf_min": 0, "qf_max": 699, "montant_unique": 9.35},
+                {"qf_min": 700, "qf_max": 999, "montant_unique": 10},
+                {"qf_min": 1000, "qf_max": 99999, "montant_unique": 10.35},
+            ],
+        })
+
+        self.assertEqual(len(tarif["regles"]), 3)
+        self.assertEqual(tarif["regles"][0], {
+            "type": "qf", "qf_min": 0.0, "qf_max": 699.0, "montant": "9,35 €"
+        })
+        self.assertEqual(tarif["regles"][2]["montant"], "10,35 €")
+        self.assertTrue(tarif["descriptible"])
+        self.assertFalse(tarif["exact_sans_contexte"])
+
+    def test_tarif_futur_est_identifie_sans_remplacer_le_tarif_courant(self):
+        tarif = TARIFS.decrire_tarif({
+            "nom_tarif": "Tarif rentrée",
+            "methode": "montant_unique",
+            "date_debut": "2026-09-01",
+            "lignes_calcul": [{"montant_unique": 12}],
+        }, date_reference=datetime.date(2026, 8, 21))
+        self.assertEqual(tarif["statut"], "futur")
+        self.assertEqual(tarif["date_debut"], "01/09/2026")
+
+    def test_tarif_contextuel_ne_devient_pas_un_faux_prix_personnalise(self):
+        tarif = TARIFS.decrire_tarif({
+            "nom_tarif": "Garderie",
+            "methode": "duree_qf",
+            "groupes": [1, 2],
+            "filtres": [{"IDquestion": 3}],
+            "lignes_calcul": [{"qf_min": 0, "qf_max": 1000, "montant_unique": 0.80}],
+        })
+
+        self.assertFalse(tarif["descriptible"])
+        self.assertFalse(tarif["exact_sans_contexte"])
+        self.assertEqual(tarif["regles"], [])
+        texte = " ".join(tarif["avertissements"])
+        self.assertIn("groupe de l'inscription", texte)
+        self.assertIn("questionnaire", texte)
+        self.assertIn("contexte réel", texte)
+
+    def test_dates_et_qf_sont_decrits_ligne_par_ligne(self):
+        tarif = TARIFS.decrire_tarif({
+            "nom_tarif": "Sortie",
+            "methode": "qf_date",
+            "lignes_calcul": [
+                {"date": "2026-10-21", "qf_min": 0, "qf_max": 699, "montant_unique": 5},
+                {"date": "2026-10-21", "qf_min": 700, "qf_max": 999, "montant_unique": 7.5},
+            ],
+        })
+        self.assertEqual(tarif["regles"][0]["date"], "21/10/2026")
+        self.assertEqual(tarif["regles"][1]["montant"], "7,50 €")
+
+    def test_html_echappe_les_libelles_et_indique_les_tarifs_contextuels(self):
+        descriptions = [
+            TARIFS.decrire_tarif({
+                "nom_activite": "ALSH <Bais>",
+                "nom_tarif": "Journée & repas",
+                "methode": "qf",
+                "lignes_calcul": [{"qf_min": 0, "qf_max": 699, "montant_unique": 9.35}],
+            }),
+            TARIFS.decrire_tarif({
+                "nom_tarif": "Montant événement",
+                "methode": "montant_evenement",
+                "lignes_calcul": [],
+            }),
+        ]
+        rendu = TARIFS.construire_html(descriptions, titre="Mes tarifs")
+
+        self.assertIn("ALSH &lt;Bais&gt;", rendu)
+        self.assertIn("Journée &amp; repas", rendu)
+        self.assertIn("9,35 €", rendu)
+        self.assertIn("Le montant dépend de la réservation ou de la situation réelle.", rendu)
+        self.assertNotIn("<Bais>", rendu)
+
+    def test_liste_exclut_les_tarifs_expires_par_defaut(self):
+        tarifs = [
+            {
+                "nom_tarif": "Ancien",
+                "methode": "montant_unique",
+                "date_fin": "2025-12-31",
+                "lignes_calcul": [{"montant_unique": 5}],
+            },
+            {
+                "nom_tarif": "Actuel",
+                "methode": "montant_unique",
+                "date_debut": "2026-01-01",
+                "lignes_calcul": [{"montant_unique": 6}],
+            },
+        ]
+        resultat = TARIFS.decrire_tarifs(tarifs, date_reference=datetime.date(2026, 8, 21))
+        self.assertEqual([x["nom"] for x in resultat], ["Actuel"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_portail_tarifs_donnees.py
+++ b/tests/test_portail_tarifs_donnees.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOETHYS = ROOT / "noethys"
+if str(NOETHYS) not in sys.path:
+    sys.path.insert(0, str(NOETHYS))
+
+from Data.DATA_Tables import DB_DATA
+from Utils import UTILS_Portail_tarifs_donnees as DONNEES
+
+
+class FakeDB(object):
+    def __init__(self):
+        self.requetes = []
+
+    def ExecuterReq(self, requete):
+        self.requetes.append(requete)
+        return True
+
+    def ResultatReq(self):
+        requete = self.requetes[-1]
+        if "FROM activites" in requete:
+            return [(1, "ALSH Bais"), (2, "École multisports")]
+        if "FROM categories_tarifs" in requete:
+            return [(10, 1, "QF A"), (11, 1, "QF B"), (20, 2, "EMS")]
+        if "FROM tarifs_lignes" in requete:
+            champs = [champ[0] for champ in DB_DATA["tarifs_lignes"]]
+            def ligne(IDtarif, num_ligne, qf_min, qf_max, montant):
+                valeurs = {champ: None for champ in champs}
+                valeurs.update({
+                    "IDligne": IDtarif * 100 + num_ligne,
+                    "IDactivite": 1,
+                    "IDtarif": IDtarif,
+                    "code": "qf",
+                    "num_ligne": num_ligne,
+                    "qf_min": qf_min,
+                    "qf_max": qf_max,
+                    "montant_unique": montant,
+                    "IDmodele": None,
+                })
+                return tuple(valeurs[champ] for champ in champs)
+            return [
+                ligne(100, 1, 0, 699, 9.35),
+                ligne(100, 2, 700, 999, 10.00),
+                ligne(200, 1, None, None, 89.00),
+            ]
+        if "FROM questionnaire_filtres" in requete:
+            return [(501, 100)]
+        if "FROM tarifs" in requete:
+            # Ordre strictement identique à CHAMPS_TARIFS.
+            return [
+                (
+                    100, 1, 1000, "Journée", "2026-09-01", "2027-08-31",
+                    0, 0, 0, 0, 0, "qf",
+                    "10;11", "1;2", None, "JOURN", None, None,
+                    None, None, None, None, "706", None, 0,
+                    None, "reservation;present", 1, "Accueil journée", "Journée", "", None,
+                ),
+                (
+                    200, 2, 2000, "Licence EMS", "2026-09-01", "2027-08-31",
+                    0, 0, 0, 0, 0, "montant_unique",
+                    "20", None, None, "FORFAIT", None, None,
+                    None, None, None, None, "706", None, 0,
+                    None, None, 1, "Licence annuelle", "EMS", "", None,
+                ),
+            ]
+        raise AssertionError("Requête inattendue : %s" % requete)
+
+
+class PortailTarifsDonneesTests(unittest.TestCase):
+
+    def test_conversion_du_format_historique_de_listes(self):
+        self.assertEqual(DONNEES.convertir_liste_ids("1;2;3"), [1, 2, 3])
+        self.assertEqual(DONNEES.convertir_liste_ids("reservation;present", type_texte=True), ["reservation", "present"])
+        self.assertIsNone(DONNEES.convertir_liste_ids(""))
+
+    def test_charge_les_baremes_et_les_developpe_par_categorie(self):
+        tarifs = DONNEES.charger_baremes(FakeDB())
+
+        # Le tarif ALSH attaché à deux catégories devient deux descriptions
+        # distinctes ; le tarif EMS n'en produit qu'une.
+        self.assertEqual(len(tarifs), 3)
+        alsh_a = tarifs[0]
+        alsh_b = tarifs[1]
+        ems = tarifs[2]
+
+        self.assertEqual(alsh_a["nom_activite"], "ALSH Bais")
+        self.assertEqual(alsh_a["IDcategorie_tarif"], 10)
+        self.assertEqual(alsh_a["nom_categorie_tarif"], "QF A")
+        self.assertEqual(alsh_b["IDcategorie_tarif"], 11)
+        self.assertEqual(alsh_b["nom_categorie_tarif"], "QF B")
+        self.assertEqual(len(alsh_a["lignes_calcul"]), 2)
+        self.assertEqual(alsh_a["lignes_calcul"][0]["montant_unique"], 9.35)
+        self.assertEqual(alsh_a["filtres"], [{"IDfiltre": 501}])
+        self.assertEqual(alsh_a["groupes"], [1, 2])
+        self.assertEqual(alsh_a["etats"], ["reservation", "present"])
+
+        self.assertEqual(ems["nom_activite"], "École multisports")
+        self.assertEqual(ems["nom_categorie_tarif"], "EMS")
+        self.assertEqual(ems["lignes_calcul"][0]["montant_unique"], 89.0)
+        self.assertEqual(ems["filtres"], [])
+
+    def test_filtre_par_activite_est_applique_apres_lecture(self):
+        tarifs = DONNEES.charger_baremes(FakeDB(), IDsactivites=[2])
+        self.assertEqual(len(tarifs), 1)
+        self.assertEqual(tarifs[0]["IDactivite"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_portail_tarifs_donnees.py
+++ b/tests/test_portail_tarifs_donnees.py
@@ -17,8 +17,9 @@ from Utils import UTILS_Portail_tarifs_donnees as DONNEES
 
 
 class FakeDB(object):
-    def __init__(self):
+    def __init__(self, nouvelle_activite=False):
         self.requetes = []
+        self.nouvelle_activite = nouvelle_activite
 
     def ExecuterReq(self, requete):
         self.requetes.append(requete)
@@ -27,18 +28,25 @@ class FakeDB(object):
     def ResultatReq(self):
         requete = self.requetes[-1]
         if "FROM activites" in requete:
-            return [(1, "ALSH Bais"), (2, "École multisports")]
+            lignes = [(1, "ALSH Bais"), (2, "École multisports")]
+            if self.nouvelle_activite:
+                lignes.append((3, "Sport-Santé"))
+            return lignes
         if "FROM categories_tarifs" in requete:
-            return [(10, 1, "QF A"), (11, 1, "QF B"), (20, 2, "EMS")]
+            lignes = [(10, 1, "QF A"), (11, 1, "QF B"), (20, 2, "EMS")]
+            if self.nouvelle_activite:
+                lignes.append((30, 3, "Sport-Santé"))
+            return lignes
         if "FROM tarifs_lignes" in requete:
             champs = [champ[0] for champ in DB_DATA["tarifs_lignes"]]
-            def ligne(IDtarif, num_ligne, qf_min, qf_max, montant):
+
+            def ligne(IDtarif, IDactivite, code, num_ligne, qf_min, qf_max, montant):
                 valeurs = {champ: None for champ in champs}
                 valeurs.update({
                     "IDligne": IDtarif * 100 + num_ligne,
-                    "IDactivite": 1,
+                    "IDactivite": IDactivite,
                     "IDtarif": IDtarif,
-                    "code": "qf",
+                    "code": code,
                     "num_ligne": num_ligne,
                     "qf_min": qf_min,
                     "qf_max": qf_max,
@@ -46,16 +54,20 @@ class FakeDB(object):
                     "IDmodele": None,
                 })
                 return tuple(valeurs[champ] for champ in champs)
-            return [
-                ligne(100, 1, 0, 699, 9.35),
-                ligne(100, 2, 700, 999, 10.00),
-                ligne(200, 1, None, None, 89.00),
+
+            lignes = [
+                ligne(100, 1, "qf", 1, 0, 699, 9.35),
+                ligne(100, 1, "qf", 2, 700, 999, 10.00),
+                ligne(200, 2, "montant_unique", 1, None, None, 89.00),
             ]
+            if self.nouvelle_activite:
+                lignes.append(ligne(300, 3, "montant_unique", 1, None, None, 109.00))
+            return lignes
         if "FROM questionnaire_filtres" in requete:
             return [(501, 100)]
         if "FROM tarifs" in requete:
             # Ordre strictement identique à CHAMPS_TARIFS.
-            return [
+            lignes = [
                 (
                     100, 1, 1000, "Journée", "2026-09-01", "2027-08-31",
                     0, 0, 0, 0, 0, "qf",
@@ -71,6 +83,15 @@ class FakeDB(object):
                     None, None, 1, "Licence annuelle", "EMS", "", None,
                 ),
             ]
+            if self.nouvelle_activite:
+                lignes.append((
+                    300, 3, 3000, "Sport-Santé annuel", "2026-09-01", "2027-08-31",
+                    0, 0, 0, 0, 0, "montant_unique",
+                    "30", None, None, "FORFAIT", None, None,
+                    None, None, None, None, "706", None, 0,
+                    None, None, 1, "Adhésion Sport-Santé", "Sport-Santé", "", None,
+                ))
+            return lignes
         raise AssertionError("Requête inattendue : %s" % requete)
 
 
@@ -80,6 +101,14 @@ class PortailTarifsDonneesTests(unittest.TestCase):
         self.assertEqual(DONNEES.convertir_liste_ids("1;2;3"), [1, 2, 3])
         self.assertEqual(DONNEES.convertir_liste_ids("reservation;present", type_texte=True), ["reservation", "present"])
         self.assertIsNone(DONNEES.convertir_liste_ids(""))
+
+    def test_politique_automatique_est_le_defaut(self):
+        politique = DONNEES.normaliser_politique()
+        self.assertEqual(politique, {
+            "mode": "automatique",
+            "IDsactivites": [],
+            "IDsactivites_exclues": [],
+        })
 
     def test_charge_les_baremes_et_les_developpe_par_categorie(self):
         tarifs = DONNEES.charger_baremes(FakeDB())
@@ -107,11 +136,33 @@ class PortailTarifsDonneesTests(unittest.TestCase):
         self.assertEqual(ems["lignes_calcul"][0]["montant_unique"], 89.0)
         self.assertEqual(ems["filtres"], [])
 
-    def test_filtre_par_activite_est_applique_apres_lecture(self):
+    def test_selection_explicite_reste_disponible(self):
         tarifs = DONNEES.charger_baremes(FakeDB(), IDsactivites=[2])
         self.assertEqual(len(tarifs), 1)
         self.assertEqual(tarifs[0]["IDactivite"], 2)
         self.assertEqual(DONNEES.charger_baremes(FakeDB(), IDsactivites=[]), [])
+
+    def test_nouvelle_activite_tarifee_est_incluse_sans_modifier_la_configuration(self):
+        publication = DONNEES.construire_publication(
+            FakeDB(nouvelle_activite=True),
+            date_reference=datetime.date(2026, 9, 2),
+        )
+
+        self.assertEqual(publication["politique"]["mode"], "automatique")
+        self.assertIn(3, publication["IDsactivites_publiees"])
+        self.assertIn("Sport-Santé", publication["html"])
+        self.assertIn("109,00 €", publication["html"])
+
+    def test_exclusion_explicite_survit_a_la_decouverte_automatique(self):
+        publication = DONNEES.construire_publication(
+            FakeDB(nouvelle_activite=True),
+            politique={"mode": "automatique", "IDsactivites_exclues": [3]},
+            date_reference=datetime.date(2026, 9, 2),
+        )
+
+        self.assertNotIn(3, publication["IDsactivites_publiees"])
+        self.assertNotIn("Sport-Santé", publication["html"])
+        self.assertIn("École multisports", publication["html"])
 
     def test_publication_relit_la_source_noethys_et_signale_les_conditions(self):
         publication = DONNEES.construire_publication(

--- a/tests/test_portail_tarifs_donnees.py
+++ b/tests/test_portail_tarifs_donnees.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import datetime
 import sys
 import unittest
 from pathlib import Path
@@ -110,6 +111,29 @@ class PortailTarifsDonneesTests(unittest.TestCase):
         tarifs = DONNEES.charger_baremes(FakeDB(), IDsactivites=[2])
         self.assertEqual(len(tarifs), 1)
         self.assertEqual(tarifs[0]["IDactivite"], 2)
+        self.assertEqual(DONNEES.charger_baremes(FakeDB(), IDsactivites=[]), [])
+
+    def test_publication_relit_la_source_noethys_et_signale_les_conditions(self):
+        publication = DONNEES.construire_publication(
+            FakeDB(),
+            IDsactivites=[1, 2],
+            date_reference=datetime.date(2026, 9, 2),
+        )
+
+        self.assertEqual(len(publication["baremes"]), 3)
+        self.assertEqual(len(publication["descriptions"]), 3)
+        html = publication["html"]
+        self.assertIn("Tarifs des activités", html)
+        self.assertIn("ALSH Bais", html)
+        self.assertIn("École multisports", html)
+        self.assertIn("QF A", html)
+        self.assertIn("9,35 €", html)
+        self.assertIn("89,00 €", html)
+        # Le tarif ALSH fictif porte groupe, filtre et états : la publication
+        # doit l'indiquer au lieu de le présenter comme un prix personnalisé.
+        self.assertIn("groupe de l&#x27;inscription", html)
+        self.assertIn("questionnaire", html)
+        self.assertIn("état de la consommation", html)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Objectif
Poser le socle de publication des tarifs Noethys sans créer une seconde logique de facturation.

## Implémentation
- nouveau module pur `UTILS_Portail_tarifs.py` sans wxPython ni accès base ;
- représentation canonique d'un barème : activité, tarif, validité, catégorie, méthode, règles et avertissements ;
- publication directe des méthodes descriptibles : montant fixe, QF, date, date+QF et choix ;
- identification des tarifs futurs / expirés ;
- rendu HTML autonome et échappé ;
- règles contextuelles explicitement signalées au lieu d'inventer un montant ;
- tests `unittest` exécutables par la CI actuelle ;
- documentation de la séparation V1 `Tarifs des activités` / V2 `Mes tarifs` personnalisée.

## Principe métier
Le moteur de facturation Noethys reste la source de vérité. Ce lot **décrit** les règles existantes ; il ne recalcule pas une facture et n'affiche pas « votre prix » lorsqu'une réservation, une durée, un événement, un questionnaire, un forfait/crédit ou une autre condition doit être résolu.

## Compatibilité Connecthys
La V1 pourra générer un `bloc_texte` historique à partir de ces descriptions, donc sans modification du Connecthys hébergé.

L'audit du Connecthys historique confirme en revanche que les pages personnalisées sont globales : la V2 réellement personnalisée par famille nécessitera un point d'intégration authentifié côté Connecthys. Aucun contournement par ID famille dans une URL ne sera introduit.

## Suite
1. lecteur SQL séparé des barèmes configurés ;
2. sélection des activités à publier ;
3. aperçu HTML dans Noethys ;
4. génération automatique du bloc portail ;
5. validation sur copie de base réelle avant toute personnalisation.

Avance #67 et #62. Dépend du socle #63.