### PR TITLE
UI: moderniser la navigation commune Repens

### DIFF
--- a/noethys/Utils/UTILS_Aui.py
+++ b/noethys/Utils/UTILS_Aui.py
@@ -169,32 +169,92 @@ def ConfigurerGrille(grille):
     return True
 
 
-def ConfigurerNotebook(notebook):
-    """Donne aux onglets AUI une hauteur lisible et cohérente."""
-    if notebook is None:
+def _TypesNavigationStandard(wx):
+    """Retourne les contrôles book disponibles dans la version courante de wxPython."""
+    types_navigation = []
+    for nom in ("Notebook", "Choicebook", "Listbook", "Treebook", "Simplebook"):
+        classe = getattr(wx, nom, None)
+        if isinstance(classe, type):
+            types_navigation.append(classe)
+    return tuple(types_navigation)
+
+
+def _StyliserControleNavigation(controle, UTILS_Interface):
+    """Style un sélecteur interne de book sans modifier sa géométrie native."""
+    if controle is None:
+        return
+    try:
+        controle.SetBackgroundColour(UTILS_Interface.GetCouleurRole("surface_container_low"))
+        controle.SetForegroundColour(UTILS_Interface.GetCouleurRole("on_surface"))
+        controle.Refresh()
+    except Exception:
+        pass
+
+
+def ConfigurerNavigation(book):
+    """Applique Repens aux notebooks/listbooks/choicebooks sans redessiner leurs onglets."""
+    if book is None:
         return False
     try:
+        import wx
         import wx.lib.agw.aui as aui
         from Utils import UTILS_UIMetrics
         from Utils import UTILS_Interface
-        if not isinstance(notebook, aui.AuiNotebook):
-            return False
     except Exception:
         return False
 
+    types_standard = _TypesNavigationStandard(wx)
+    est_aui = isinstance(book, aui.AuiNotebook)
+    if not est_aui and (not types_standard or not isinstance(book, types_standard)):
+        return False
+
     try:
-        notebook.SetTabCtrlHeight(UTILS_UIMetrics.px(32))
+        book.SetBackgroundColour(UTILS_Interface.GetCouleurRole("surface"))
+        book.SetForegroundColour(UTILS_Interface.GetCouleurRole("on_surface"))
     except Exception:
         pass
+
+    # AUI expose explicitement la hauteur de sa barre d'onglets. Les books
+    # natifs conservent volontairement leur métrique plateforme et leur focus.
+    if est_aui:
+        try:
+            book.SetTabCtrlHeight(UTILS_UIMetrics.px(32))
+        except Exception:
+            pass
+
+    # Listbook/Choicebook/Treebook fournissent selon la version de wxPython un
+    # contrôle de navigation interne. On le thématise sans remplacer son rendu.
+    for getter in ("GetListView", "GetChoiceCtrl", "GetTreeCtrl"):
+        try:
+            controle = getattr(book, getter)()
+        except Exception:
+            controle = None
+        _StyliserControleNavigation(controle, UTILS_Interface)
+
+    # Les pages reçoivent uniquement les rôles de surface/texte. Leur layout,
+    # leurs tailles et leur logique métier restent intégralement inchangés.
     try:
-        notebook.SetBackgroundColour(UTILS_Interface.GetCouleurRole("surface"))
+        nombre_pages = book.GetPageCount()
     except Exception:
-        pass
+        nombre_pages = 0
+    for index in range(nombre_pages):
+        try:
+            page = book.GetPage(index)
+            page.SetBackgroundColour(UTILS_Interface.GetCouleurRole("surface"))
+            page.SetForegroundColour(UTILS_Interface.GetCouleurRole("on_surface"))
+        except Exception:
+            pass
+
     try:
-        notebook.Refresh()
+        book.Refresh()
     except Exception:
         pass
     return True
+
+
+def ConfigurerNotebook(notebook):
+    """Compatibilité historique : configure désormais toute navigation de type book."""
+    return ConfigurerNavigation(notebook)
 
 
 def _ConfigurerComposantsDuManager(manager):
@@ -207,6 +267,7 @@ def _ConfigurerComposantsDuManager(manager):
     except Exception:
         return
 
+    types_navigation = _TypesNavigationStandard(wx)
     deja_vues = set()
     for pane in panes:
         racine = getattr(pane, "window", None)
@@ -221,8 +282,8 @@ def _ConfigurerComposantsDuManager(manager):
                     taille_base = _TailleBitmapExistante(fenetre, defaut=16)
                 ConfigurerToolBar(fenetre, taille_base=taille_base, fond_uni=True)
                 continue
-            if isinstance(fenetre, aui.AuiNotebook):
-                ConfigurerNotebook(fenetre)
+            if isinstance(fenetre, aui.AuiNotebook) or (types_navigation and isinstance(fenetre, types_navigation)):
+                ConfigurerNavigation(fenetre)
                 continue
             if isinstance(fenetre, gridlib.Grid):
                 ConfigurerGrille(fenetre)

--- a/tests/test_navigation_ui_contract.py
+++ b/tests/test_navigation_ui_contract.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""Contrats statiques pour la navigation commune Repens."""
+
+import ast
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class NavigationUIContractTests(unittest.TestCase):
+    def _read_aui(self):
+        path = ROOT / "noethys/Utils/UTILS_Aui.py"
+        text = path.read_text(encoding="utf-8")
+        ast.parse(text)
+        return text
+
+    def test_common_book_navigation_is_semantic_and_cross_platform(self):
+        text = self._read_aui()
+        self.assertIn("def ConfigurerNavigation(book):", text)
+        self.assertIn('("Notebook", "Choicebook", "Listbook", "Treebook", "Simplebook")', text)
+        self.assertIn('GetCouleurRole("surface")', text)
+        self.assertIn('GetCouleurRole("surface_container_low")', text)
+        self.assertIn('GetCouleurRole("on_surface")', text)
+        self.assertIn('("GetListView", "GetChoiceCtrl", "GetTreeCtrl")', text)
+
+    def test_native_books_keep_platform_geometry_and_focus(self):
+        text = self._read_aui()
+        navigation = text.split("def ConfigurerNavigation(book):", 1)[1].split("def ConfigurerNotebook", 1)[0]
+        self.assertIn("if est_aui:", navigation)
+        self.assertIn("SetTabCtrlHeight", navigation)
+        self.assertNotIn("SetMinSize", navigation)
+        self.assertNotIn("SetSize", navigation)
+        self.assertNotIn("SetWindowStyle", navigation)
+
+    def test_historical_notebook_entry_point_delegates_to_common_navigation(self):
+        text = self._read_aui()
+        wrapper = text.split("def ConfigurerNotebook(notebook):", 1)[1].split("def _ConfigurerComposantsDuManager", 1)[0]
+        self.assertIn("return ConfigurerNavigation(notebook)", wrapper)
+
+    def test_aui_manager_discovers_standard_books_without_relaying_out_panes(self):
+        text = self._read_aui()
+        manager_components = text.split("def _ConfigurerComposantsDuManager(manager):", 1)[1].split("def _ConfigurerPoliceCaptions", 1)[0]
+        self.assertIn("types_navigation = _TypesNavigationStandard(wx)", manager_components)
+        self.assertIn("ConfigurerNavigation(fenetre)", manager_components)
+        self.assertNotIn("DockSize", manager_components)
+        self.assertNotIn("BestSize", manager_components)
+        self.assertNotIn("MinSize", manager_components)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Objet

Poursuivre la refonte UI commune sur le prochain lot prévu : la navigation et le workspace principal.

## Changements

- étend le style Repens aux `wx.Notebook`, `wx.Choicebook`, `wx.Listbook`, `wx.Treebook` et `wx.Simplebook` lorsqu'ils sont disponibles ;
- conserve la prise en charge de `AuiNotebook` et l'ancien point d'entrée `ConfigurerNotebook` ;
- applique les rôles sémantiques `surface`, `surface_container_low` et `on_surface` aux books et à leurs sélecteurs internes ;
- conserve les métriques, le focus et le rendu natifs des books standards ; seule la hauteur des onglets AUI reste explicitement responsive ;
- détecte automatiquement ces contrôles dans les panes du manager AUI sans modifier docking, tailles ou perspectives ;
- ajoute des contrats statiques dédiés pour empêcher une reprise de contrôle de la géométrie par la couche graphique.

## Principe

Modernisation centrale et progressive : aucune logique métier modifiée, aucun redessin local des onglets et aucune nouvelle dépendance.