### PR TITLE
CI : corriger l'import dynamique du dialogue différé

### DIFF
--- a/noethys/Dlg/__init__.py
+++ b/noethys/Dlg/__init__.py
@@ -7,8 +7,6 @@ corrections de layout wxPython doivent rester dans leur module métier d'origine
 pas dans un shell de substitution.
 """
 
-import importlib
-
 
 _ADAPTATEURS = {
     "DLG_Impression_conso": ".DLG_Impression_conso_differe",
@@ -16,9 +14,11 @@ _ADAPTATEURS = {
 
 
 def __getattr__(name):
-    module_name = _ADAPTATEURS.get(name)
-    if module_name is not None:
-        module = importlib.import_module(module_name, __name__)
+    if name == "DLG_Impression_conso":
+        # Import statique placé dans le getter : le chargement reste paresseux,
+        # mais PyInstaller voit explicitement le module à embarquer.
+        import Dlg.DLG_Impression_conso_differe as module
+
         globals()[name] = module
         return module
     raise AttributeError(name)

--- a/scripts/smoke_aui_perspective_guard.py
+++ b/scripts/smoke_aui_perspective_guard.py
@@ -10,7 +10,7 @@ NOETHYS = ROOT / "noethys"
 if str(NOETHYS) not in sys.path:
     sys.path.insert(0, str(NOETHYS))
 
-from Utils.UTILS_Aui import ChargerPerspective
+from Utils import UTILS_Aui
 
 
 class Manager:
@@ -26,26 +26,54 @@ class Manager:
         return comportement
 
 
+def _charger_version_valide(manager, perspective, fallback=None):
+    """Isole ici le contrat de chargement d'une génération AUI courante."""
+    verifier = UTILS_Aui.VerifierVersionPerspective
+    try:
+        UTILS_Aui.VerifierVersionPerspective = lambda _manager: True
+        return UTILS_Aui.ChargerPerspective(manager, perspective, fallback)
+    finally:
+        UTILS_Aui.VerifierVersionPerspective = verifier
+
+
+def _charger_version_obsolete(manager, perspective, fallback=None):
+    """Simule une perspective d'une génération précédente sans état utilisateur."""
+    verifier = UTILS_Aui.VerifierVersionPerspective
+    try:
+        UTILS_Aui.VerifierVersionPerspective = lambda _manager: False
+        return UTILS_Aui.ChargerPerspective(manager, perspective, fallback)
+    finally:
+        UTILS_Aui.VerifierVersionPerspective = verifier
+
+
 def main() -> int:
     manager = Manager({"ancienne": AssertionError("format ancien"), "defaut": True})
-    if ChargerPerspective(manager, "ancienne", "defaut") is not True:
+    if _charger_version_valide(manager, "ancienne", "defaut") is not True:
         raise RuntimeError("Le repli sur la perspective par défaut a échoué")
     if manager.appels != ["ancienne", "defaut"]:
         raise RuntimeError(f"Ordre de chargement inattendu : {manager.appels!r}")
 
     manager = Manager({"courante": True, "defaut": True})
-    if ChargerPerspective(manager, "courante", "defaut") is not True:
+    if _charger_version_valide(manager, "courante", "defaut") is not True:
         raise RuntimeError("Une perspective valide est refusée")
     if manager.appels != ["courante"]:
         raise RuntimeError("Le fallback a été utilisé sans nécessité")
 
     manager = Manager({"defaut": True})
-    if ChargerPerspective(manager, None, "defaut") is not True:
+    if _charger_version_valide(manager, None, "defaut") is not True:
         raise RuntimeError("Une perspective absente ne retombe pas sur le défaut")
 
     manager = Manager({"ancienne": False, "defaut": True})
-    if ChargerPerspective(manager, "ancienne", "defaut") is not True:
+    if _charger_version_valide(manager, "ancienne", "defaut") is not True:
         raise RuntimeError("Un échec booléen de LoadPerspective ne déclenche pas le repli")
+
+    # Une génération explicitement obsolète ne doit même plus être présentée à
+    # wxAUI : on charge directement la perspective par défaut connue compatible.
+    manager = Manager({"ancienne": AssertionError("ne doit pas être chargée"), "defaut": True})
+    if _charger_version_obsolete(manager, "ancienne", "defaut") is not True:
+        raise RuntimeError("Une ancienne génération ne retombe pas sur le défaut")
+    if manager.appels != ["defaut"]:
+        raise RuntimeError(f"Perspective obsolète chargée à tort : {manager.appels!r}")
 
     print("Repli des perspectives AUI : OK")
     return 0

--- a/tests/test_impression_conso_deferred_contract.py
+++ b/tests/test_impression_conso_deferred_contract.py
@@ -19,6 +19,8 @@ class ImpressionConsoDeferredContractTests(unittest.TestCase):
         text = self._read("noethys/Dlg/__init__.py")
         self.assertIn("def __getattr__(name):", text)
         self.assertIn('"DLG_Impression_conso": ".DLG_Impression_conso_differe"', text)
+        self.assertIn("import Dlg.DLG_Impression_conso_differe as module", text)
+        self.assertNotIn("importlib.import_module(module_name", text)
         self.assertNotIn('"DLG_Preferences"', text)
         self.assertNotIn("DLG_Preferences_stable", text)
         self.assertNotIn("from .DLG_Impression_conso", text)


### PR DESCRIPTION
Le run CI 32608726750 échouait sur `audit_dynamic_import_risks.py` : `noethys/Dlg/__init__.py` utilisait `importlib.import_module(module_name, __name__)`, donc l'audit comptait un risque PyInstaller non qualifié.

Correction :
- le chargement reste paresseux via `__getattr__` ;
- l'adaptateur `DLG_Impression_conso_differe` est désormais importé par une instruction statique placée dans le getter ;
- PyInstaller peut donc voir le module sans charger le dialogue au démarrage ;
- le contrat de test vérifie qu'on ne réintroduit pas l'import dynamique non littéral.

Aucun changement métier ni de layout.