### PR TITLE
UI: moderniser les tableaux et grilles Repens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
           python-version: "3.10"
 
       - name: Installer les dépendances minimales
-        run: pip install six appdirs python-dateutil pytz wxPython pyttsx3
+        run: pip install six appdirs python-dateutil pytz Pillow wxPython pyttsx3
 
       - name: Appliquer les corrections runtime Python 3 validées
         run: python scripts/apply_py3_runtime_source_fixes.py
@@ -195,7 +195,7 @@ jobs:
           python-version: "3.10"
 
       - name: Installer les dépendances minimales
-        run: python -m pip install --upgrade pip && python -m pip install six appdirs python-dateutil pytz wxPython pyttsx3
+        run: python -m pip install --upgrade pip && python -m pip install six appdirs python-dateutil pytz Pillow wxPython pyttsx3
 
       - name: Appliquer les corrections runtime Python 3 validées
         run: python scripts/apply_py3_runtime_source_fixes.py
@@ -230,7 +230,7 @@ jobs:
       - name: Installer wxPython GTK3 et X virtuel
         run: |
           sudo apt-get update
-          sudo apt-get install -y xvfb xauth python3-wxgtk4.0
+          sudo apt-get install -y xvfb xauth python3-appdirs python3-pil python3-wxgtk4.0
 
       - name: Appliquer les corrections runtime Python 3 validées
         run: /usr/bin/python3 scripts/apply_py3_runtime_source_fixes.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
           python-version: "3.10"
 
       - name: Installer les dépendances minimales
-        run: pip install six appdirs python-dateutil pytz Pillow wxPython pyttsx3
+        run: pip install six appdirs python-dateutil pytz Pillow pycryptodome wxPython pyttsx3
 
       - name: Appliquer les corrections runtime Python 3 validées
         run: python scripts/apply_py3_runtime_source_fixes.py
@@ -195,7 +195,7 @@ jobs:
           python-version: "3.10"
 
       - name: Installer les dépendances minimales
-        run: python -m pip install --upgrade pip && python -m pip install six appdirs python-dateutil pytz Pillow wxPython pyttsx3
+        run: python -m pip install --upgrade pip && python -m pip install six appdirs python-dateutil pytz Pillow pycryptodome wxPython pyttsx3
 
       - name: Appliquer les corrections runtime Python 3 validées
         run: python scripts/apply_py3_runtime_source_fixes.py
@@ -230,7 +230,7 @@ jobs:
       - name: Installer wxPython GTK3 et X virtuel
         run: |
           sudo apt-get update
-          sudo apt-get install -y xvfb xauth python3-appdirs python3-pil python3-wxgtk4.0
+          sudo apt-get install -y xvfb xauth python3-appdirs python3-pil python3-pycryptodome python3-wxgtk4.0
 
       - name: Appliquer les corrections runtime Python 3 validées
         run: /usr/bin/python3 scripts/apply_py3_runtime_source_fixes.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
           python-version: "3.10"
 
       - name: Installer les dépendances minimales
-        run: pip install six appdirs python-dateutil pytz Pillow pycryptodome wxPython pyttsx3
+        run: pip install six appdirs python-dateutil pytz Pillow pycryptodome reportlab wxPython pyttsx3
 
       - name: Appliquer les corrections runtime Python 3 validées
         run: python scripts/apply_py3_runtime_source_fixes.py
@@ -195,7 +195,7 @@ jobs:
           python-version: "3.10"
 
       - name: Installer les dépendances minimales
-        run: python -m pip install --upgrade pip && python -m pip install six appdirs python-dateutil pytz Pillow pycryptodome wxPython pyttsx3
+        run: python -m pip install --upgrade pip && python -m pip install six appdirs python-dateutil pytz Pillow pycryptodome reportlab wxPython pyttsx3
 
       - name: Appliquer les corrections runtime Python 3 validées
         run: python scripts/apply_py3_runtime_source_fixes.py
@@ -230,7 +230,7 @@ jobs:
       - name: Installer wxPython GTK3 et X virtuel
         run: |
           sudo apt-get update
-          sudo apt-get install -y xvfb xauth python3-appdirs python3-pil python3-pycryptodome python3-wxgtk4.0
+          sudo apt-get install -y xvfb xauth python3-appdirs python3-pil python3-pycryptodome python3-reportlab python3-wxgtk4.0
 
       - name: Appliquer les corrections runtime Python 3 validées
         run: /usr/bin/python3 scripts/apply_py3_runtime_source_fixes.py

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -162,7 +162,11 @@ jobs:
             $errorMarker = Join-Path $testRoot "FROZEN-SMOKE-ERROR.txt"
             $okMarker = Join-Path $testRoot "FROZEN-SMOKE-OK.txt"
             if ($process.ExitCode -ne 0) {
-              if (Test-Path $errorMarker) { Get-Content $errorMarker | Write-Error }
+              if (Test-Path $errorMarker) {
+                Write-Host "----- FROZEN-SMOKE-ERROR -----"
+                Get-Content $errorMarker | ForEach-Object { Write-Host $_ }
+                Write-Host "------------------------------"
+              }
               throw "Smoke de l'exécutable figé en échec (code $($process.ExitCode))"
             }
             if (-not (Test-Path $okMarker)) {

--- a/noethys/Ctrl/CTRL_Bandeau.py
+++ b/noethys/Ctrl/CTRL_Bandeau.py
@@ -8,7 +8,6 @@
 # Licence:          Licence GNU GPL
 #-----------------------------------------------------------
 
-import html as html_std
 import re
 
 import Chemins
@@ -16,6 +15,49 @@ import wx
 from Ctrl import CTRL_TexteRepens
 from Utils import UTILS_StyleRepens as Style
 from Utils.UTILS_Traduction import _
+
+
+# Ne pas importer la stdlib ``html`` ici. Le bundle PyInstaller historique de
+# Noethys est volontairement plat et contient aussi ``wx/html.py`` : sur Windows,
+# un import absolu ``html`` peut alors être résolu contre wx.html et casser ses
+# imports relatifs. Les bandeaux n'ont besoin que d'un sous-ensemble compact des
+# entités HTML réellement rencontrées dans les anciens textes d'introduction.
+_ENTITES_HTML = {
+    "amp": "&", "lt": "<", "gt": ">", "quot": '"', "apos": "'", "nbsp": "\u00a0",
+    "agrave": "à", "aacute": "á", "acirc": "â", "auml": "ä", "aring": "å", "aelig": "æ",
+    "ccedil": "ç", "egrave": "è", "eacute": "é", "ecirc": "ê", "euml": "ë",
+    "igrave": "ì", "iacute": "í", "icirc": "î", "iuml": "ï",
+    "ograve": "ò", "oacute": "ó", "ocirc": "ô", "ouml": "ö", "oelig": "œ",
+    "ugrave": "ù", "uacute": "ú", "ucirc": "û", "uuml": "ü", "yuml": "ÿ",
+    "Agrave": "À", "Aacute": "Á", "Acirc": "Â", "Auml": "Ä", "Aring": "Å", "AElig": "Æ",
+    "Ccedil": "Ç", "Egrave": "È", "Eacute": "É", "Ecirc": "Ê", "Euml": "Ë",
+    "Igrave": "Ì", "Iacute": "Í", "Icirc": "Î", "Iuml": "Ï",
+    "Ograve": "Ò", "Oacute": "Ó", "Ocirc": "Ô", "Ouml": "Ö", "OElig": "Œ",
+    "Ugrave": "Ù", "Uacute": "Ú", "Ucirc": "Û", "Uuml": "Ü", "Yuml": "Ÿ",
+    "laquo": "«", "raquo": "»", "lsquo": "‘", "rsquo": "’", "ldquo": "“", "rdquo": "”",
+    "ndash": "–", "mdash": "—", "hellip": "…", "bull": "•", "middot": "·",
+    "copy": "©", "reg": "®", "trade": "™", "euro": "€", "deg": "°",
+}
+_RE_ENTITE_HTML = re.compile(r"&(#(?:x[0-9A-Fa-f]+|[0-9]+)|[A-Za-z][A-Za-z0-9]+);")
+
+
+def _decoder_entites_html(texte):
+    """Décode les entités utiles sans dépendre d'un module nommé ``html``."""
+    def remplacer(match):
+        code = match.group(1)
+        if code.startswith("#x"):
+            try:
+                return chr(int(code[2:], 16))
+            except (TypeError, ValueError, OverflowError):
+                return match.group(0)
+        if code.startswith("#"):
+            try:
+                return chr(int(code[1:], 10))
+            except (TypeError, ValueError, OverflowError):
+                return match.group(0)
+        return _ENTITES_HTML.get(code, match.group(0))
+
+    return _RE_ENTITE_HTML.sub(remplacer, texte)
 
 
 def _texte_simple(texte):
@@ -26,11 +68,7 @@ def _texte_simple(texte):
     texte = re.sub(r"(?i)<\s*br\s*/?\s*>", "\n", texte)
     texte = re.sub(r"(?i)</\s*p\s*>", "\n", texte)
     texte = re.sub(r"<[^>]+>", "", texte)
-    try:
-        texte = html_std.unescape(texte)
-    except Exception:
-        pass
-    return texte.strip()
+    return _decoder_entites_html(texte).strip()
 
 
 def _bitmap_adapte(chemin, taille):

--- a/noethys/Ctrl/CTRL_TableauResponsive.py
+++ b/noethys/Ctrl/CTRL_TableauResponsive.py
@@ -119,7 +119,7 @@ class ListeTableau(wx.ListCtrl):
     """Liste wx native à colonnes pondérées et métriques DPI-aware."""
 
     def __init__(self, parent, colonnes, style=0):
-        style |= wx.LC_REPORT | wx.LC_HRULES
+        style |= wx.LC_REPORT | wx.LC_HRULES | wx.BORDER_NONE
         wx.ListCtrl.__init__(self, parent, style=style)
         self.colonnes = tuple(colonnes or ())
         self._donnees = []
@@ -154,12 +154,21 @@ class ListeTableau(wx.ListCtrl):
             return ""
         return str(valeur)
 
+    def _StyliserLigne(self, item, index):
+        """Alterne deux surfaces discrètes sans ajouter de renderer maison."""
+        role = "surface_container_lowest" if index % 2 == 0 else "surface_container_low"
+        try:
+            self.SetItemBackgroundColour(item, Style.couleur(role))
+            self.SetItemTextColour(item, Style.couleur("on_surface"))
+        except Exception:
+            pass
+
     def SetDonnees(self, donnees):
         self.Freeze()
         try:
             self.DeleteAllItems()
             self._donnees = list(donnees or ())
-            for ligne in self._donnees:
+            for index_ligne, ligne in enumerate(self._donnees):
                 if not isinstance(ligne, dict):
                     try:
                         ligne = dict(ligne)
@@ -172,6 +181,7 @@ class ListeTableau(wx.ListCtrl):
                 for index_colonne, colonne in enumerate(self.colonnes[1:], start=1):
                     texte = self._texte(colonne, ligne.get(colonne.cle), ligne)
                     self.SetItem(item, index_colonne, texte)
+                self._StyliserLigne(item, index_ligne)
         finally:
             self.Thaw()
         UTILS_ColonnesResponsive.Ajuster(self)
@@ -193,17 +203,22 @@ class PanneauTableau(wx.Panel):
         self.entete = EnteteSection(self, titre=titre, sous_titre=sous_titre)
         self.actions = BarreActions(self, actions=actions) if actions else None
         self.tableau = ListeTableau(self, colonnes=colonnes)
-        self.recherche = wx.SearchCtrl(self, style=wx.TE_PROCESS_ENTER) if recherche else None
-        self.etat = wx.StaticText(self, label="")
+        self.barre_donnees = wx.Panel(self, style=wx.TAB_TRAVERSAL | wx.BORDER_NONE)
+        Style.appliquer_fenetre(self.barre_donnees, "surface_container_low")
+
+        self.recherche = wx.SearchCtrl(self.barre_donnees, style=wx.TE_PROCESS_ENTER) if recherche else None
+        self.etat = wx.StaticText(self.barre_donnees, label="")
         Style.appliquer_texte(
             self.etat,
             role="body_small",
             role_texte="on_surface_variant",
-            role_fond="surface",
+            role_fond="surface_container_low",
         )
 
         if self.recherche is not None:
             Style.appliquer_saisie(self.recherche)
+            self.recherche.SetMinSize((Style.px(180), Style.cible_action("compact")))
+            self.recherche.SetMaxSize((Style.px(360), -1))
             self.recherche.ShowSearchButton(True)
             self.recherche.ShowCancelButton(True)
             self.recherche.SetDescriptiveText("Rechercher…")
@@ -212,19 +227,21 @@ class PanneauTableau(wx.Panel):
         else:
             self._donnees_source = None
 
+        outils = wx.BoxSizer(wx.HORIZONTAL)
+        marge = Style.espace(2)
+        if self.recherche is not None:
+            outils.Add(self.recherche, 0, wx.ALIGN_CENTER_VERTICAL)
+            outils.AddSpacer(marge)
+        outils.AddStretchSpacer(1)
+        outils.Add(self.etat, 0, wx.ALIGN_CENTER_VERTICAL)
+        self.barre_donnees.SetSizer(outils)
+
         sizer = wx.BoxSizer(wx.VERTICAL)
         sizer.Add(self.entete, 0, wx.EXPAND)
         if self.actions is not None:
             sizer.Add(self.actions, 0, wx.EXPAND)
+        sizer.Add(self.barre_donnees, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP | wx.BOTTOM, marge)
         sizer.Add(self.tableau, 1, wx.EXPAND)
-
-        bas = wx.BoxSizer(wx.HORIZONTAL)
-        marge = Style.espace(2)
-        if self.recherche is not None:
-            bas.Add(self.recherche, 1, wx.RIGHT | wx.ALIGN_CENTER_VERTICAL, marge)
-        bas.Add(self.etat, 0, wx.ALIGN_CENTER_VERTICAL)
-        sizer.Add(bas, 0, wx.EXPAND | wx.ALL, marge)
-
         self.SetSizer(sizer)
 
     def SetDonnees(self, donnees):

--- a/noethys/Dlg/__init__.py
+++ b/noethys/Dlg/__init__.py
@@ -16,9 +16,10 @@ _ADAPTATEURS = {
 
 
 def __getattr__(name):
-    module_name = _ADAPTATEURS.get(name)
-    if module_name is not None:
-        module = importlib.import_module(module_name, __name__)
+    # Garder la cible littérale ici est volontaire : PyInstaller peut ainsi
+    # l'identifier statiquement tout en conservant le chargement paresseux.
+    if name == "DLG_Impression_conso":
+        module = importlib.import_module(".DLG_Impression_conso_differe", __name__)
         globals()[name] = module
         return module
     raise AttributeError(name)

--- a/noethys/Utils/UTILS_Aui.py
+++ b/noethys/Utils/UTILS_Aui.py
@@ -110,54 +110,18 @@ def _ItererDescendants(window):
 
 
 def ConfigurerGrille(grille):
-    """Applique la grammaire visuelle commune à une wx.Grid existante."""
+    """Applique le langage Repens à une wx.Grid sans toucher au métier."""
     if grille is None:
         return False
     try:
         import wx.grid as gridlib
-        from Utils import UTILS_Interface
-        from Utils import UTILS_UIMetrics
+        from Utils import UTILS_StyleRepens as Style
         if not isinstance(grille, gridlib.Grid):
             return False
     except Exception:
         return False
 
-    try:
-        grille.EnableGridLines(True)
-        grille.SetGridLineColour(UTILS_Interface.GetCouleurRole("outline_variant"))
-    except Exception:
-        pass
-    try:
-        grille.SetLabelBackgroundColour(UTILS_Interface.GetCouleurRole("surface_container_high"))
-        grille.SetLabelTextColour(UTILS_Interface.GetCouleurRole("on_surface"))
-    except Exception:
-        pass
-    try:
-        grille.SetDefaultCellBackgroundColour(UTILS_Interface.GetCouleurRole("surface_container_lowest"))
-        grille.SetDefaultCellTextColour(UTILS_Interface.GetCouleurRole("on_surface"))
-    except Exception:
-        pass
-
-    try:
-        if not hasattr(grille, "_noethys_default_row_base"):
-            grille._noethys_default_row_base = grille.GetDefaultRowSize()
-        grille.SetDefaultRowSize(
-            max(UTILS_UIMetrics.row_height("table"), UTILS_UIMetrics.px(grille._noethys_default_row_base)),
-            True,
-        )
-    except Exception:
-        pass
-
-    for getter, setter, attribut in (
-        ("GetRowLabelSize", "SetRowLabelSize", "_noethys_row_label_base"),
-        ("GetColLabelSize", "SetColLabelSize", "_noethys_col_label_base"),
-    ):
-        try:
-            if not hasattr(grille, attribut):
-                setattr(grille, attribut, getattr(grille, getter)())
-            getattr(grille, setter)(UTILS_UIMetrics.px(getattr(grille, attribut)))
-        except Exception:
-            pass
+    Style.appliquer_grille(grille)
 
     try:
         grille.ForceRefresh()

--- a/noethys/Utils/UTILS_Config.py
+++ b/noethys/Utils/UTILS_Config.py
@@ -23,9 +23,11 @@ from Utils import UTILS_Json
 
 def GetNomFichierConfig(nomFichier="Config.json"):
     return UTILS_Fichiers.GetRepUtilisateur(nomFichier)
+
 def IsFichierExists() :
     nomFichier = GetNomFichierConfig()
     return os.path.isfile(nomFichier)
+
 def GenerationFichierConfig():
     dictDonnees = {}
     nouveau_fichier = True
@@ -77,6 +79,7 @@ def GenerationFichierConfig():
 
     print("nouveau_fichier = %s" % nouveau_fichier)
     return nouveau_fichier
+
 def SupprimerFichier():
     nomFichier = GetNomFichierConfig()
     os.remove(nomFichier)
@@ -167,7 +170,7 @@ class FichierConfig():
         data = self.GetDictConfig()
         for key, valeur in dictParametres.items():
             data[key] = valeur
-        self.SetDictConfig(dictParametres)
+        self.SetDictConfig(data)
 
     def DelItemConfig(self, key ):
         """ Supprime une valeur dans le fichier de config """
@@ -262,3 +265,4 @@ def SetParametres(dictParametres={}):
 # --------------- TESTS ----------------------------------------------------------------------------------------------------------
 if __name__ == u"__main__":
     print("GET :", GetParametres( {"impression_factures_impayes" : 0} ))
+    #print("SET :", SetParametres( {"test1" : True, "test2" : True} ))

--- a/noethys/Utils/UTILS_Config.py
+++ b/noethys/Utils/UTILS_Config.py
@@ -23,11 +23,9 @@ from Utils import UTILS_Json
 
 def GetNomFichierConfig(nomFichier="Config.json"):
     return UTILS_Fichiers.GetRepUtilisateur(nomFichier)
-
 def IsFichierExists() :
     nomFichier = GetNomFichierConfig()
     return os.path.isfile(nomFichier)
-
 def GenerationFichierConfig():
     dictDonnees = {}
     nouveau_fichier = True
@@ -79,7 +77,6 @@ def GenerationFichierConfig():
 
     print("nouveau_fichier = %s" % nouveau_fichier)
     return nouveau_fichier
-
 def SupprimerFichier():
     nomFichier = GetNomFichierConfig()
     os.remove(nomFichier)
@@ -148,7 +145,14 @@ class FichierConfig():
         if key in data :
             valeur = data[key]
         else:
-            valeur = defaut
+            # Une configuration Noethys neuve déclare historiquement
+            # ``nomFichier`` comme chaîne vide. Conserver ce contrat quand le
+            # fichier de configuration n'existe pas encore évite de faire
+            # remonter ``None`` jusqu'à GestionDB, qui manipule un nom texte.
+            if key == "nomFichier" and defaut is None:
+                valeur = ""
+            else:
+                valeur = defaut
         return valeur
     
     def SetItemConfig(self, key, valeur ):
@@ -163,7 +167,7 @@ class FichierConfig():
         data = self.GetDictConfig()
         for key, valeur in dictParametres.items():
             data[key] = valeur
-        self.SetDictConfig(data)
+        self.SetDictConfig(dictParametres)
 
     def DelItemConfig(self, key ):
         """ Supprime une valeur dans le fichier de config """
@@ -258,4 +262,3 @@ def SetParametres(dictParametres={}):
 # --------------- TESTS ----------------------------------------------------------------------------------------------------------
 if __name__ == u"__main__":
     print("GET :", GetParametres( {"impression_factures_impayes" : 0} ))
-    #print("SET :", SetParametres( {"test1" : True, "test2" : True} ))

--- a/noethys/Utils/UTILS_Fichiers.py
+++ b/noethys/Utils/UTILS_Fichiers.py
@@ -72,6 +72,8 @@ def _GetRepUtilisateurSousDossier(nom, fichier=""):
     chemin = _GetRepPortableSousDossier(nom)
     if chemin is None:
         chemin = GetRepUtilisateur(nom)
+        if not os.path.isdir(chemin):
+            os.mkdir(chemin)
     return os.path.join(chemin, fichier)
 
 
@@ -106,7 +108,6 @@ def GetRepUtilisateur(fichier=""):
     if not os.path.isdir(chemin):
         os.mkdir(chemin)
     return os.path.join(chemin, fichier)
-
 def DeplaceFichiers():
     """ Vérifie si des fichiers du répertoire Data ou du répertoire Utilisateur sont à déplacer vers le répertoire Utilisateur>AppData>Roaming """
 
@@ -137,7 +138,7 @@ def DeplaceFichiers():
                 nomFichier = nomFichier.decode("utf8")
             if nomFichier.endswith(".dat") and "_" in nomFichier and "EXEMPLE_" not in nomFichier and "_archive.dat" not in nomFichier :
                 print(["copie base de donnees :", nomFichier, " > ", GetRepData(nomFichier)])
-                shutil.copy(Chemins.GetMainPath(u"Data/%s" % nomFichier), GetRepData(nomFichier))
+                shutil.copy(os.path.join(chemin, nomFichier), GetRepData(nomFichier))
                 try :
                     os.rename(Chemins.GetMainPath(u"Data/%s" % nomFichier), Chemins.GetMainPath(u"Data/%s" % nomFichier.replace(".dat", "_archive.dat")))
                 except :

--- a/noethys/Utils/UTILS_Fichiers.py
+++ b/noethys/Utils/UTILS_Fichiers.py
@@ -50,20 +50,19 @@ def GetRepData(fichier=""):
     if chemin != "" and os.path.isdir(chemin):
         return os.path.join(chemin, fichier)
 
-    # Recherche le chemin du répertoire des données
+    # Recherche le chemin du répertoire des données. appdirs peut retourner une
+    # arborescence dont les parents n'existent pas encore (notamment ~/.local/share
+    # sur une session Linux neuve), donc il faut créer la chaîne complète.
     if sys.platform == "win32" and platform.release() != "Vista" :
         chemin = appdirs.site_data_dir(appname=None, appauthor=False)
         chemin = os.path.join(chemin, "noethys")
         if not os.path.isdir(chemin):
-            os.mkdir(chemin)
+            os.makedirs(chemin)
     else :
         chemin = appdirs.user_data_dir(appname=None, appauthor=False)
-        chemin = os.path.join(chemin, "noethys")
+        chemin = os.path.join(chemin, "noethys", "Data")
         if not os.path.isdir(chemin):
-            os.mkdir(chemin)
-        chemin = os.path.join(chemin, "Data")
-        if not os.path.isdir(chemin):
-            os.mkdir(chemin)
+            os.makedirs(chemin)
 
     return os.path.join(chemin, fichier)
 

--- a/noethys/Utils/UTILS_StyleRepens.py
+++ b/noethys/Utils/UTILS_StyleRepens.py
@@ -193,13 +193,74 @@ def appliquer_saisie(ctrl):
 
 
 def appliquer_liste(ctrl):
-    """Style de base des listes/grilles lorsque leur renderer reste natif."""
+    """Style de base des listes lorsque leur renderer reste natif."""
     try:
         ctrl.SetFont(police("body"))
         ctrl.SetForegroundColour(couleur("on_surface"))
         ctrl.SetBackgroundColour(couleur("surface_container_lowest"))
     except Exception:
         pass
+    return ctrl
+
+
+def appliquer_grille(ctrl):
+    """Style sémantique commun d'une ``wx.grid.Grid`` existante.
+
+    Repens ne touche ni aux renderers métier, ni aux éditeurs, ni aux dimensions
+    de colonnes. Seuls la typographie, les surfaces, la sélection, les traits et
+    les métriques de ligne communes sont harmonisés.
+    """
+    try:
+        import wx.grid as gridlib
+        if not isinstance(ctrl, gridlib.Grid):
+            return ctrl
+    except Exception:
+        return ctrl
+
+    appliquer_liste(ctrl)
+
+    for methode, valeur in (
+        ("SetDefaultCellFont", police("body")),
+        ("SetLabelFont", police("label")),
+        ("SetGridLineColour", couleur("outline_variant")),
+        ("SetLabelBackgroundColour", couleur("surface_container_low")),
+        ("SetLabelTextColour", couleur("on_surface_variant")),
+        ("SetDefaultCellBackgroundColour", couleur("surface_container_lowest")),
+        ("SetDefaultCellTextColour", couleur("on_surface")),
+        ("SetSelectionBackground", couleur("selection")),
+        ("SetSelectionForeground", couleur("selection_text")),
+    ):
+        try:
+            getattr(ctrl, methode)(valeur)
+        except Exception:
+            pass
+
+    try:
+        ctrl.EnableGridLines(True)
+    except Exception:
+        pass
+
+    try:
+        if not hasattr(ctrl, "_noethys_default_row_base"):
+            ctrl._noethys_default_row_base = ctrl.GetDefaultRowSize()
+        ctrl.SetDefaultRowSize(
+            max(hauteur_ligne("table"), px(ctrl._noethys_default_row_base)),
+            True,
+        )
+    except Exception:
+        pass
+
+    for getter, setter, attribut in (
+        ("GetRowLabelSize", "SetRowLabelSize", "_noethys_row_label_base"),
+        ("GetColLabelSize", "SetColLabelSize", "_noethys_col_label_base"),
+    ):
+        try:
+            if not hasattr(ctrl, attribut):
+                setattr(ctrl, attribut, getattr(ctrl, getter)())
+            getattr(ctrl, setter)(px(getattr(ctrl, attribut)))
+        except Exception:
+            pass
+
     return ctrl
 
 

--- a/packaging/noethys.spec
+++ b/packaging/noethys.spec
@@ -25,13 +25,6 @@ def collect_runtime_submodules(package):
 
 
 hiddenimports = [
-    # CTRL_Bandeau utilise le module stdlib ``html`` pour décoder les entités.
-    # Dans le bundle plat Windows, wxPython fournit aussi ``wx.html`` ; forcer
-    # explicitement la stdlib évite qu'un import absolu ``html`` soit résolu
-    # contre le sous-module wx et casse ses imports relatifs.
-    "html",
-    "html.entities",
-    "html.parser",
     # wx.richtext charge wx._xml au runtime. PyInstaller ne détecte pas toujours
     # ce module natif via le graphe d'import ; sans lui le portable plante dès
     # l'import de DLG_Portail_config.

--- a/packaging/noethys.spec
+++ b/packaging/noethys.spec
@@ -25,6 +25,13 @@ def collect_runtime_submodules(package):
 
 
 hiddenimports = [
+    # CTRL_Bandeau utilise le module stdlib ``html`` pour décoder les entités.
+    # Dans le bundle plat Windows, wxPython fournit aussi ``wx.html`` ; forcer
+    # explicitement la stdlib évite qu'un import absolu ``html`` soit résolu
+    # contre le sous-module wx et casse ses imports relatifs.
+    "html",
+    "html.entities",
+    "html.parser",
     # wx.richtext charge wx._xml au runtime. PyInstaller ne détecte pas toujours
     # ce module natif via le graphe d'import ; sans lui le portable plante dès
     # l'import de DLG_Portail_config.

--- a/packaging/runtime_frozen_smoke.py
+++ b/packaging/runtime_frozen_smoke.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import importlib
 import os
 import sys
+import traceback
 from pathlib import Path
 
 
@@ -77,8 +78,8 @@ if os.environ.get("NOETHYS_FROZEN_SMOKE") == "1":
             _finish(
                 root,
                 4,
-                "Import figé en échec pour %s: %s: %s"
-                % (module_name, type(exc).__name__, exc),
+                "Import figé en échec pour %s: %s: %s\n%s"
+                % (module_name, type(exc).__name__, exc, traceback.format_exc()),
             )
 
     _finish(root, 0, "Bundle figé Noethys validé")

--- a/scripts/smoke_aui_perspective_guard.py
+++ b/scripts/smoke_aui_perspective_guard.py
@@ -10,7 +10,7 @@ NOETHYS = ROOT / "noethys"
 if str(NOETHYS) not in sys.path:
     sys.path.insert(0, str(NOETHYS))
 
-from Utils.UTILS_Aui import ChargerPerspective
+from Utils import UTILS_Aui
 
 
 class Manager:
@@ -26,26 +26,54 @@ class Manager:
         return comportement
 
 
+def _charger_version_valide(manager, perspective, fallback=None):
+    """Isole ici le contrat de chargement d'une génération AUI courante."""
+    verifier = UTILS_Aui.VerifierVersionPerspective
+    try:
+        UTILS_Aui.VerifierVersionPerspective = lambda _manager: True
+        return UTILS_Aui.ChargerPerspective(manager, perspective, fallback)
+    finally:
+        UTILS_Aui.VerifierVersionPerspective = verifier
+
+
+def _charger_version_obsolete(manager, perspective, fallback=None):
+    """Simule une perspective d'une génération précédente sans état utilisateur."""
+    verifier = UTILS_Aui.VerifierVersionPerspective
+    try:
+        UTILS_Aui.VerifierVersionPerspective = lambda _manager: False
+        return UTILS_Aui.ChargerPerspective(manager, perspective, fallback)
+    finally:
+        UTILS_Aui.VerifierVersionPerspective = verifier
+
+
 def main() -> int:
     manager = Manager({"ancienne": AssertionError("format ancien"), "defaut": True})
-    if ChargerPerspective(manager, "ancienne", "defaut") is not True:
+    if _charger_version_valide(manager, "ancienne", "defaut") is not True:
         raise RuntimeError("Le repli sur la perspective par défaut a échoué")
     if manager.appels != ["ancienne", "defaut"]:
         raise RuntimeError(f"Ordre de chargement inattendu : {manager.appels!r}")
 
     manager = Manager({"courante": True, "defaut": True})
-    if ChargerPerspective(manager, "courante", "defaut") is not True:
+    if _charger_version_valide(manager, "courante", "defaut") is not True:
         raise RuntimeError("Une perspective valide est refusée")
     if manager.appels != ["courante"]:
         raise RuntimeError("Le fallback a été utilisé sans nécessité")
 
     manager = Manager({"defaut": True})
-    if ChargerPerspective(manager, None, "defaut") is not True:
+    if _charger_version_valide(manager, None, "defaut") is not True:
         raise RuntimeError("Une perspective absente ne retombe pas sur le défaut")
 
     manager = Manager({"ancienne": False, "defaut": True})
-    if ChargerPerspective(manager, "ancienne", "defaut") is not True:
+    if _charger_version_valide(manager, "ancienne", "defaut") is not True:
         raise RuntimeError("Un échec booléen de LoadPerspective ne déclenche pas le repli")
+
+    # Une génération explicitement obsolète ne doit même plus être présentée à
+    # wxAUI : on charge directement la perspective par défaut connue compatible.
+    manager = Manager({"ancienne": AssertionError("ne doit pas être chargée"), "defaut": True})
+    if _charger_version_obsolete(manager, "ancienne", "defaut") is not True:
+        raise RuntimeError("Une ancienne génération ne retombe pas sur le défaut")
+    if manager.appels != ["defaut"]:
+        raise RuntimeError(f"Perspective obsolète chargée à tort : {manager.appels!r}")
 
     print("Repli des perspectives AUI : OK")
     return 0

--- a/tests/test_bandeau_html_contract.py
+++ b/tests/test_bandeau_html_contract.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""Contrats du texte de bandeau dans le bundle PyInstaller plat."""
+
+import ast
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BANDEAU = ROOT / "noethys" / "Ctrl" / "CTRL_Bandeau.py"
+SPEC = ROOT / "packaging" / "noethys.spec"
+
+
+class BandeauHtmlContractTests(unittest.TestCase):
+    def test_bandeau_does_not_import_top_level_html(self):
+        source = BANDEAU.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        imports = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imports.extend(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imports.append(node.module)
+
+        self.assertNotIn("html", imports)
+        self.assertIn("def _decoder_entites_html", source)
+        self.assertIn("chr(int(code[2:], 16))", source)
+        self.assertIn("chr(int(code[1:], 10))", source)
+
+    def test_packaging_does_not_try_to_mask_html_name_collision(self):
+        source = SPEC.read_text(encoding="utf-8")
+        self.assertNotIn('"html",', source)
+        self.assertNotIn('"html.entities"', source)
+        self.assertNotIn('"html.parser"', source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config_empty_database_contract.py
+++ b/tests/test_config_empty_database_contract.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+
+def _load_config(root):
+    chemins = types.ModuleType("Chemins")
+    sys.modules["Chemins"] = chemins
+
+    wx = types.ModuleType("wx")
+    sys.modules["wx"] = wx
+
+    six = types.ModuleType("six")
+    six.PY2 = False
+    sys.modules["six"] = six
+
+    utils_pkg = types.ModuleType("Utils")
+    utils_pkg.__path__ = []
+    sys.modules["Utils"] = utils_pkg
+
+    fichiers = types.ModuleType("Utils.UTILS_Fichiers")
+    fichiers.GetRepUtilisateur = lambda fichier="": str(Path(root) / fichier)
+    sys.modules["Utils.UTILS_Fichiers"] = fichiers
+    utils_pkg.UTILS_Fichiers = fichiers
+
+    json_utils = types.ModuleType("Utils.UTILS_Json")
+
+    def _lire(_path):
+        raise FileNotFoundError(_path)
+
+    json_utils.Lire = _lire
+    json_utils.Ecrire = lambda **kwargs: None
+    sys.modules["Utils.UTILS_Json"] = json_utils
+    utils_pkg.UTILS_Json = json_utils
+
+    path = Path(__file__).resolve().parents[1] / "noethys" / "Utils" / "UTILS_Config.py"
+    spec = importlib.util.spec_from_file_location("config_empty_database_contract", str(path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class ConfigEmptyDatabaseContractTests(unittest.TestCase):
+    def test_missing_config_keeps_historical_empty_database_name(self):
+        with tempfile.TemporaryDirectory() as temp:
+            module = _load_config(temp)
+            cfg = module.FichierConfig()
+            self.assertEqual(cfg.GetItemConfig("nomFichier"), "")
+
+    def test_other_missing_keys_keep_their_requested_default(self):
+        with tempfile.TemporaryDirectory() as temp:
+            module = _load_config(temp)
+            cfg = module.FichierConfig()
+            self.assertIsNone(cfg.GetItemConfig("autre"))
+            self.assertEqual(cfg.GetItemConfig("autre", "repli"), "repli")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_noe_041_portable_paths.py
+++ b/tests/test_noe_041_portable_paths.py
@@ -70,6 +70,16 @@ class PortablePathsTests(unittest.TestCase):
                 self.assertEqual(Path(path).parent, portable / dirname)
                 self.assertTrue((portable / dirname).is_dir())
 
+    def test_standard_data_directory_creates_missing_appdirs_parents(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            module = _load_utils_files(root)
+
+            data = Path(module.GetRepData("demo.dat"))
+            expected = root / "outside-user-data" / "noethys" / "Data" / "demo.dat"
+            self.assertEqual(data, expected)
+            self.assertTrue(expected.parent.is_dir())
+
     def test_standard_runtime_subdirectories_are_created_on_demand(self):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)

--- a/tests/test_noe_041_portable_paths.py
+++ b/tests/test_noe_041_portable_paths.py
@@ -70,6 +70,24 @@ class PortablePathsTests(unittest.TestCase):
                 self.assertEqual(Path(path).parent, portable / dirname)
                 self.assertTrue((portable / dirname).is_dir())
 
+    def test_standard_runtime_subdirectories_are_created_on_demand(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "outside-user-config").mkdir()
+            module = _load_utils_files(root)
+
+            base = root / "outside-user-config" / "noethys"
+            expected = {
+                "Temp": module.GetRepTemp("journal.tmp"),
+                "Updates": module.GetRepUpdates("update.bin"),
+                "Lang": module.GetRepLang("fr.xlang"),
+                "Sync": module.GetRepSync("sync.json"),
+                "Extensions": module.GetRepExtensions("plugin.py"),
+            }
+            for dirname, path in expected.items():
+                self.assertEqual(Path(path).parent, base / dirname)
+                self.assertTrue((base / dirname).is_dir())
+
     def test_portable_mode_does_not_use_appdirs(self):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)

--- a/tests/test_table_grid_repens_contract.py
+++ b/tests/test_table_grid_repens_contract.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""Contrats statiques de la couche tableaux/grilles Repens."""
+
+import ast
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+STYLE = ROOT / "noethys" / "Utils" / "UTILS_StyleRepens.py"
+AUI = ROOT / "noethys" / "Utils" / "UTILS_Aui.py"
+TABLEAU = ROOT / "noethys" / "Ctrl" / "CTRL_TableauResponsive.py"
+
+
+class TableGridRepensContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.style_text = STYLE.read_text(encoding="utf-8")
+        cls.aui_text = AUI.read_text(encoding="utf-8")
+        cls.tableau_text = TABLEAU.read_text(encoding="utf-8")
+        for texte in (cls.style_text, cls.aui_text, cls.tableau_text):
+            ast.parse(texte)
+
+    def test_grid_style_is_owned_by_repens_facade(self):
+        self.assertIn("def appliquer_grille", self.style_text)
+        self.assertIn('SetLabelFont", police("label")', self.style_text)
+        self.assertIn('SetSelectionBackground", couleur("selection")', self.style_text)
+        self.assertIn('SetSelectionForeground", couleur("selection_text")', self.style_text)
+        self.assertIn('hauteur_ligne("table")', self.style_text)
+        self.assertNotIn("wx.Colour(", self.style_text)
+
+    def test_aui_grid_adapter_delegates_without_business_geometry(self):
+        debut = self.aui_text.index("def ConfigurerGrille")
+        fin = self.aui_text.index("\ndef ConfigurerNotebook", debut)
+        bloc = self.aui_text[debut:fin]
+        self.assertIn("UTILS_StyleRepens as Style", bloc)
+        self.assertIn("Style.appliquer_grille(grille)", bloc)
+        self.assertNotIn("UTILS_Interface", bloc)
+        self.assertNotIn("UTILS_UIMetrics", bloc)
+        self.assertNotIn("SetColSize", bloc)
+        self.assertNotIn("SetRowSize", bloc)
+
+    def test_responsive_table_uses_semantic_zebra_rows(self):
+        self.assertIn("def _StyliserLigne", self.tableau_text)
+        self.assertIn('"surface_container_lowest" if index % 2 == 0 else "surface_container_low"', self.tableau_text)
+        self.assertIn('Style.couleur("on_surface")', self.tableau_text)
+        self.assertNotIn("wx.Colour(", self.tableau_text)
+
+    def test_search_and_count_are_above_the_data_surface(self):
+        self.assertIn("self.barre_donnees = wx.Panel", self.tableau_text)
+        self.assertIn("self.recherche.SetMaxSize((Style.px(360), -1))", self.tableau_text)
+        position_barre = self.tableau_text.index("sizer.Add(self.barre_donnees")
+        position_tableau = self.tableau_text.index("sizer.Add(self.tableau", position_barre)
+        self.assertLess(position_barre, position_tableau)
+        self.assertNotIn("wx.FlexGridSizer(", self.tableau_text)
+        self.assertNotIn("wx.GridSizer(", self.tableau_text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Objet

Poursuivre la refonte UI transverse avec le lot tableaux/grilles, sans modifier la logique métier ni les renderers spécialisés, et remettre la qualification runtime révélée par ce lot dans un état exploitable.

## UI

- ajoute `Style.appliquer_grille()` comme point d'entrée unique pour typographie, surfaces, traits, sélection et hauteur de ligne des `wx.grid.Grid` ;
- fait déléguer `UTILS_Aui.ConfigurerGrille()` à cette façade ;
- conserve largeurs de colonnes, renderers, éditeurs et couleurs métier existants ;
- densifie `CTRL_TableauResponsive` : bordure supprimée, bandes alternées sémantiques, recherche et compteur regroupés au-dessus de la surface de données ;
- borne la largeur du champ de recherche pour éviter les grands vides horizontaux ;
- ajoute des contrats statiques empêchant le retour des couleurs locales et géométries métier dans la couche graphique.

## Qualification révélée par la PR

Les smokes ont également exposé plusieurs défauts de socle indépendants du rendu des grilles. Ils sont corrigés à la source dans cette branche :

- configuration neuve : `nomFichier` reste une chaîne vide et les mises à jour multiples conservent le dictionnaire existant ;
- création robuste des répertoires utilisateur/data, y compris sous GTK/Linux et en mode portable ;
- import paresseux de dialogue rendu explicite pour l'analyse PyInstaller ;
- diagnostic du smoke de l'exécutable figé rendu lisible ;
- collision du nom de module `html` dans le bundle PyInstaller plat supprimée dans `CTRL_Bandeau`, sans surcouche runtime ni faux hidden import ;
- contrats de non-régression associés.

## Principe

Toujours la même règle : centraliser la grammaire visuelle dans Repens, conserver le comportement natif wxPython et corriger les défauts de runtime à leur source plutôt que les masquer.