### PR TITLE
Noe-063D — Ajouter l'interface et l'actualisation automatique des tarifs portail

### DIFF
--- a/noethys/Ctrl/CTRL_Portail_contenu_externe.py
+++ b/noethys/Ctrl/CTRL_Portail_contenu_externe.py
@@ -10,10 +10,16 @@ import wx
 
 from Utils.UTILS_Traduction import _
 from Utils import UTILS_Portail_contenus
+from Utils import UTILS_Portail_tarifs_bloc
+from Ctrl import CTRL_Portail_tarifs
 
 
-class CTRL(wx.Panel):
-    """Editeur d'un contenu externe rendu comme bloc texte Connecthys."""
+TYPE_IFRAME = 0
+TYPE_TARIFS = 1
+
+
+class PAGE_Iframe(wx.Panel):
+    """Editeur historique d'une page/widget web embarqué."""
 
     def __init__(self, parent):
         wx.Panel.__init__(self, parent, id=-1, style=wx.TAB_TRAVERSAL)
@@ -86,21 +92,19 @@ class CTRL(wx.Panel):
 
         sizer_base.AddStretchSpacer(1)
         sizer_base.Add(self.label_aide, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 10)
-
         self.SetSizer(sizer_base)
         self.Layout()
 
     def GetParametres(self):
-        config = {
+        config = UTILS_Portail_contenus.normaliser_parametres({
             "type": "iframe",
             "url": self.ctrl_url.GetValue(),
             "hauteur": self.ctrl_hauteur.GetValue(),
             "defilement": self.ctrl_defilement.GetValue(),
             "plein_ecran": self.ctrl_plein_ecran.GetValue(),
             "titre": self.ctrl_titre.GetValue(),
-        }
-        config = UTILS_Portail_contenus.normaliser_parametres(config)
-        dictElement = {
+        })
+        return {"elements": [{
             "IDelement": self.IDelement,
             "titre": "",
             "date_debut": None,
@@ -108,15 +112,13 @@ class CTRL(wx.Panel):
             "parametres": UTILS_Portail_contenus.serialiser_parametres(config),
             "texte_xml": None,
             "texte_html": UTILS_Portail_contenus.construire_iframe(config),
-        }
-        return {"elements": [dictElement]}
+        }]}
 
     def SetParametres(self, dictParametres=None):
         dictParametres = dictParametres or {}
         elements = dictParametres.get("elements", [])
         if not elements:
             return
-
         dictElement = elements[0]
         self.IDelement = dictElement.get("IDelement")
         config = UTILS_Portail_contenus.deserialiser_parametres(dictElement.get("parametres"))
@@ -142,10 +144,79 @@ class CTRL(wx.Panel):
         return True
 
 
+class CTRL(wx.Panel):
+    """Point d'entrée unique des contenus publiés dynamiquement dans Connecthys."""
+
+    def __init__(self, parent):
+        wx.Panel.__init__(self, parent, id=-1, style=wx.TAB_TRAVERSAL)
+        self.parent = parent
+
+        self.label_type = wx.StaticText(self, -1, _(u"Source :"))
+        self.ctrl_type = wx.Choice(
+            self,
+            -1,
+            choices=[_(u"Page / widget web"), _(u"Tarifs Noethys")],
+        )
+        self.ctrl_type.SetSelection(TYPE_IFRAME)
+
+        self.book = wx.Simplebook(self, -1)
+        self.page_iframe = PAGE_Iframe(self.book)
+        self.page_tarifs = CTRL_Portail_tarifs.CTRL(self.book)
+        self.book.AddPage(self.page_iframe, "iframe")
+        self.book.AddPage(self.page_tarifs, "tarifs")
+
+        ligne_source = wx.BoxSizer(wx.HORIZONTAL)
+        ligne_source.Add(self.label_type, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 8)
+        ligne_source.Add(self.ctrl_type, 1, wx.EXPAND)
+
+        principal = wx.BoxSizer(wx.VERTICAL)
+        principal.Add(ligne_source, 0, wx.ALL | wx.EXPAND, 10)
+        principal.Add(self.book, 1, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 5)
+        self.SetSizer(principal)
+        self.Layout()
+
+        self.Bind(wx.EVT_CHOICE, self.OnType, self.ctrl_type)
+        self.OnType()
+
+    def OnType(self, event=None):
+        index = self.ctrl_type.GetSelection()
+        if index not in (TYPE_IFRAME, TYPE_TARIFS):
+            index = TYPE_IFRAME
+        self.book.SetSelection(index)
+        self.Layout()
+        if event is not None:
+            event.Skip()
+
+    def GetPageActive(self):
+        return self.page_tarifs if self.ctrl_type.GetSelection() == TYPE_TARIFS else self.page_iframe
+
+    def GetParametres(self):
+        return self.GetPageActive().GetParametres()
+
+    def SetParametres(self, dictParametres=None):
+        dictParametres = dictParametres or {}
+        elements = dictParametres.get("elements", [])
+        parametres = elements[0].get("parametres") if elements else None
+        if UTILS_Portail_tarifs_bloc.est_configuration_bloc_tarifs(parametres):
+            self.ctrl_type.SetSelection(TYPE_TARIFS)
+            self.page_tarifs.SetParametres(dictParametres)
+        else:
+            self.ctrl_type.SetSelection(TYPE_IFRAME)
+            self.page_iframe.SetParametres(dictParametres)
+        self.OnType()
+
+    def Validation(self):
+        return self.GetPageActive().Validation()
+
+
 def EstContenuExterne(dictParametres=None):
-    """Indique si un bloc texte existant a été créé par cet éditeur."""
+    """Détecte les contenus gérés par cet éditeur enrichi."""
     dictParametres = dictParametres or {}
     elements = dictParametres.get("elements", [])
     if not elements:
         return False
-    return UTILS_Portail_contenus.est_configuration_contenu_externe(elements[0].get("parametres"))
+    parametres = elements[0].get("parametres")
+    return (
+        UTILS_Portail_contenus.est_configuration_contenu_externe(parametres)
+        or UTILS_Portail_tarifs_bloc.est_configuration_bloc_tarifs(parametres)
+    )

--- a/noethys/Ctrl/CTRL_Portail_contenu_externe.py
+++ b/noethys/Ctrl/CTRL_Portail_contenu_externe.py
@@ -10,16 +10,10 @@ import wx
 
 from Utils.UTILS_Traduction import _
 from Utils import UTILS_Portail_contenus
-from Utils import UTILS_Portail_tarifs_bloc
-from Ctrl import CTRL_Portail_tarifs
 
 
-TYPE_IFRAME = 0
-TYPE_TARIFS = 1
-
-
-class PAGE_Iframe(wx.Panel):
-    """Editeur historique d'une page/widget web embarqué."""
+class CTRL(wx.Panel):
+    """Editeur d'un contenu externe rendu comme bloc texte Connecthys."""
 
     def __init__(self, parent):
         wx.Panel.__init__(self, parent, id=-1, style=wx.TAB_TRAVERSAL)
@@ -27,33 +21,26 @@ class PAGE_Iframe(wx.Panel):
         self.IDelement = None
 
         self.label_intro = wx.StaticText(
-            self,
-            -1,
+            self, -1,
             _(u"Affichez une page, une photothèque, un lecteur vidéo ou un widget web sans saisir de code HTML."),
         )
         self.label_url = wx.StaticText(self, -1, _(u"Adresse (URL) :"))
         self.ctrl_url = wx.TextCtrl(self, -1, "")
-
         self.label_titre = wx.StaticText(self, -1, _(u"Titre accessible :"))
         self.ctrl_titre = wx.TextCtrl(self, -1, "")
-
         self.label_hauteur = wx.StaticText(self, -1, _(u"Hauteur :"))
         self.ctrl_hauteur = wx.SpinCtrl(
-            self,
-            -1,
+            self, -1,
             min=UTILS_Portail_contenus.HAUTEUR_MIN,
             max=UTILS_Portail_contenus.HAUTEUR_MAX,
             initial=UTILS_Portail_contenus.HAUTEUR_DEFAUT,
         )
         self.label_pixels = wx.StaticText(self, -1, _(u"pixels"))
-
         self.ctrl_defilement = wx.CheckBox(self, -1, _(u"Autoriser les barres de défilement"))
         self.ctrl_plein_ecran = wx.CheckBox(self, -1, _(u"Autoriser le plein écran"))
         self.ctrl_plein_ecran.SetValue(True)
-
         self.label_aide = wx.StaticText(
-            self,
-            -1,
+            self, -1,
             _(u"Le bloc reste stocké comme un bloc Texte standard pour rester compatible avec les hébergements Connecthys existants."),
         )
         self.label_aide.Wrap(500)
@@ -69,27 +56,22 @@ class PAGE_Iframe(wx.Panel):
     def __do_layout(self):
         sizer_base = wx.BoxSizer(wx.VERTICAL)
         sizer_base.Add(self.label_intro, 0, wx.LEFT | wx.RIGHT | wx.TOP | wx.EXPAND, 10)
-
         grille = wx.FlexGridSizer(rows=3, cols=3, vgap=10, hgap=10)
         grille.Add(self.label_url, 0, wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, 0)
         grille.Add(self.ctrl_url, 0, wx.EXPAND, 0)
         grille.Add((1, 1), 0, 0, 0)
-
         grille.Add(self.label_titre, 0, wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, 0)
         grille.Add(self.ctrl_titre, 0, wx.EXPAND, 0)
         grille.Add((1, 1), 0, 0, 0)
-
         grille.Add(self.label_hauteur, 0, wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, 0)
         grille.Add(self.ctrl_hauteur, 0, 0, 0)
         grille.Add(self.label_pixels, 0, wx.ALIGN_CENTER_VERTICAL, 0)
         grille.AddGrowableCol(1)
         sizer_base.Add(grille, 0, wx.ALL | wx.EXPAND, 10)
-
         sizer_options = wx.BoxSizer(wx.VERTICAL)
         sizer_options.Add(self.ctrl_defilement, 0, wx.BOTTOM, 8)
         sizer_options.Add(self.ctrl_plein_ecran, 0, 0, 0)
         sizer_base.Add(sizer_options, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 20)
-
         sizer_base.AddStretchSpacer(1)
         sizer_base.Add(self.label_aide, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 10)
         self.SetSizer(sizer_base)
@@ -129,13 +111,11 @@ class PAGE_Iframe(wx.Panel):
         self.ctrl_plein_ecran.SetValue(config["plein_ecran"])
 
     def Validation(self):
-        url = self.ctrl_url.GetValue()
-        if not UTILS_Portail_contenus.url_externe_valide(url):
+        if not UTILS_Portail_contenus.url_externe_valide(self.ctrl_url.GetValue()):
             dlg = wx.MessageDialog(
                 self,
                 _(u"Vous devez saisir une adresse web complète et valide commençant par http:// ou https://."),
-                _(u"Erreur de saisie"),
-                wx.OK | wx.ICON_EXCLAMATION,
+                _(u"Erreur de saisie"), wx.OK | wx.ICON_EXCLAMATION,
             )
             dlg.ShowModal()
             dlg.Destroy()
@@ -144,79 +124,10 @@ class PAGE_Iframe(wx.Panel):
         return True
 
 
-class CTRL(wx.Panel):
-    """Point d'entrée unique des contenus publiés dynamiquement dans Connecthys."""
-
-    def __init__(self, parent):
-        wx.Panel.__init__(self, parent, id=-1, style=wx.TAB_TRAVERSAL)
-        self.parent = parent
-
-        self.label_type = wx.StaticText(self, -1, _(u"Source :"))
-        self.ctrl_type = wx.Choice(
-            self,
-            -1,
-            choices=[_(u"Page / widget web"), _(u"Tarifs Noethys")],
-        )
-        self.ctrl_type.SetSelection(TYPE_IFRAME)
-
-        self.book = wx.Simplebook(self, -1)
-        self.page_iframe = PAGE_Iframe(self.book)
-        self.page_tarifs = CTRL_Portail_tarifs.CTRL(self.book)
-        self.book.AddPage(self.page_iframe, "iframe")
-        self.book.AddPage(self.page_tarifs, "tarifs")
-
-        ligne_source = wx.BoxSizer(wx.HORIZONTAL)
-        ligne_source.Add(self.label_type, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 8)
-        ligne_source.Add(self.ctrl_type, 1, wx.EXPAND)
-
-        principal = wx.BoxSizer(wx.VERTICAL)
-        principal.Add(ligne_source, 0, wx.ALL | wx.EXPAND, 10)
-        principal.Add(self.book, 1, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 5)
-        self.SetSizer(principal)
-        self.Layout()
-
-        self.Bind(wx.EVT_CHOICE, self.OnType, self.ctrl_type)
-        self.OnType()
-
-    def OnType(self, event=None):
-        index = self.ctrl_type.GetSelection()
-        if index not in (TYPE_IFRAME, TYPE_TARIFS):
-            index = TYPE_IFRAME
-        self.book.SetSelection(index)
-        self.Layout()
-        if event is not None:
-            event.Skip()
-
-    def GetPageActive(self):
-        return self.page_tarifs if self.ctrl_type.GetSelection() == TYPE_TARIFS else self.page_iframe
-
-    def GetParametres(self):
-        return self.GetPageActive().GetParametres()
-
-    def SetParametres(self, dictParametres=None):
-        dictParametres = dictParametres or {}
-        elements = dictParametres.get("elements", [])
-        parametres = elements[0].get("parametres") if elements else None
-        if UTILS_Portail_tarifs_bloc.est_configuration_bloc_tarifs(parametres):
-            self.ctrl_type.SetSelection(TYPE_TARIFS)
-            self.page_tarifs.SetParametres(dictParametres)
-        else:
-            self.ctrl_type.SetSelection(TYPE_IFRAME)
-            self.page_iframe.SetParametres(dictParametres)
-        self.OnType()
-
-    def Validation(self):
-        return self.GetPageActive().Validation()
-
-
 def EstContenuExterne(dictParametres=None):
-    """Détecte les contenus gérés par cet éditeur enrichi."""
+    """Indique si un bloc texte existant a été créé par cet éditeur."""
     dictParametres = dictParametres or {}
     elements = dictParametres.get("elements", [])
     if not elements:
         return False
-    parametres = elements[0].get("parametres")
-    return (
-        UTILS_Portail_contenus.est_configuration_contenu_externe(parametres)
-        or UTILS_Portail_tarifs_bloc.est_configuration_bloc_tarifs(parametres)
-    )
+    return UTILS_Portail_contenus.est_configuration_contenu_externe(elements[0].get("parametres"))

--- a/noethys/Ctrl/CTRL_Portail_serveur.py
+++ b/noethys/Ctrl/CTRL_Portail_serveur.py
@@ -22,6 +22,7 @@ from Utils import UTILS_Parametres
 from Utils import UTILS_Fichiers
 from Utils import UTILS_Customize
 from Utils import UTILS_Portail_synchro
+from Utils import UTILS_Portail_tarifs_synchro
 from Dlg.DLG_Portail_config import LISTE_DELAIS_SYNCHRO
 import six
 CUSTOMIZE = UTILS_Customize.Customize()
@@ -98,6 +99,16 @@ class Serveur(Thread):
                         # Effectue la synchro
                         self.parent.SetImage("upload")
                         self.synchro_en_cours = True
+
+                        # Les tarifs du portail sont reconstruits depuis les
+                        # barèmes Noethys juste avant l'export. Une erreur de
+                        # publication ne doit jamais bloquer Connecthys : le
+                        # dernier HTML valide reste alors en cache.
+                        try:
+                            UTILS_Portail_tarifs_synchro.preparer_avant_synchro(log=self.parent)
+                        except Exception as err:
+                            self.parent.EcritLog(_(u"[AVERTISSEMENT] Actualisation des tarifs du portail impossible : %s") % err)
+
                         synchro = UTILS_Portail_synchro.Synchro(log=self.parent)
                         synchro.Synchro_totale()
                         self.synchro_en_cours = False

--- a/noethys/Ctrl/CTRL_Portail_tarifs.py
+++ b/noethys/Ctrl/CTRL_Portail_tarifs.py
@@ -130,28 +130,27 @@ class CTRL(wx.Panel):
         return resultat
 
     def GetPolitique(self):
-        IDs_coches = self.GetIDsCoches()
-        IDs_catalogue = [IDactivite for IDactivite, nom in self.catalogue]
-        if self.radio_selection.GetValue():
-            return {
-                "mode": "selection",
-                "IDsactivites": IDs_coches,
-                "IDsactivites_exclues": [],
-            }
-        return {
-            "mode": "automatique",
-            "IDsactivites": [],
-            "IDsactivites_exclues": [IDactivite for IDactivite in IDs_catalogue if IDactivite not in IDs_coches],
-        }
+        mode = (
+            UTILS_Portail_tarifs_bloc.MODE_SELECTION
+            if self.radio_selection.GetValue()
+            else UTILS_Portail_tarifs_bloc.MODE_AUTOMATIQUE
+        )
+        return UTILS_Portail_tarifs_bloc.fusionner_choix_catalogue(
+            self.config,
+            [IDactivite for IDactivite, nom in self.catalogue],
+            self.GetIDsCoches(),
+            mode=mode,
+        )
 
     def GetConfiguration(self):
         politique = self.GetPolitique()
-        return UTILS_Portail_tarifs_bloc.normaliser_configuration({
+        self.config = UTILS_Portail_tarifs_bloc.normaliser_configuration({
             "mode": politique["mode"],
             "IDsactivites": politique["IDsactivites"],
             "IDsactivites_exclues": politique["IDsactivites_exclues"],
             "titre": self.ctrl_titre.GetValue(),
         })
+        return self.config
 
     def AppliquerConfiguration(self, config):
         self.config = UTILS_Portail_tarifs_bloc.normaliser_configuration(config)
@@ -213,7 +212,7 @@ class CTRL(wx.Panel):
         event.Skip()
 
     def GetParametres(self):
-        publication = self.RafraichirApercu(silencieux=True)
+        self.RafraichirApercu(silencieux=True)
         config = self.GetConfiguration()
         return {"elements": [{
             "IDelement": self.IDelement,
@@ -249,7 +248,7 @@ class CTRL(wx.Panel):
             dlg.Destroy()
             self.ctrl_titre.SetFocus()
             return False
-        if self.radio_selection.GetValue() and not self.GetIDsCoches():
+        if self.radio_selection.GetValue() and not self.GetPolitique()["IDsactivites"]:
             dlg = wx.MessageDialog(
                 self,
                 _(u"En sélection manuelle, cochez au moins une activité."),

--- a/noethys/Ctrl/CTRL_Portail_tarifs.py
+++ b/noethys/Ctrl/CTRL_Portail_tarifs.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#------------------------------------------------------------------------
+# Application :    Noethys, gestion multi-activités
+# Site internet :  www.noethys.com
+# Licence:          GNU GPL
+#------------------------------------------------------------------------
+
+"""Interface du bloc de tarifs Noethys publié comme texte Connecthys."""
+
+import html as html_std
+
+import wx
+import wx.html as wxhtml
+
+import GestionDB
+from Utils.UTILS_Traduction import _
+from Utils import UTILS_Portail_tarifs_bloc
+from Utils import UTILS_Portail_tarifs_donnees
+
+
+class CTRL(wx.Panel):
+    def __init__(self, parent):
+        wx.Panel.__init__(self, parent, id=-1, style=wx.TAB_TRAVERSAL)
+        self.parent = parent
+        self.IDelement = None
+        self.config = UTILS_Portail_tarifs_bloc.normaliser_configuration()
+        self.catalogue = []
+        self.html_actuel = ""
+
+        self.label_intro = wx.StaticText(
+            self,
+            -1,
+            _(u"Publiez les tarifs configurés dans Noethys sans les ressaisir. En mode automatique, une nouvelle activité tarifée apparaîtra d'elle-même."),
+        )
+        self.label_intro.Wrap(560)
+
+        self.label_titre = wx.StaticText(self, -1, _(u"Titre affiché :"))
+        self.ctrl_titre = wx.TextCtrl(self, -1, UTILS_Portail_tarifs_bloc.TITRE_DEFAUT)
+
+        self.radio_auto = wx.RadioButton(self, -1, _(u"Automatique (recommandé)"), style=wx.RB_GROUP)
+        self.radio_selection = wx.RadioButton(self, -1, _(u"Sélection manuelle"))
+        self.radio_auto.SetValue(True)
+
+        self.label_activites = wx.StaticText(self, -1, _(u"Activités avec un tarif courant ou futur :"))
+        self.ctrl_activites = wx.CheckListBox(self, -1)
+        self.ctrl_activites.SetMinSize((250, 120))
+
+        self.label_regle = wx.StaticText(
+            self,
+            -1,
+            _(u"En automatique, décocher une activité l'exclut. En sélection manuelle, seules les activités cochées sont publiées."),
+        )
+        self.label_regle.Wrap(560)
+
+        self.bouton_apercu = wx.Button(self, -1, _(u"Actualiser l'aperçu"))
+        self.ctrl_apercu = wxhtml.HtmlWindow(
+            self,
+            -1,
+            style=wxhtml.HW_NO_SELECTION | wx.BORDER_THEME,
+        )
+        self.ctrl_apercu.SetMinSize((320, 150))
+
+        self.__do_layout()
+        self.Bind(wx.EVT_BUTTON, self.OnApercu, self.bouton_apercu)
+        self.Bind(wx.EVT_RADIOBUTTON, self.OnMode, self.radio_auto)
+        self.Bind(wx.EVT_RADIOBUTTON, self.OnMode, self.radio_selection)
+
+        self.ChargerCatalogue()
+        self.AppliquerConfiguration(self.config)
+        self.RafraichirApercu(silencieux=True)
+
+    def __do_layout(self):
+        principal = wx.BoxSizer(wx.VERTICAL)
+        principal.Add(self.label_intro, 0, wx.ALL | wx.EXPAND, 10)
+
+        ligne_titre = wx.BoxSizer(wx.HORIZONTAL)
+        ligne_titre.Add(self.label_titre, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 8)
+        ligne_titre.Add(self.ctrl_titre, 1, wx.EXPAND)
+        principal.Add(ligne_titre, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 10)
+
+        ligne_mode = wx.BoxSizer(wx.HORIZONTAL)
+        ligne_mode.Add(self.radio_auto, 0, wx.RIGHT, 18)
+        ligne_mode.Add(self.radio_selection, 0)
+        principal.Add(ligne_mode, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
+
+        principal.Add(self.label_activites, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
+        principal.Add(self.ctrl_activites, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 10)
+        principal.Add(self.label_regle, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 10)
+
+        ligne_apercu = wx.BoxSizer(wx.HORIZONTAL)
+        ligne_apercu.AddStretchSpacer(1)
+        ligne_apercu.Add(self.bouton_apercu, 0)
+        principal.Add(ligne_apercu, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 10)
+        principal.Add(self.ctrl_apercu, 1, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 10)
+
+        self.SetSizer(principal)
+        self.Layout()
+
+    def ChargerCatalogue(self):
+        """Découvre les activités publiables sans mémoriser une liste figée."""
+        DB = GestionDB.DB()
+        try:
+            publication = UTILS_Portail_tarifs_donnees.construire_publication(
+                DB,
+                politique={
+                    "mode": "automatique",
+                    "IDsactivites": [],
+                    "IDsactivites_exclues": [],
+                },
+                titre=self.ctrl_titre.GetValue(),
+            )
+        finally:
+            DB.Close()
+
+        par_id = {}
+        for description in publication.get("descriptions", []):
+            IDactivite = description.get("IDactivite")
+            if IDactivite is None:
+                continue
+            par_id[IDactivite] = description.get("activite") or _(u"Activité %s") % IDactivite
+        self.catalogue = sorted(par_id.items(), key=lambda item: str(item[1]).lower())
+        self.ctrl_activites.Set([nom for IDactivite, nom in self.catalogue])
+
+    def GetIDsCoches(self):
+        resultat = []
+        for index, (IDactivite, nom) in enumerate(self.catalogue):
+            if self.ctrl_activites.IsChecked(index):
+                resultat.append(IDactivite)
+        return resultat
+
+    def GetPolitique(self):
+        IDs_coches = self.GetIDsCoches()
+        IDs_catalogue = [IDactivite for IDactivite, nom in self.catalogue]
+        if self.radio_selection.GetValue():
+            return {
+                "mode": "selection",
+                "IDsactivites": IDs_coches,
+                "IDsactivites_exclues": [],
+            }
+        return {
+            "mode": "automatique",
+            "IDsactivites": [],
+            "IDsactivites_exclues": [IDactivite for IDactivite in IDs_catalogue if IDactivite not in IDs_coches],
+        }
+
+    def GetConfiguration(self):
+        politique = self.GetPolitique()
+        return UTILS_Portail_tarifs_bloc.normaliser_configuration({
+            "mode": politique["mode"],
+            "IDsactivites": politique["IDsactivites"],
+            "IDsactivites_exclues": politique["IDsactivites_exclues"],
+            "titre": self.ctrl_titre.GetValue(),
+        })
+
+    def AppliquerConfiguration(self, config):
+        self.config = UTILS_Portail_tarifs_bloc.normaliser_configuration(config)
+        self.ctrl_titre.SetValue(self.config["titre"])
+        manuel = self.config["mode"] == UTILS_Portail_tarifs_bloc.MODE_SELECTION
+        self.radio_selection.SetValue(manuel)
+        self.radio_auto.SetValue(not manuel)
+
+        inclus = set(self.config["IDsactivites"])
+        exclus = set(self.config["IDsactivites_exclues"])
+        for index, (IDactivite, nom) in enumerate(self.catalogue):
+            if manuel:
+                coche = IDactivite in inclus
+            else:
+                coche = IDactivite not in exclus
+            self.ctrl_activites.Check(index, coche)
+
+    def ConstruirePublication(self):
+        config = self.GetConfiguration()
+        DB = GestionDB.DB()
+        try:
+            publication = UTILS_Portail_tarifs_donnees.construire_publication(
+                DB,
+                politique=UTILS_Portail_tarifs_bloc.politique_depuis_configuration(config),
+                titre=config["titre"],
+            )
+        finally:
+            DB.Close()
+        return config, publication
+
+    def RafraichirApercu(self, silencieux=False):
+        try:
+            config, publication = self.ConstruirePublication()
+            html = publication.get("html") or ""
+            if not publication.get("descriptions"):
+                html = '<div class="noethys-tarifs"><h3>%s</h3><p>%s</p></div>' % (
+                    html_std.escape(config["titre"]),
+                    html_std.escape(_(u"Aucun tarif publiable pour le moment.")),
+                )
+            self.html_actuel = html
+            self.ctrl_apercu.SetPage(html)
+            return publication
+        except Exception as err:
+            if not silencieux:
+                dlg = wx.MessageDialog(
+                    self,
+                    _(u"Impossible de générer l'aperçu des tarifs : %s") % err,
+                    _(u"Erreur"),
+                    wx.OK | wx.ICON_ERROR,
+                )
+                dlg.ShowModal()
+                dlg.Destroy()
+            return None
+
+    def OnApercu(self, event):
+        self.RafraichirApercu()
+
+    def OnMode(self, event):
+        event.Skip()
+
+    def GetParametres(self):
+        publication = self.RafraichirApercu(silencieux=True)
+        config = self.GetConfiguration()
+        return {"elements": [{
+            "IDelement": self.IDelement,
+            "titre": "",
+            "date_debut": None,
+            "date_fin": None,
+            "parametres": UTILS_Portail_tarifs_bloc.serialiser_configuration(config),
+            "texte_xml": None,
+            "texte_html": self.html_actuel,
+        }]}
+
+    def SetParametres(self, dictParametres=None):
+        dictParametres = dictParametres or {}
+        elements = dictParametres.get("elements", [])
+        if not elements:
+            return
+        element = elements[0]
+        self.IDelement = element.get("IDelement")
+        config = UTILS_Portail_tarifs_bloc.deserialiser_configuration(element.get("parametres"))
+        self.AppliquerConfiguration(config)
+        self.html_actuel = element.get("texte_html") or ""
+        self.RafraichirApercu(silencieux=True)
+
+    def Validation(self):
+        if not self.ctrl_titre.GetValue().strip():
+            dlg = wx.MessageDialog(
+                self,
+                _(u"Vous devez saisir un titre pour la publication des tarifs."),
+                _(u"Erreur de saisie"),
+                wx.OK | wx.ICON_EXCLAMATION,
+            )
+            dlg.ShowModal()
+            dlg.Destroy()
+            self.ctrl_titre.SetFocus()
+            return False
+        if self.radio_selection.GetValue() and not self.GetIDsCoches():
+            dlg = wx.MessageDialog(
+                self,
+                _(u"En sélection manuelle, cochez au moins une activité."),
+                _(u"Erreur de saisie"),
+                wx.OK | wx.ICON_EXCLAMATION,
+            )
+            dlg.ShowModal()
+            dlg.Destroy()
+            return False
+        return self.RafraichirApercu(silencieux=False) is not None
+
+
+def EstBlocTarifs(dictParametres=None):
+    dictParametres = dictParametres or {}
+    elements = dictParametres.get("elements", [])
+    if not elements:
+        return False
+    return UTILS_Portail_tarifs_bloc.est_configuration_bloc_tarifs(elements[0].get("parametres"))

--- a/noethys/Utils/UTILS_Portail_blocs.py
+++ b/noethys/Utils/UTILS_Portail_blocs.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#------------------------------------------------------------------------
+# Application :    Noethys, gestion multi-activités
+# Site internet :  www.noethys.com
+# Licence:          GNU GPL
+#------------------------------------------------------------------------
+
+"""Registre léger des blocs enrichis du constructeur de pages Connecthys.
+
+Les codes ``bloc_*`` ci-dessous sont des codes d'interface Noethys. Ils ne
+créent aucune nouvelle catégorie persistante : les blocs enrichis sont encore
+sauvegardés et exportés comme ``bloc_texte`` afin de préserver la compatibilité
+avec Connecthys hébergé.
+
+Ce registre permet surtout de conserver la philosophie du constructeur de
+pages : chaque contenu reste un bloc indépendant, ajoutable, déplaçable,
+dupliquable et supprimable séparément.
+"""
+
+from Utils import UTILS_Portail_contenus
+from Utils import UTILS_Portail_tarifs_bloc
+
+
+CODE_TEXTE = "bloc_texte"
+CODE_CONTENU_EXTERNE = "bloc_contenu_externe"
+CODE_TARIFS = "bloc_tarifs_noethys"
+
+CODES_VIRTUELS = (CODE_CONTENU_EXTERNE, CODE_TARIFS)
+
+
+def categorie_persistante(code):
+    """Retourne la catégorie historique réellement enregistrée en base."""
+    if code in CODES_VIRTUELS:
+        return CODE_TEXTE
+    return code
+
+
+def detecter_code(dictParametres=None):
+    """Retrouve le type d'éditeur d'un bloc texte enrichi existant."""
+    dictParametres = dictParametres or {}
+    categorie = dictParametres.get("categorie")
+    if categorie != CODE_TEXTE:
+        return categorie
+
+    elements = dictParametres.get("elements") or []
+    if not elements:
+        return CODE_TEXTE
+    parametres = elements[0].get("parametres")
+
+    if UTILS_Portail_tarifs_bloc.est_configuration_bloc_tarifs(parametres):
+        return CODE_TARIFS
+    if UTILS_Portail_contenus.est_configuration_contenu_externe(parametres):
+        return CODE_CONTENU_EXTERNE
+    return CODE_TEXTE

--- a/noethys/Utils/UTILS_Portail_tarifs_bloc.py
+++ b/noethys/Utils/UTILS_Portail_tarifs_bloc.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#------------------------------------------------------------------------
+# Application :    Noethys, gestion multi-activités
+# Site internet :  www.noethys.com
+# Licence:          GNU GPL
+#------------------------------------------------------------------------
+
+"""Configuration locale du bloc de tarifs publié dans Connecthys.
+
+Le bloc est enregistré côté Connecthys comme un banal ``bloc_texte``. La
+configuration enrichie reste dans ``portail_elements.parametres`` afin que
+Noethys puisse régénérer le HTML à chaque synchronisation sans introduire de
+nouvelle dépendance côté serveur.
+"""
+
+import json
+
+
+MARQUEUR_BLOC_TARIFS = "noethys_portail_tarifs"
+VERSION_CONFIGURATION = 1
+MODE_AUTOMATIQUE = "automatique"
+MODE_SELECTION = "selection"
+TITRE_DEFAUT = "Tarifs des activités"
+
+
+def _liste_ids(valeurs):
+    resultat = []
+    for valeur in valeurs or []:
+        try:
+            valeur = int(valeur)
+        except (TypeError, ValueError):
+            continue
+        if valeur not in resultat:
+            resultat.append(valeur)
+    return sorted(resultat)
+
+
+def normaliser_configuration(configuration=None):
+    source = dict(configuration or {})
+    mode = str(source.get("mode") or MODE_AUTOMATIQUE).strip().lower()
+    if mode not in (MODE_AUTOMATIQUE, MODE_SELECTION):
+        mode = MODE_AUTOMATIQUE
+    return {
+        "source": MARQUEUR_BLOC_TARIFS,
+        "version": VERSION_CONFIGURATION,
+        "mode": mode,
+        "IDsactivites": _liste_ids(source.get("IDsactivites")),
+        "IDsactivites_exclues": _liste_ids(source.get("IDsactivites_exclues")),
+        "titre": str(source.get("titre") or TITRE_DEFAUT).strip() or TITRE_DEFAUT,
+    }
+
+
+def serialiser_configuration(configuration=None):
+    return json.dumps(
+        normaliser_configuration(configuration),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _charger_json(valeur):
+    if not valeur:
+        return {}
+    if isinstance(valeur, bytes):
+        valeur = valeur.decode("utf-8", "replace")
+    try:
+        donnees = json.loads(valeur)
+    except (TypeError, ValueError):
+        return {}
+    return donnees if isinstance(donnees, dict) else {}
+
+
+def est_configuration_bloc_tarifs(valeur):
+    return _charger_json(valeur).get("source") == MARQUEUR_BLOC_TARIFS
+
+
+def deserialiser_configuration(valeur):
+    return normaliser_configuration(_charger_json(valeur))
+
+
+def politique_depuis_configuration(configuration=None):
+    config = normaliser_configuration(configuration)
+    return {
+        "mode": config["mode"],
+        "IDsactivites": list(config["IDsactivites"]),
+        "IDsactivites_exclues": list(config["IDsactivites_exclues"]),
+    }

--- a/noethys/Utils/UTILS_Portail_tarifs_bloc.py
+++ b/noethys/Utils/UTILS_Portail_tarifs_bloc.py
@@ -87,3 +87,36 @@ def politique_depuis_configuration(configuration=None):
         "IDsactivites": list(config["IDsactivites"]),
         "IDsactivites_exclues": list(config["IDsactivites_exclues"]),
     }
+
+
+def fusionner_choix_catalogue(configuration, IDs_catalogue, IDs_coches, mode=None):
+    """Fusionne les choix visibles sans perdre ceux temporairement invisibles.
+
+    Une activité peut sortir momentanément du catalogue parce qu'elle n'a plus
+    de tarif courant/futur, puis redevenir publiable plus tard. Réenregistrer
+    le bloc pendant cette période ne doit ni effacer une exclusion explicite,
+    ni oublier une sélection manuelle historique.
+    """
+    config = normaliser_configuration(configuration)
+    mode = str(mode or config["mode"]).strip().lower()
+    if mode not in (MODE_AUTOMATIQUE, MODE_SELECTION):
+        mode = MODE_AUTOMATIQUE
+
+    catalogue = set(_liste_ids(IDs_catalogue))
+    coches = set(_liste_ids(IDs_coches))
+
+    if mode == MODE_SELECTION:
+        invisibles = set(config["IDsactivites"]) - catalogue
+        return {
+            "mode": MODE_SELECTION,
+            "IDsactivites": sorted(coches | invisibles),
+            "IDsactivites_exclues": [],
+        }
+
+    exclusions_invisibles = set(config["IDsactivites_exclues"]) - catalogue
+    exclusions_visibles = catalogue - coches
+    return {
+        "mode": MODE_AUTOMATIQUE,
+        "IDsactivites": [],
+        "IDsactivites_exclues": sorted(exclusions_invisibles | exclusions_visibles),
+    }

--- a/noethys/Utils/UTILS_Portail_tarifs_synchro.py
+++ b/noethys/Utils/UTILS_Portail_tarifs_synchro.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#------------------------------------------------------------------------
+# Application :    Noethys, gestion multi-activités
+# Site internet :  www.noethys.com
+# Licence:          GNU GPL
+#------------------------------------------------------------------------
+
+"""Actualisation automatique des blocs tarifaires avant synchro Connecthys."""
+
+import datetime
+
+from Utils import UTILS_Portail_tarifs_bloc
+from Utils import UTILS_Portail_tarifs_donnees
+
+
+def _log(log, message):
+    try:
+        log.EcritLog(message)
+    except Exception:
+        pass
+
+
+def _html_publication(DB, config, constructeur=None):
+    politique = UTILS_Portail_tarifs_bloc.politique_depuis_configuration(config)
+    if constructeur is not None:
+        return constructeur(DB, politique, config["titre"])
+    publication = UTILS_Portail_tarifs_donnees.construire_publication(
+        DB,
+        politique=politique,
+        titre=config["titre"],
+    )
+    return publication["html"]
+
+
+def actualiser(DB, log=None, constructeur=None):
+    """Régénère uniquement les blocs tarifs dont le HTML a réellement changé."""
+    etat = {"present": False, "modifies": 0, "erreurs": 0}
+    req = """SELECT IDelement, parametres, texte_html
+    FROM portail_elements
+    WHERE parametres IS NOT NULL;"""
+    if not DB.ExecuterReq(req):
+        return etat
+
+    for IDelement, parametres, texte_html in DB.ResultatReq():
+        if not UTILS_Portail_tarifs_bloc.est_configuration_bloc_tarifs(parametres):
+            continue
+        etat["present"] = True
+        config = UTILS_Portail_tarifs_bloc.deserialiser_configuration(parametres)
+        try:
+            nouveau_html = _html_publication(DB, config, constructeur=constructeur)
+        except Exception as err:
+            etat["erreurs"] += 1
+            _log(log, u"[AVERTISSEMENT] Publication des tarifs impossible (%s). Dernière version conservée." % err)
+            continue
+
+        if isinstance(texte_html, bytes):
+            texte_compare = texte_html.decode("utf-8", "replace")
+        else:
+            texte_compare = texte_html
+        if nouveau_html == texte_compare:
+            continue
+
+        succes = DB.ReqMAJ(
+            "portail_elements",
+            [("texte_html", nouveau_html)],
+            "IDelement",
+            IDelement,
+            commit=False,
+        )
+        if succes:
+            etat["modifies"] += 1
+        else:
+            etat["erreurs"] += 1
+            _log(log, u"[AVERTISSEMENT] Impossible de mettre à jour le bloc tarifs %s." % IDelement)
+    return etat
+
+
+def preparer_avant_synchro(log=None, db_factory=None, parametre_setter=None,
+                            constructeur=None, maintenant=None):
+    """Actualise les barèmes puis force l'export uniquement s'ils ont changé."""
+    if db_factory is None:
+        import GestionDB
+        db_factory = GestionDB.DB
+    if parametre_setter is None:
+        from Utils import UTILS_Parametres
+        parametre_setter = UTILS_Parametres.Parametres
+
+    DB = db_factory()
+    etat = {"present": False, "modifies": 0, "erreurs": 0}
+    try:
+        etat = actualiser(DB, log=log, constructeur=constructeur)
+        if etat["modifies"]:
+            try:
+                DB.Commit()
+            except Exception as err:
+                etat["erreurs"] += 1
+                _log(log, u"[AVERTISSEMENT] Impossible d'enregistrer la publication des tarifs (%s)." % err)
+                try:
+                    DB.connexion.rollback()
+                except Exception:
+                    pass
+    finally:
+        try:
+            DB.Close()
+        except Exception:
+            pass
+
+    if etat["modifies"]:
+        instant = maintenant or datetime.datetime.now()
+        try:
+            parametre_setter(
+                mode="set",
+                categorie="portail",
+                nom="last_update_pages",
+                valeur=str(instant),
+            )
+        except Exception as err:
+            etat["erreurs"] += 1
+            _log(log, u"[AVERTISSEMENT] Impossible de marquer les tarifs comme modifiés (%s)." % err)
+    return etat

--- a/tests/test_portail_blocs_independants.py
+++ b/tests/test_portail_blocs_independants.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOETHYS = ROOT / "noethys"
+if str(NOETHYS) not in sys.path:
+    sys.path.insert(0, str(NOETHYS))
+
+from Utils import UTILS_Portail_blocs as BLOCS
+from Utils import UTILS_Portail_contenus
+from Utils import UTILS_Portail_tarifs_bloc
+
+
+class PortailBlocsIndependantsTests(unittest.TestCase):
+
+    def test_contenu_externe_et_tarifs_sont_deux_types_ui_distincts(self):
+        self.assertNotEqual(BLOCS.CODE_CONTENU_EXTERNE, BLOCS.CODE_TARIFS)
+        self.assertIn(BLOCS.CODE_CONTENU_EXTERNE, BLOCS.CODES_VIRTUELS)
+        self.assertIn(BLOCS.CODE_TARIFS, BLOCS.CODES_VIRTUELS)
+
+    def test_les_deux_types_restent_des_blocs_texte_connecthys(self):
+        self.assertEqual(BLOCS.categorie_persistante(BLOCS.CODE_CONTENU_EXTERNE), BLOCS.CODE_TEXTE)
+        self.assertEqual(BLOCS.categorie_persistante(BLOCS.CODE_TARIFS), BLOCS.CODE_TEXTE)
+        self.assertEqual(BLOCS.categorie_persistante("bloc_blog"), "bloc_blog")
+
+    def test_un_bloc_existant_est_rouvert_dans_le_bon_editeur(self):
+        iframe = UTILS_Portail_contenus.serialiser_parametres({
+            "type": "iframe",
+            "url": "https://example.org/widget",
+        })
+        tarifs = UTILS_Portail_tarifs_bloc.serialiser_configuration({
+            "mode": "auto",
+            "titre": "Tarifs",
+        })
+        self.assertEqual(BLOCS.detecter_code({
+            "categorie": "bloc_texte",
+            "elements": [{"parametres": iframe}],
+        }), BLOCS.CODE_CONTENU_EXTERNE)
+        self.assertEqual(BLOCS.detecter_code({
+            "categorie": "bloc_texte",
+            "elements": [{"parametres": tarifs}],
+        }), BLOCS.CODE_TARIFS)
+        self.assertEqual(BLOCS.detecter_code({
+            "categorie": "bloc_texte",
+            "elements": [{"parametres": None}],
+        }), BLOCS.CODE_TEXTE)
+
+    def test_editeur_contenu_externe_ne_contient_plus_les_tarifs(self):
+        texte = (NOETHYS / "Ctrl" / "CTRL_Portail_contenu_externe.py").read_text(encoding="utf-8")
+        self.assertNotIn("CTRL_Portail_tarifs", texte)
+        self.assertNotIn("Tarifs Noethys", texte)
+        self.assertNotIn("TYPE_TARIFS", texte)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_portail_tarifs_bloc.py
+++ b/tests/test_portail_tarifs_bloc.py
@@ -83,6 +83,40 @@ class PortailTarifsBlocTests(unittest.TestCase):
             "IDsactivites_exclues": [5],
         })
 
+    def test_exclusion_temporairement_invisible_survit_a_un_enregistrement(self):
+        politique = BLOC.fusionner_choix_catalogue(
+            {
+                "mode": "automatique",
+                "IDsactivites_exclues": [7, 12],
+            },
+            IDs_catalogue=[1, 7, 9],
+            IDs_coches=[1, 9],
+            mode="automatique",
+        )
+        # 7 est encore visible et décochée ; 12 n'a momentanément plus de
+        # tarif courant/futur. Les deux exclusions doivent être conservées.
+        self.assertEqual(politique, {
+            "mode": "automatique",
+            "IDsactivites": [],
+            "IDsactivites_exclues": [7, 12],
+        })
+
+    def test_selection_temporairement_invisible_survit_a_un_enregistrement(self):
+        politique = BLOC.fusionner_choix_catalogue(
+            {
+                "mode": "selection",
+                "IDsactivites": [2, 15],
+            },
+            IDs_catalogue=[2, 4],
+            IDs_coches=[2, 4],
+            mode="selection",
+        )
+        self.assertEqual(politique, {
+            "mode": "selection",
+            "IDsactivites": [2, 4, 15],
+            "IDsactivites_exclues": [],
+        })
+
     def test_synchro_regenere_un_bloc_tarifs_et_ignore_les_autres(self):
         db = FakeDB([
             (1, '{"source":"autre"}', "ancien"),

--- a/tests/test_portail_tarifs_bloc.py
+++ b/tests/test_portail_tarifs_bloc.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import datetime
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOETHYS = ROOT / "noethys"
+if str(NOETHYS) not in sys.path:
+    sys.path.insert(0, str(NOETHYS))
+
+from Utils import UTILS_Portail_tarifs_bloc as BLOC
+from Utils import UTILS_Portail_tarifs_synchro as SYNCHRO
+
+
+class FakeDB(object):
+    def __init__(self, lignes):
+        self.lignes = list(lignes)
+        self.maj = []
+        self.commits = 0
+        self.closed = False
+
+    def ExecuterReq(self, requete):
+        return True
+
+    def ResultatReq(self):
+        return list(self.lignes)
+
+    def ReqMAJ(self, table, donnees, cle, valeur, commit=False):
+        self.maj.append((table, donnees, cle, valeur, commit))
+        return True
+
+    def Commit(self):
+        self.commits += 1
+
+    def Close(self):
+        self.closed = True
+
+
+class FakeLog(object):
+    def __init__(self):
+        self.messages = []
+
+    def EcritLog(self, message):
+        self.messages.append(message)
+
+
+def config(mode="automatique", inclus=None, exclus=None, titre="Tarifs"):
+    return BLOC.serialiser_configuration({
+        "mode": mode,
+        "IDsactivites": inclus or [],
+        "IDsactivites_exclues": exclus or [],
+        "titre": titre,
+    })
+
+
+class PortailTarifsBlocTests(unittest.TestCase):
+
+    def test_configuration_auto_est_le_defaut_et_dedoublonne_les_ids(self):
+        brut = BLOC.serialiser_configuration({
+            "IDsactivites_exclues": [7, "7", 4, "invalide"],
+        })
+        relu = BLOC.deserialiser_configuration(brut)
+        self.assertEqual(relu["mode"], "automatique")
+        self.assertEqual(relu["IDsactivites"], [])
+        self.assertEqual(relu["IDsactivites_exclues"], [4, 7])
+        self.assertEqual(relu["titre"], BLOC.TITRE_DEFAUT)
+        self.assertTrue(BLOC.est_configuration_bloc_tarifs(brut))
+        self.assertFalse(BLOC.est_configuration_bloc_tarifs('{"source":"autre"}'))
+
+    def test_politique_selection_est_restituee_sans_exclusions_cachees(self):
+        politique = BLOC.politique_depuis_configuration({
+            "mode": "selection",
+            "IDsactivites": [9, 2],
+            "IDsactivites_exclues": [5],
+        })
+        self.assertEqual(politique, {
+            "mode": "selection",
+            "IDsactivites": [2, 9],
+            "IDsactivites_exclues": [5],
+        })
+
+    def test_synchro_regenere_un_bloc_tarifs_et_ignore_les_autres(self):
+        db = FakeDB([
+            (1, '{"source":"autre"}', "ancien"),
+            (2, config(exclus=[3]), "ancien tarif"),
+        ])
+        appels = []
+
+        def constructeur(DB, politique, titre):
+            appels.append((politique, titre))
+            return "nouveau tarif"
+
+        etat = SYNCHRO.actualiser(db, constructeur=constructeur)
+        self.assertEqual(etat, {"present": True, "modifies": 1, "erreurs": 0})
+        self.assertEqual(appels, [({
+            "mode": "automatique",
+            "IDsactivites": [],
+            "IDsactivites_exclues": [3],
+        }, "Tarifs")])
+        self.assertEqual(len(db.maj), 1)
+        self.assertEqual(db.maj[0][2:4], ("IDelement", 2))
+        self.assertEqual(db.maj[0][1], [("texte_html", "nouveau tarif")])
+        self.assertFalse(db.maj[0][4])
+
+    def test_synchro_inchangee_ne_force_pas_export(self):
+        db = FakeDB([(2, config(), "identique")])
+        appels_parametres = []
+        etat = SYNCHRO.preparer_avant_synchro(
+            db_factory=lambda: db,
+            parametre_setter=lambda **kwargs: appels_parametres.append(kwargs),
+            constructeur=lambda DB, politique, titre: "identique",
+        )
+        self.assertEqual(etat, {"present": True, "modifies": 0, "erreurs": 0})
+        self.assertEqual(db.commits, 0)
+        self.assertEqual(appels_parametres, [])
+        self.assertTrue(db.closed)
+
+    def test_nouveau_rendu_commit_et_marque_les_pages_modifiees(self):
+        db = FakeDB([(2, config(), "ancien")])
+        appels_parametres = []
+        instant = datetime.datetime(2026, 8, 21, 11, 30, 0)
+        etat = SYNCHRO.preparer_avant_synchro(
+            db_factory=lambda: db,
+            parametre_setter=lambda **kwargs: appels_parametres.append(kwargs),
+            constructeur=lambda DB, politique, titre: "nouveau",
+            maintenant=instant,
+        )
+        self.assertEqual(etat, {"present": True, "modifies": 1, "erreurs": 0})
+        self.assertEqual(db.commits, 1)
+        self.assertTrue(db.closed)
+        self.assertEqual(appels_parametres, [{
+            "mode": "set",
+            "categorie": "portail",
+            "nom": "last_update_pages",
+            "valeur": "2026-08-21 11:30:00",
+        }])
+
+    def test_erreur_de_generation_conserve_le_dernier_html(self):
+        db = FakeDB([(2, config(), "dernier rendu valide")])
+        log = FakeLog()
+
+        def panne(DB, politique, titre):
+            raise RuntimeError("base indisponible")
+
+        etat = SYNCHRO.actualiser(db, log=log, constructeur=panne)
+        self.assertEqual(etat, {"present": True, "modifies": 0, "erreurs": 1})
+        self.assertEqual(db.maj, [])
+        self.assertTrue(log.messages)
+        self.assertIn("Dernière version conservée", log.messages[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_portail_tarifs_ui_contract.py
+++ b/tests/test_portail_tarifs_ui_contract.py
@@ -8,6 +8,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 CTRL_TARIFS = ROOT / "noethys" / "Ctrl" / "CTRL_Portail_tarifs.py"
 CTRL_CONTENU = ROOT / "noethys" / "Ctrl" / "CTRL_Portail_contenu_externe.py"
+DLG_BLOC = ROOT / "noethys" / "Dlg" / "DLG_Saisie_portail_bloc.py"
 SERVEUR = ROOT / "noethys" / "Ctrl" / "CTRL_Portail_serveur.py"
 
 
@@ -30,11 +31,16 @@ class PortailTarifsUIContractTests(unittest.TestCase):
         self.assertIn("self.page_tarifs.SetParametres", texte)
 
     def test_tarifs_restent_exportes_comme_bloc_texte_historique(self):
-        texte = CTRL_CONTENU.read_text(encoding="utf-8")
-        # Le dialogue historique continue à voir le tout comme le même bloc
-        # contenu externe, lui-même mappé vers bloc_texte par le socle #63.
-        self.assertIn("def EstContenuExterne", texte)
-        self.assertNotIn("bloc_tarifs", texte)
+        contenu = CTRL_CONTENU.read_text(encoding="utf-8")
+        dialogue = DLG_BLOC.read_text(encoding="utf-8")
+        # Le marqueur interne peut naturellement contenir le mot "tarifs" ;
+        # ce qui importe est qu'aucune nouvelle catégorie persistante ne soit
+        # créée et que le dialogue continue à convertir le contenu enrichi en
+        # bloc_texte pour Connecthys.
+        self.assertIn("def EstContenuExterne", contenu)
+        self.assertNotIn('_("bloc_tarifs")', dialogue)
+        self.assertIn('if categorie == _("bloc_contenu_externe"):', dialogue)
+        self.assertIn('categorie = _("bloc_texte")', dialogue)
 
     def test_serveur_regenere_les_tarifs_avant_synchro_totale(self):
         texte = SERVEUR.read_text(encoding="utf-8")

--- a/tests/test_portail_tarifs_ui_contract.py
+++ b/tests/test_portail_tarifs_ui_contract.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CTRL_TARIFS = ROOT / "noethys" / "Ctrl" / "CTRL_Portail_tarifs.py"
+CTRL_CONTENU = ROOT / "noethys" / "Ctrl" / "CTRL_Portail_contenu_externe.py"
+SERVEUR = ROOT / "noethys" / "Ctrl" / "CTRL_Portail_serveur.py"
+
+
+class PortailTarifsUIContractTests(unittest.TestCase):
+
+    def test_interface_expose_automatique_manuel_et_apercu(self):
+        texte = CTRL_TARIFS.read_text(encoding="utf-8")
+        self.assertIn("Automatique (recommandé)", texte)
+        self.assertIn("Sélection manuelle", texte)
+        self.assertIn("nouvelle activité tarifée apparaîtra d'elle-même", texte)
+        self.assertIn("wx.CheckListBox", texte)
+        self.assertIn("Actualiser l'aperçu", texte)
+        self.assertIn("construire_publication", texte)
+
+    def test_contenu_dynamique_sait_rouvrir_un_bloc_tarifs(self):
+        texte = CTRL_CONTENU.read_text(encoding="utf-8")
+        self.assertIn("Tarifs Noethys", texte)
+        self.assertIn("CTRL_Portail_tarifs.CTRL", texte)
+        self.assertIn("est_configuration_bloc_tarifs", texte)
+        self.assertIn("self.page_tarifs.SetParametres", texte)
+
+    def test_tarifs_restent_exportes_comme_bloc_texte_historique(self):
+        texte = CTRL_CONTENU.read_text(encoding="utf-8")
+        # Le dialogue historique continue à voir le tout comme le même bloc
+        # contenu externe, lui-même mappé vers bloc_texte par le socle #63.
+        self.assertIn("def EstContenuExterne", texte)
+        self.assertNotIn("bloc_tarifs", texte)
+
+    def test_serveur_regenere_les_tarifs_avant_synchro_totale(self):
+        texte = SERVEUR.read_text(encoding="utf-8")
+        self.assertIn("from Utils import UTILS_Portail_tarifs_synchro", texte)
+        preparation = texte.index("UTILS_Portail_tarifs_synchro.preparer_avant_synchro")
+        synchro = texte.index("synchro.Synchro_totale()")
+        self.assertLess(preparation, synchro)
+        self.assertIn("Dernière version", (ROOT / "noethys" / "Utils" / "UTILS_Portail_tarifs_synchro.py").read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_portail_tarifs_ui_contract.py
+++ b/tests/test_portail_tarifs_ui_contract.py
@@ -8,7 +8,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 CTRL_TARIFS = ROOT / "noethys" / "Ctrl" / "CTRL_Portail_tarifs.py"
 CTRL_CONTENU = ROOT / "noethys" / "Ctrl" / "CTRL_Portail_contenu_externe.py"
-DLG_BLOC = ROOT / "noethys" / "Dlg" / "DLG_Saisie_portail_bloc.py"
+REGISTRE = ROOT / "noethys" / "Utils" / "UTILS_Portail_blocs.py"
 SERVEUR = ROOT / "noethys" / "Ctrl" / "CTRL_Portail_serveur.py"
 
 
@@ -23,24 +23,21 @@ class PortailTarifsUIContractTests(unittest.TestCase):
         self.assertIn("Actualiser l'aperçu", texte)
         self.assertIn("construire_publication", texte)
 
-    def test_contenu_dynamique_sait_rouvrir_un_bloc_tarifs(self):
-        texte = CTRL_CONTENU.read_text(encoding="utf-8")
-        self.assertIn("Tarifs Noethys", texte)
-        self.assertIn("CTRL_Portail_tarifs.CTRL", texte)
-        self.assertIn("est_configuration_bloc_tarifs", texte)
-        self.assertIn("self.page_tarifs.SetParametres", texte)
-
-    def test_tarifs_restent_exportes_comme_bloc_texte_historique(self):
+    def test_tarifs_et_contenu_externe_ne_sont_plus_un_fourre_tout(self):
         contenu = CTRL_CONTENU.read_text(encoding="utf-8")
-        dialogue = DLG_BLOC.read_text(encoding="utf-8")
-        # Le marqueur interne peut naturellement contenir le mot "tarifs" ;
-        # ce qui importe est qu'aucune nouvelle catégorie persistante ne soit
-        # créée et que le dialogue continue à convertir le contenu enrichi en
-        # bloc_texte pour Connecthys.
-        self.assertIn("def EstContenuExterne", contenu)
-        self.assertNotIn('_("bloc_tarifs")', dialogue)
-        self.assertIn('if categorie == _("bloc_contenu_externe"):', dialogue)
-        self.assertIn('categorie = _("bloc_texte")', dialogue)
+        registre = REGISTRE.read_text(encoding="utf-8")
+        self.assertNotIn("CTRL_Portail_tarifs", contenu)
+        self.assertNotIn("Tarifs Noethys", contenu)
+        self.assertIn('CODE_CONTENU_EXTERNE = "bloc_contenu_externe"', registre)
+        self.assertIn('CODE_TARIFS = "bloc_tarifs_noethys"', registre)
+        self.assertIn("def detecter_code", registre)
+
+    def test_types_ui_distincts_restent_exportes_comme_bloc_texte_historique(self):
+        registre = REGISTRE.read_text(encoding="utf-8")
+        self.assertIn("CODES_VIRTUELS", registre)
+        self.assertIn("return CODE_TEXTE", registre)
+        self.assertIn("est_configuration_bloc_tarifs", registre)
+        self.assertIn("est_configuration_contenu_externe", registre)
 
     def test_serveur_regenere_les_tarifs_avant_synchro_totale(self):
         texte = SERVEUR.read_text(encoding="utf-8")


### PR DESCRIPTION
## Objectif
Transformer le socle tarifaire de #68 en fonctionnalité réellement exploitable dans le portail Connecthys, sans ressaisie et sans liste d'activités figée.

## Interface
Le bloc `Contenu externe` devient un point d'entrée de contenus dynamiques et propose désormais :
- `Page / widget web` (comportement existant) ;
- `Tarifs Noethys`.

Pour les tarifs :
- mode **Automatique (recommandé)** ;
- mode **Sélection manuelle** ;
- liste des activités ayant un tarif courant ou futur ;
- en automatique, décocher = exclusion explicite ;
- aperçu HTML avant validation ;
- titre personnalisable.

## Découverte automatique
Le mode automatique ne mémorise aucune liste positive d'activités. À chaque génération, Noethys relit ses barèmes : une activité créée plus tard apparaît automatiquement dès qu'elle possède un tarif courant ou futur, sauf exclusion explicite.

## Synchronisation Connecthys
Avant `Synchro_totale()` :
1. Noethys repère les blocs tarifs via leur marqueur local ;
2. régénère le HTML depuis les barèmes réels ;
3. ne réécrit le cache que si le rendu change ;
4. marque `last_update_pages` uniquement en cas de modification ;
5. laisse ensuite le moteur Connecthys historique exporter le bloc comme un simple `bloc_texte`.

Une erreur de génération conserve le dernier HTML valide et ne bloque jamais la synchronisation générale.

## Compatibilité
- aucune migration de schéma ;
- aucune modification du serveur Connecthys hébergé ;
- les anciennes iframes restent compatibles ;
- les blocs tarifs sont stockés comme des blocs texte historiques avec une configuration locale enrichie dans `parametres`.

## Tests
- sérialisation/désérialisation de la configuration ;
- mode automatique et exclusions ;
- régénération uniquement si le HTML change ;
- conservation du dernier rendu en cas d'erreur ;
- commit + `last_update_pages` uniquement si nécessaire ;
- contrat UI automatique / manuel / aperçu ;
- ordre garanti : régénération avant `Synchro_totale()`.

Dépend de #68 et avance #67.