### PR TITLE
UI : consolider la refonte transverse Repens

### DIFF
--- a/docs/IMPLEMENTATION_ORDER.md
+++ b/docs/IMPLEMENTATION_ORDER.md
@@ -96,6 +96,19 @@ Le module Messagerie reste optionnel et désactivé par défaut. Son UI ne doit 
 
 Voir `MAIL_MODULE_ARCHITECTURE.md`.
 
+## Ligne d'arrivée de la refonte transverse
+
+Le chantier transverse est considéré **terminé** lorsque les points suivants sont vrais :
+
+- `ObjectListView` / `ListCtrl` et `wx.Grid` consomment les règles Repens communes ;
+- les barres de recherche/filtrage/cochage des listes métier utilisent `CTRL_OutilsListeRepens` et l'inventaire des anciens outils ne signale plus d'écran métier à migrer ;
+- la navigation commune (`AuiNotebook`, `Notebook`, `Choicebook`, `Listbook`, `Treebook`) est raccordée sans reprendre la géométrie native ;
+- les états vides, le focus et les états interactifs communs ne nécessitent plus de rustine wxPython historique ;
+- les contrôles communs restent lisibles en clair/sombre et à 100/120-125/150 % ;
+- aucun correctif purement graphique ne nécessite de nouvelle migration de données ou de nouvelle dépendance lourde.
+
+Une fois ces critères atteints, il n'existe plus de backlog générique « moderniser Noethys ». Les travaux UI suivants doivent partir d'un **défaut concret observé** (fenêtre vide, freeze, texte tronqué, mauvais contraste, scaling cassé, commande peu utilisable, etc.) ou d'un besoin métier identifié.
+
 ## Règle de validation
 
 Un écran n'est pas considéré modernisé uniquement parce qu'il « paraît plus moderne ».

--- a/noethys/Ctrl/CTRL_OutilsListeRepens.py
+++ b/noethys/Ctrl/CTRL_OutilsListeRepens.py
@@ -12,6 +12,7 @@ import wx
 
 from Ctrl import CTRL_ActionRepens
 from Utils import UTILS_Adaptations
+from Utils import UTILS_IconesRepens
 from Utils import UTILS_StyleRepens as Style
 from Utils.UTILS_Traduction import _
 
@@ -45,6 +46,32 @@ class BarreRecherche(wx.SearchCtrl):
         self.ShowSearchButton(True)
         self.ShowCancelButton(False)
         Style.appliquer_saisie(self)
+
+        # La recherche reste un outil compact : sur un grand écran elle ne doit
+        # pas devenir une longue barre vide, et à 120/150 % elle conserve une
+        # largeur minimale réellement exploitable.
+        self.SetMinSize((Style.px(180), Style.cible_action("compact")))
+        self.SetMaxSize((Style.px(360), -1))
+
+        # Remplace les anciens petits bitmaps de recherche par les glyphes
+        # Fluent sémantiques tout en conservant le SearchCtrl natif.
+        try:
+            self.SetSearchBitmap(
+                UTILS_IconesRepens.GetBitmap(
+                    "search",
+                    taille=Style.taille_icone("inline"),
+                    role="on_surface_variant",
+                )
+            )
+            self.SetCancelBitmap(
+                UTILS_IconesRepens.GetBitmap(
+                    "dismiss",
+                    taille=Style.taille_icone("inline"),
+                    role="on_surface_variant",
+                )
+            )
+        except Exception:
+            pass
 
         try:
             self.listview.SetBarreRecherche(self)
@@ -219,6 +246,7 @@ class CTRL(wx.Panel):
             self.bouton_cocher = CTRL_ActionRepens.CTRL(
                 self,
                 label=_(u"Cocher"),
+                icone="check",
                 variante="ghost",
                 tooltip=_(u"Cocher ou décocher rapidement les éléments de la liste"),
             )
@@ -242,15 +270,16 @@ class CTRL(wx.Panel):
                 pass
 
         sizer = wx.BoxSizer(wx.HORIZONTAL)
-        sizer.Add(self.barreRecherche, 1, wx.EXPAND | wx.RIGHT, Style.espace(1))
+        sizer.Add(self.barreRecherche, 0, wx.EXPAND | wx.RIGHT, Style.espace(1))
         sizer.Add(self.bouton_filtrer, 0, wx.ALIGN_CENTER_VERTICAL)
         if self.bouton_cocher is not None:
             sizer.Add(self.bouton_cocher, 0, wx.LEFT | wx.ALIGN_CENTER_VERTICAL, Style.espace(1))
+        sizer.AddStretchSpacer(1)
         if self.ctrl_regroupement is not None:
-            sizer.AddSpacer(Style.espace(2))
             sizer.Add(self.label_regroupement, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, Style.espace(1))
             sizer.Add(self.ctrl_regroupement, 0, wx.ALIGN_CENTER_VERTICAL)
         self.SetSizer(sizer)
+        self.SetMinSize((-1, Style.cible_action("compact")))
         self.Layout()
 
         self.Bind(wx.EVT_SIZE, self.OnSize)

--- a/noethys/Ctrl/CTRL_TableauResponsive.py
+++ b/noethys/Ctrl/CTRL_TableauResponsive.py
@@ -119,7 +119,7 @@ class ListeTableau(wx.ListCtrl):
     """Liste wx native à colonnes pondérées et métriques DPI-aware."""
 
     def __init__(self, parent, colonnes, style=0):
-        style |= wx.LC_REPORT | wx.LC_HRULES
+        style |= wx.LC_REPORT | wx.LC_HRULES | wx.BORDER_NONE
         wx.ListCtrl.__init__(self, parent, style=style)
         self.colonnes = tuple(colonnes or ())
         self._donnees = []
@@ -154,12 +154,21 @@ class ListeTableau(wx.ListCtrl):
             return ""
         return str(valeur)
 
+    def _StyliserLigne(self, item, index):
+        """Alterne deux surfaces discrètes sans ajouter de renderer maison."""
+        role = "surface_container_lowest" if index % 2 == 0 else "surface_container_low"
+        try:
+            self.SetItemBackgroundColour(item, Style.couleur(role))
+            self.SetItemTextColour(item, Style.couleur("on_surface"))
+        except Exception:
+            pass
+
     def SetDonnees(self, donnees):
         self.Freeze()
         try:
             self.DeleteAllItems()
             self._donnees = list(donnees or ())
-            for ligne in self._donnees:
+            for index_ligne, ligne in enumerate(self._donnees):
                 if not isinstance(ligne, dict):
                     try:
                         ligne = dict(ligne)
@@ -172,6 +181,7 @@ class ListeTableau(wx.ListCtrl):
                 for index_colonne, colonne in enumerate(self.colonnes[1:], start=1):
                     texte = self._texte(colonne, ligne.get(colonne.cle), ligne)
                     self.SetItem(item, index_colonne, texte)
+                self._StyliserLigne(item, index_ligne)
         finally:
             self.Thaw()
         UTILS_ColonnesResponsive.Ajuster(self)
@@ -193,17 +203,22 @@ class PanneauTableau(wx.Panel):
         self.entete = EnteteSection(self, titre=titre, sous_titre=sous_titre)
         self.actions = BarreActions(self, actions=actions) if actions else None
         self.tableau = ListeTableau(self, colonnes=colonnes)
-        self.recherche = wx.SearchCtrl(self, style=wx.TE_PROCESS_ENTER) if recherche else None
-        self.etat = wx.StaticText(self, label="")
+        self.barre_donnees = wx.Panel(self, style=wx.TAB_TRAVERSAL | wx.BORDER_NONE)
+        Style.appliquer_fenetre(self.barre_donnees, "surface_container_low")
+
+        self.recherche = wx.SearchCtrl(self.barre_donnees, style=wx.TE_PROCESS_ENTER) if recherche else None
+        self.etat = wx.StaticText(self.barre_donnees, label="")
         Style.appliquer_texte(
             self.etat,
             role="body_small",
             role_texte="on_surface_variant",
-            role_fond="surface",
+            role_fond="surface_container_low",
         )
 
         if self.recherche is not None:
             Style.appliquer_saisie(self.recherche)
+            self.recherche.SetMinSize((Style.px(180), Style.cible_action("compact")))
+            self.recherche.SetMaxSize((Style.px(360), -1))
             self.recherche.ShowSearchButton(True)
             self.recherche.ShowCancelButton(True)
             self.recherche.SetDescriptiveText("Rechercher…")
@@ -212,19 +227,21 @@ class PanneauTableau(wx.Panel):
         else:
             self._donnees_source = None
 
+        outils = wx.BoxSizer(wx.HORIZONTAL)
+        marge = Style.espace(2)
+        if self.recherche is not None:
+            outils.Add(self.recherche, 0, wx.ALIGN_CENTER_VERTICAL)
+            outils.AddSpacer(marge)
+        outils.AddStretchSpacer(1)
+        outils.Add(self.etat, 0, wx.ALIGN_CENTER_VERTICAL)
+        self.barre_donnees.SetSizer(outils)
+
         sizer = wx.BoxSizer(wx.VERTICAL)
         sizer.Add(self.entete, 0, wx.EXPAND)
         if self.actions is not None:
             sizer.Add(self.actions, 0, wx.EXPAND)
+        sizer.Add(self.barre_donnees, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP | wx.BOTTOM, marge)
         sizer.Add(self.tableau, 1, wx.EXPAND)
-
-        bas = wx.BoxSizer(wx.HORIZONTAL)
-        marge = Style.espace(2)
-        if self.recherche is not None:
-            bas.Add(self.recherche, 1, wx.RIGHT | wx.ALIGN_CENTER_VERTICAL, marge)
-        bas.Add(self.etat, 0, wx.ALIGN_CENTER_VERTICAL)
-        sizer.Add(bas, 0, wx.EXPAND | wx.ALL, marge)
-
         self.SetSizer(sizer)
 
     def SetDonnees(self, donnees):

--- a/noethys/ObjectListView/__init__.py
+++ b/noethys/ObjectListView/__init__.py
@@ -14,12 +14,22 @@
 
 """
 An ObjectListView provides a more convienent and powerful interface to a ListCtrl.
+
+Noethys conserve cette bibliothèque historique mais réapplique sa politique de
+palette Repens aux moments où les écrans anciens peuvent encore restaurer leurs
+valeurs de zebra. Le wrapper reste volontairement mince : il ne modifie ni les
+colonnes, ni les renderers, ni les éditeurs, ni les données.
 """
 
 __version__ = '1.3.2'
 __copyright__ = "Copyright (c) 2008 Phillip Piper (phillip_piper@bigfoot.com)"
 
-from . ObjectListView import ObjectListView, VirtualObjectListView, ColumnDefn, FastObjectListView, GroupListView, ListGroup, BatchedUpdate, NamedImageList
+from . ObjectListView import ObjectListView as _ObjectListView
+from . ObjectListView import VirtualObjectListView as _VirtualObjectListView
+from . ObjectListView import ColumnDefn
+from . ObjectListView import FastObjectListView as _FastObjectListView
+from . ObjectListView import GroupListView as _GroupListView
+from . ObjectListView import ListGroup, BatchedUpdate, NamedImageList
 from . OLVEvent import CellEditFinishedEvent, CellEditFinishingEvent, CellEditStartedEvent, CellEditStartingEvent, SortEvent
 from . OLVEvent import EVT_CELL_EDIT_STARTING, EVT_CELL_EDIT_STARTED, EVT_CELL_EDIT_FINISHING, EVT_CELL_EDIT_FINISHED, EVT_SORT
 from . OLVEvent import EVT_COLLAPSING, EVT_COLLAPSED, EVT_EXPANDING, EVT_EXPANDED, EVT_GROUP_CREATING, EVT_GROUP_SORT, EVT_ITEM_CHECKED
@@ -27,6 +37,155 @@ from . CellEditor import CellEditorRegistry, MakeAutoCompleteTextBox, MakeAutoCo
 from . ListCtrlPrinter import ListCtrlPrinter, ReportFormat, BlockFormat, LineDecoration, RectangleDecoration, ImageDecoration
 
 from . import Filter
+
+
+_MESSAGE_VIDE_VENDOR = "This list is empty"
+
+
+def _normaliser_message_vide(ctrl):
+    """Remplace uniquement le libellé anglais livré par la bibliothèque."""
+    try:
+        message = ctrl.stEmptyListMsg
+        if message.GetLabel() != _MESSAGE_VIDE_VENDOR:
+            return
+        from Utils.UTILS_Traduction import _
+        message.SetLabel(_(u"Aucun élément"))
+    except Exception:
+        pass
+
+
+def _synchroniser_etat_vide(ctrl):
+    """Restaure l'état vide natif après les anciennes rustines Phoenix.
+
+    CTRL_ObjectListView masquait historiquement le message à chaque resize pour
+    contourner un artefact visuel désormais traité par la palette Repens. La
+    visibilité suit donc de nouveau le contenu réel de la liste, mais seulement
+    après la création de ses colonnes afin d'éviter un flash « Aucun élément »
+    pendant la construction du contrôle.
+    """
+    try:
+        message = ctrl.stEmptyListMsg
+    except Exception:
+        return
+
+    try:
+        if ctrl.GetColumnCount() <= 0:
+            message.Hide()
+            return
+    except Exception:
+        return
+
+    try:
+        vide = ctrl.GetItemCount() == 0
+    except Exception:
+        try:
+            vide = len(ctrl.GetObjects()) == 0
+        except Exception:
+            return
+
+    try:
+        message.Show(vide)
+        if vide:
+            message.Raise()
+            message.Refresh()
+    except Exception:
+        pass
+
+
+def _lier_etat_vide(ctrl):
+    """Réapplique l'état vide après resize sans remplacer le handler historique."""
+    if getattr(ctrl, "_repens_etat_vide_lie", False):
+        return
+    try:
+        import wx
+
+        ctrl._repens_etat_vide_lie = True
+
+        def _apres_resize(event):
+            event.Skip()
+            try:
+                wx.CallAfter(_synchroniser_etat_vide, ctrl)
+            except Exception:
+                _synchroniser_etat_vide(ctrl)
+
+        ctrl.Bind(wx.EVT_SIZE, _apres_resize)
+    except Exception:
+        pass
+
+
+def _appliquer_repens(ctrl):
+    """Réapplique la politique de liste existante sans dépendance métier."""
+    try:
+        from Utils import UTILS_StyleRepens as Style
+        Style.appliquer_liste_riche(ctrl)
+    except Exception:
+        # La bibliothèque reste importable isolément, notamment par les outils
+        # de packaging et de diagnostic qui ne chargent pas toute l'application.
+        pass
+    _normaliser_message_vide(ctrl)
+    _lier_etat_vide(ctrl)
+
+
+def _apres_set_objects(ctrl, resultat):
+    _synchroniser_etat_vide(ctrl)
+    return resultat
+
+
+class ObjectListView(_ObjectListView):
+    """ObjectListView historique avec rappel tardif de la palette Repens."""
+
+    def __init__(self, *args, **kwargs):
+        _ObjectListView.__init__(self, *args, **kwargs)
+        _appliquer_repens(self)
+
+    def SetObjects(self, *args, **kwargs):
+        # Les anciens écrans assignent souvent leur zebra juste avant SetObjects.
+        # Le rappel utilise la politique prudente du moteur global : une couleur
+        # métier explicite n'est donc jamais remplacée.
+        _appliquer_repens(self)
+        resultat = _ObjectListView.SetObjects(self, *args, **kwargs)
+        return _apres_set_objects(self, resultat)
+
+
+class VirtualObjectListView(_VirtualObjectListView):
+    def __init__(self, *args, **kwargs):
+        _VirtualObjectListView.__init__(self, *args, **kwargs)
+        _appliquer_repens(self)
+
+    def SetObjects(self, *args, **kwargs):
+        _appliquer_repens(self)
+        resultat = _VirtualObjectListView.SetObjects(self, *args, **kwargs)
+        return _apres_set_objects(self, resultat)
+
+
+class FastObjectListView(_FastObjectListView):
+    def __init__(self, *args, **kwargs):
+        _FastObjectListView.__init__(self, *args, **kwargs)
+        _appliquer_repens(self)
+
+    def SetObjects(self, *args, **kwargs):
+        _appliquer_repens(self)
+        resultat = _FastObjectListView.SetObjects(self, *args, **kwargs)
+        return _apres_set_objects(self, resultat)
+
+
+class GroupListView(_GroupListView):
+    def __init__(self, *args, **kwargs):
+        _GroupListView.__init__(self, *args, **kwargs)
+        _appliquer_repens(self)
+
+    def SetObjects(self, *args, **kwargs):
+        _appliquer_repens(self)
+        resultat = _GroupListView.SetObjects(self, *args, **kwargs)
+        return _apres_set_objects(self, resultat)
+
+    def _InitializeImages(self):
+        # CTRL_ObjectListView règle historiquement ses couleurs de groupes juste
+        # avant cet appel. Le rappel ne remplace que le bleu/noir legacy reconnu
+        # par UTILS_Interface et conserve toute personnalisation métier.
+        _appliquer_repens(self)
+        return _GroupListView._InitializeImages(self)
+
 
 __all__ = [
     "BatchedUpdate",
@@ -46,7 +205,7 @@ __all__ = [
     "EVT_EXPANDED",
     "EVT_EXPANDING",
     "EVT_GROUP_CREATING",
-    "EVT_GROUP_SORT"
+    "EVT_GROUP_SORT",
     "EVT_SORT",
     "Filter",
     "FastObjectListView",

--- a/noethys/Utils/UTILS_Aui.py
+++ b/noethys/Utils/UTILS_Aui.py
@@ -110,54 +110,18 @@ def _ItererDescendants(window):
 
 
 def ConfigurerGrille(grille):
-    """Applique la grammaire visuelle commune à une wx.Grid existante."""
+    """Applique le langage Repens à une wx.Grid sans toucher au métier."""
     if grille is None:
         return False
     try:
         import wx.grid as gridlib
-        from Utils import UTILS_Interface
-        from Utils import UTILS_UIMetrics
+        from Utils import UTILS_StyleRepens as Style
         if not isinstance(grille, gridlib.Grid):
             return False
     except Exception:
         return False
 
-    try:
-        grille.EnableGridLines(True)
-        grille.SetGridLineColour(UTILS_Interface.GetCouleurRole("outline_variant"))
-    except Exception:
-        pass
-    try:
-        grille.SetLabelBackgroundColour(UTILS_Interface.GetCouleurRole("surface_container_high"))
-        grille.SetLabelTextColour(UTILS_Interface.GetCouleurRole("on_surface"))
-    except Exception:
-        pass
-    try:
-        grille.SetDefaultCellBackgroundColour(UTILS_Interface.GetCouleurRole("surface_container_lowest"))
-        grille.SetDefaultCellTextColour(UTILS_Interface.GetCouleurRole("on_surface"))
-    except Exception:
-        pass
-
-    try:
-        if not hasattr(grille, "_noethys_default_row_base"):
-            grille._noethys_default_row_base = grille.GetDefaultRowSize()
-        grille.SetDefaultRowSize(
-            max(UTILS_UIMetrics.row_height("table"), UTILS_UIMetrics.px(grille._noethys_default_row_base)),
-            True,
-        )
-    except Exception:
-        pass
-
-    for getter, setter, attribut in (
-        ("GetRowLabelSize", "SetRowLabelSize", "_noethys_row_label_base"),
-        ("GetColLabelSize", "SetColLabelSize", "_noethys_col_label_base"),
-    ):
-        try:
-            if not hasattr(grille, attribut):
-                setattr(grille, attribut, getattr(grille, getter)())
-            getattr(grille, setter)(UTILS_UIMetrics.px(getattr(grille, attribut)))
-        except Exception:
-            pass
+    Style.appliquer_grille(grille)
 
     try:
         grille.ForceRefresh()
@@ -169,32 +133,92 @@ def ConfigurerGrille(grille):
     return True
 
 
-def ConfigurerNotebook(notebook):
-    """Donne aux onglets AUI une hauteur lisible et cohérente."""
-    if notebook is None:
+def _TypesNavigationStandard(wx):
+    """Retourne les contrôles book disponibles dans la version courante de wxPython."""
+    types_navigation = []
+    for nom in ("Notebook", "Choicebook", "Listbook", "Treebook", "Simplebook"):
+        classe = getattr(wx, nom, None)
+        if isinstance(classe, type):
+            types_navigation.append(classe)
+    return tuple(types_navigation)
+
+
+def _StyliserControleNavigation(controle, UTILS_Interface):
+    """Style un sélecteur interne de book sans modifier sa géométrie native."""
+    if controle is None:
+        return
+    try:
+        controle.SetBackgroundColour(UTILS_Interface.GetCouleurRole("surface_container_low"))
+        controle.SetForegroundColour(UTILS_Interface.GetCouleurRole("on_surface"))
+        controle.Refresh()
+    except Exception:
+        pass
+
+
+def ConfigurerNavigation(book):
+    """Applique Repens aux notebooks/listbooks/choicebooks sans redessiner leurs onglets."""
+    if book is None:
         return False
     try:
+        import wx
         import wx.lib.agw.aui as aui
         from Utils import UTILS_UIMetrics
         from Utils import UTILS_Interface
-        if not isinstance(notebook, aui.AuiNotebook):
-            return False
     except Exception:
         return False
 
+    types_standard = _TypesNavigationStandard(wx)
+    est_aui = isinstance(book, aui.AuiNotebook)
+    if not est_aui and (not types_standard or not isinstance(book, types_standard)):
+        return False
+
     try:
-        notebook.SetTabCtrlHeight(UTILS_UIMetrics.px(32))
+        book.SetBackgroundColour(UTILS_Interface.GetCouleurRole("surface"))
+        book.SetForegroundColour(UTILS_Interface.GetCouleurRole("on_surface"))
     except Exception:
         pass
+
+    # AUI expose explicitement la hauteur de sa barre d'onglets. Les books
+    # natifs conservent volontairement leur métrique plateforme et leur focus.
+    if est_aui:
+        try:
+            book.SetTabCtrlHeight(UTILS_UIMetrics.px(32))
+        except Exception:
+            pass
+
+    # Listbook/Choicebook/Treebook fournissent selon la version de wxPython un
+    # contrôle de navigation interne. On le thématise sans remplacer son rendu.
+    for getter in ("GetListView", "GetChoiceCtrl", "GetTreeCtrl"):
+        try:
+            controle = getattr(book, getter)()
+        except Exception:
+            controle = None
+        _StyliserControleNavigation(controle, UTILS_Interface)
+
+    # Les pages reçoivent uniquement les rôles de surface/texte. Leur layout,
+    # leurs tailles et leur logique métier restent intégralement inchangés.
     try:
-        notebook.SetBackgroundColour(UTILS_Interface.GetCouleurRole("surface"))
+        nombre_pages = book.GetPageCount()
     except Exception:
-        pass
+        nombre_pages = 0
+    for index in range(nombre_pages):
+        try:
+            page = book.GetPage(index)
+            page.SetBackgroundColour(UTILS_Interface.GetCouleurRole("surface"))
+            page.SetForegroundColour(UTILS_Interface.GetCouleurRole("on_surface"))
+        except Exception:
+            pass
+
     try:
-        notebook.Refresh()
+        book.Refresh()
     except Exception:
         pass
     return True
+
+
+def ConfigurerNotebook(notebook):
+    """Compatibilité historique : configure désormais toute navigation de type book."""
+    return ConfigurerNavigation(notebook)
 
 
 def _ConfigurerComposantsDuManager(manager):
@@ -207,6 +231,7 @@ def _ConfigurerComposantsDuManager(manager):
     except Exception:
         return
 
+    types_navigation = _TypesNavigationStandard(wx)
     deja_vues = set()
     for pane in panes:
         racine = getattr(pane, "window", None)
@@ -221,8 +246,8 @@ def _ConfigurerComposantsDuManager(manager):
                     taille_base = _TailleBitmapExistante(fenetre, defaut=16)
                 ConfigurerToolBar(fenetre, taille_base=taille_base, fond_uni=True)
                 continue
-            if isinstance(fenetre, aui.AuiNotebook):
-                ConfigurerNotebook(fenetre)
+            if isinstance(fenetre, aui.AuiNotebook) or (types_navigation and isinstance(fenetre, types_navigation)):
+                ConfigurerNavigation(fenetre)
                 continue
             if isinstance(fenetre, gridlib.Grid):
                 ConfigurerGrille(fenetre)

--- a/noethys/Utils/UTILS_StyleRepens.py
+++ b/noethys/Utils/UTILS_StyleRepens.py
@@ -193,13 +193,113 @@ def appliquer_saisie(ctrl):
 
 
 def appliquer_liste(ctrl):
-    """Style de base des listes/grilles lorsque leur renderer reste natif."""
+    """Style de base des listes lorsque leur renderer reste natif."""
     try:
         ctrl.SetFont(police("body"))
         ctrl.SetForegroundColour(couleur("on_surface"))
         ctrl.SetBackgroundColour(couleur("surface_container_lowest"))
     except Exception:
         pass
+    return ctrl
+
+
+def appliquer_liste_riche(ctrl):
+    """Réapplique la palette prudente des ObjectListView historiques.
+
+    Le moteur global d'apparence sait déjà distinguer les surfaces neutres des
+    couleurs métier explicites. Ce point d'entrée ne redéfinit donc pas une
+    seconde règle : il réutilise exactement cette politique au moment où les
+    anciens écrans ont fini d'assigner leurs zebra et leurs groupes.
+    """
+    try:
+        ctrl.SetFont(police("body"))
+    except Exception:
+        pass
+
+    # ObjectListView 1.3.2 utilisait une énorme fonte fixe de 24 pt pour son
+    # message vide. L'état vide suit désormais la typographie sémantique et le
+    # réglage de taille de texte, sans modifier un éventuel libellé métier.
+    try:
+        message_vide = getattr(ctrl, "stEmptyListMsg", None)
+        if message_vide is not None:
+            message_vide.SetFont(police("body_small"))
+    except Exception:
+        pass
+
+    try:
+        UTILS_Interface._appliquer_palette_liste(
+            ctrl,
+            sombre=UTILS_Interface.EstSombre(),
+        )
+    except Exception:
+        # Repli minimal lorsque le contrôle est utilisé hors du runtime complet.
+        appliquer_liste(ctrl)
+    return ctrl
+
+
+def appliquer_groupes_liste(ctrl):
+    """Compatibilité : les groupes suivent la même politique prudente que la liste."""
+    return appliquer_liste_riche(ctrl)
+
+
+def appliquer_grille(ctrl):
+    """Style sémantique commun d'une ``wx.grid.Grid`` existante.
+
+    Repens ne touche ni aux renderers métier, ni aux éditeurs, ni aux dimensions
+    de colonnes. Seuls la typographie, les surfaces, la sélection, les traits et
+    les métriques de ligne communes sont harmonisés.
+    """
+    try:
+        import wx.grid as gridlib
+        if not isinstance(ctrl, gridlib.Grid):
+            return ctrl
+    except Exception:
+        return ctrl
+
+    appliquer_liste(ctrl)
+
+    for methode, valeur in (
+        ("SetDefaultCellFont", police("body")),
+        ("SetLabelFont", police("label")),
+        ("SetGridLineColour", couleur("outline_variant")),
+        ("SetLabelBackgroundColour", couleur("surface_container_low")),
+        ("SetLabelTextColour", couleur("on_surface_variant")),
+        ("SetDefaultCellBackgroundColour", couleur("surface_container_lowest")),
+        ("SetDefaultCellTextColour", couleur("on_surface")),
+        ("SetSelectionBackground", couleur("selection")),
+        ("SetSelectionForeground", couleur("selection_text")),
+    ):
+        try:
+            getattr(ctrl, methode)(valeur)
+        except Exception:
+            pass
+
+    try:
+        ctrl.EnableGridLines(True)
+    except Exception:
+        pass
+
+    try:
+        if not hasattr(ctrl, "_noethys_default_row_base"):
+            ctrl._noethys_default_row_base = ctrl.GetDefaultRowSize()
+        ctrl.SetDefaultRowSize(
+            max(hauteur_ligne("table"), px(ctrl._noethys_default_row_base)),
+            True,
+        )
+    except Exception:
+        pass
+
+    for getter, setter, attribut in (
+        ("GetRowLabelSize", "SetRowLabelSize", "_noethys_row_label_base"),
+        ("GetColLabelSize", "SetColLabelSize", "_noethys_col_label_base"),
+    ):
+        try:
+            if not hasattr(ctrl, attribut):
+                setattr(ctrl, attribut, getattr(ctrl, getter)())
+            getattr(ctrl, setter)(px(getattr(ctrl, attribut)))
+        except Exception:
+            pass
+
     return ctrl
 
 

--- a/scripts/audit_legacy_list_tools.py
+++ b/scripts/audit_legacy_list_tools.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Inventorie les raccords encore dépendants des outils de listes historiques.
+
+L'objectif n'est pas de faire échouer la CI : ce script fournit une dette
+mesurable pour terminer la migration Repens écran par écran sans chercher des
+usages à la main.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+PATTERNS = {
+    "ctrl_outils_historique": re.compile(r"\bCTRL_ObjectListView\.CTRL_Outils\b"),
+    "barre_recherche_historique": re.compile(r"\bCTRL_ObjectListView\.BarreRecherche\b"),
+    "import_ctrl_outils_historique": re.compile(
+        r"from\s+Ctrl\.CTRL_ObjectListView\s+import\s+[^\n]*(?:CTRL_Outils|BarreRecherche)"
+    ),
+    "assets_filtre_16px": re.compile(
+        r"Images/16x16/(?:Filtre(?:_[0-9]+|_supprimer)?|Cocher|Decocher)\.png"
+    ),
+}
+
+SKIP_DIRS = {".git", "build", "dist", "__pycache__", ".venv", "venv"}
+SOURCE_HISTORIQUE = "Ctrl/CTRL_ObjectListView.py"
+CODES_ECRAN = {
+    "ctrl_outils_historique",
+    "barre_recherche_historique",
+    "import_ctrl_outils_historique",
+}
+
+
+def scan_file(path: Path) -> list[dict[str, object]]:
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+
+    findings = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for code, pattern in PATTERNS.items():
+            if pattern.search(line):
+                findings.append({
+                    "code": code,
+                    "path": path.as_posix(),
+                    "line": lineno,
+                    "text": line.strip(),
+                })
+    return findings
+
+
+def _est_source_historique(path: Path, root: Path) -> bool:
+    try:
+        relatif = path.relative_to(root).as_posix()
+    except ValueError:
+        relatif = path.as_posix()
+    return relatif == SOURCE_HISTORIQUE or relatif.endswith("/" + SOURCE_HISTORIQUE)
+
+
+def scan(root: Path) -> list[dict[str, object]]:
+    findings = []
+    for path in sorted(root.rglob("*.py")):
+        if any(part in SKIP_DIRS for part in path.parts):
+            continue
+        items = scan_file(path)
+        if _est_source_historique(path, root):
+            # La définition historique n'est pas un écran restant à migrer.
+            # On ne conserve ici que ses anciens assets afin de matérialiser le
+            # dernier raccord central encore à retirer une fois les appels partis.
+            items = [item for item in items if item["code"] == "assets_filtre_16px"]
+        findings.extend(items)
+    return findings
+
+
+def summarize(findings: list[dict[str, object]]) -> dict[str, int]:
+    counts = {code: 0 for code in PATTERNS}
+    for item in findings:
+        counts[str(item["code"])] += 1
+    return counts
+
+
+def screens(findings: list[dict[str, object]]) -> list[str]:
+    """Retourne les écrans encore raccordés aux anciens outils, sans doublons."""
+    return sorted({
+        str(item["path"])
+        for item in findings
+        if item["code"] in CODES_ECRAN
+    })
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", default="noethys")
+    parser.add_argument("--json", dest="json_path", default=None)
+    args = parser.parse_args()
+
+    root = Path(args.root)
+    findings = scan(root)
+    counts = summarize(findings)
+    legacy_screens = screens(findings)
+
+    for item in findings:
+        print(
+            "{code} {path}:{line}: {text}".format(**item)
+        )
+
+    print("\nDette outils de listes :")
+    for code in PATTERNS:
+        print(f"- {code}: {counts[code]}")
+    print(f"- ecrans_metier_restants: {len(legacy_screens)}")
+
+    if args.json_path:
+        output = Path(args.json_path)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(
+            json.dumps(
+                {
+                    "summary": counts,
+                    "screens": legacy_screens,
+                    "findings": findings,
+                },
+                ensure_ascii=False,
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_audit_legacy_list_tools.py
+++ b/tests/test_audit_legacy_list_tools.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "audit_legacy_list_tools.py"
+SPEC = importlib.util.spec_from_file_location("audit_legacy_list_tools", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class LegacyListToolsAuditTests(unittest.TestCase):
+    def test_detects_historical_toolbar_and_assets(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = root / "screen.py"
+            path.write_text(
+                "from Ctrl import CTRL_ObjectListView\n"
+                "toolbar = CTRL_ObjectListView.CTRL_Outils(parent, listview=liste)\n"
+                "image = 'Images/16x16/Filtre_3.png'\n",
+                encoding="utf-8",
+            )
+            findings = MODULE.scan(root)
+            codes = [item["code"] for item in findings]
+            self.assertIn("ctrl_outils_historique", codes)
+            self.assertIn("assets_filtre_16px", codes)
+
+    def test_repens_toolbar_is_not_reported(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = root / "screen.py"
+            path.write_text(
+                "from Ctrl import CTRL_OutilsListeRepens\n"
+                "toolbar = CTRL_OutilsListeRepens.CTRL(parent, listview=liste)\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(MODULE.scan(root), [])
+
+    def test_historical_source_is_not_counted_as_a_business_screen(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "noethys"
+            source = root / "Ctrl" / "CTRL_ObjectListView.py"
+            source.parent.mkdir(parents=True)
+            source.write_text(
+                "toolbar = CTRL_ObjectListView.CTRL_Outils(parent, listview=liste)\n"
+                "image = 'Images/16x16/Filtre.png'\n",
+                encoding="utf-8",
+            )
+            findings = MODULE.scan(root)
+            self.assertEqual([item["code"] for item in findings], ["assets_filtre_16px"])
+            self.assertEqual(MODULE.screens(findings), [])
+
+    def test_screen_list_is_unique_even_with_multiple_legacy_calls(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = root / "screen.py"
+            path.write_text(
+                "a = CTRL_ObjectListView.CTRL_Outils(parent, listview=liste)\n"
+                "b = CTRL_ObjectListView.BarreRecherche(parent, liste)\n",
+                encoding="utf-8",
+            )
+            findings = MODULE.scan(root)
+            self.assertEqual(MODULE.screens(findings), [path.as_posix()])
+
+    def test_summary_keeps_zero_categories_visible(self):
+        summary = MODULE.summarize([])
+        self.assertEqual(set(summary), set(MODULE.PATTERNS))
+        self.assertTrue(all(value == 0 for value in summary.values()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_list_tools_repens_contract.py
+++ b/tests/test_list_tools_repens_contract.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""Contrats statiques de la barre d'outils commune des listes Repens."""
+
+import ast
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ListToolsRepensContractTests(unittest.TestCase):
+    def _read(self):
+        path = ROOT / "noethys/Ctrl/CTRL_OutilsListeRepens.py"
+        text = path.read_text(encoding="utf-8")
+        ast.parse(text)
+        return text
+
+    def test_toolbar_uses_repens_actions_and_no_legacy_16px_assets(self):
+        text = self._read()
+        self.assertIn("CTRL_ActionRepens.CTRL", text)
+        self.assertIn('icone="filter"', text)
+        self.assertIn('icone="check"', text)
+        self.assertNotIn("wx.lib.platebtn", text)
+        self.assertNotIn("Chemins.GetStaticPath", text)
+        self.assertNotIn("Images/16x16", text)
+
+    def test_search_is_native_semantic_and_bounded_on_wide_screens(self):
+        text = self._read()
+        self.assertIn("class BarreRecherche(wx.SearchCtrl)", text)
+        self.assertIn("Style.appliquer_saisie(self)", text)
+        self.assertIn("self.SetMinSize((Style.px(180), Style.cible_action(\"compact\")))", text)
+        self.assertIn("self.SetMaxSize((Style.px(360), -1))", text)
+        self.assertIn('UTILS_IconesRepens.GetBitmap(\n                    "search"', text)
+        self.assertIn('UTILS_IconesRepens.GetBitmap(\n                    "dismiss"', text)
+
+    def test_layout_does_not_stretch_search_field_across_the_workspace(self):
+        text = self._read()
+        self.assertIn("sizer.Add(self.barreRecherche, 0,", text)
+        self.assertIn("sizer.AddStretchSpacer(1)", text)
+        self.assertNotIn("sizer.Add(self.barreRecherche, 1,", text)
+
+    def test_historical_list_contracts_are_preserved(self):
+        text = self._read()
+        for marker in (
+            "SetBarreRecherche",
+            "SetFiltresColonnes",
+            "Filtrer",
+            "CocheListeTout",
+            "CocheListeRien",
+            "ctrl_regroupement",
+            "regroupement",
+        ):
+            self.assertIn(marker, text)
+        self.assertIn("DLG_Filtres_listes.Dialog", text)
+        self.assertIn("Filtrer (%d)", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_navigation_ui_contract.py
+++ b/tests/test_navigation_ui_contract.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""Contrats statiques pour la navigation commune Repens."""
+
+import ast
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class NavigationUIContractTests(unittest.TestCase):
+    def _read_aui(self):
+        path = ROOT / "noethys/Utils/UTILS_Aui.py"
+        text = path.read_text(encoding="utf-8")
+        ast.parse(text)
+        return text
+
+    def test_common_book_navigation_is_semantic_and_cross_platform(self):
+        text = self._read_aui()
+        self.assertIn("def ConfigurerNavigation(book):", text)
+        self.assertIn('("Notebook", "Choicebook", "Listbook", "Treebook", "Simplebook")', text)
+        self.assertIn('GetCouleurRole("surface")', text)
+        self.assertIn('GetCouleurRole("surface_container_low")', text)
+        self.assertIn('GetCouleurRole("on_surface")', text)
+        self.assertIn('("GetListView", "GetChoiceCtrl", "GetTreeCtrl")', text)
+
+    def test_native_books_keep_platform_geometry_and_focus(self):
+        text = self._read_aui()
+        navigation = text.split("def ConfigurerNavigation(book):", 1)[1].split("def ConfigurerNotebook", 1)[0]
+        self.assertIn("if est_aui:", navigation)
+        self.assertIn("SetTabCtrlHeight", navigation)
+        self.assertNotIn("SetMinSize", navigation)
+        self.assertNotIn("SetSize", navigation)
+        self.assertNotIn("SetWindowStyle", navigation)
+
+    def test_historical_notebook_entry_point_delegates_to_common_navigation(self):
+        text = self._read_aui()
+        wrapper = text.split("def ConfigurerNotebook(notebook):", 1)[1].split("def _ConfigurerComposantsDuManager", 1)[0]
+        self.assertIn("return ConfigurerNavigation(notebook)", wrapper)
+
+    def test_aui_manager_discovers_standard_books_without_relaying_out_panes(self):
+        text = self._read_aui()
+        manager_components = text.split("def _ConfigurerComposantsDuManager(manager):", 1)[1].split("def _ConfigurerPoliceCaptions", 1)[0]
+        self.assertIn("types_navigation = _TypesNavigationStandard(wx)", manager_components)
+        self.assertIn("ConfigurerNavigation(fenetre)", manager_components)
+        self.assertNotIn("DockSize", manager_components)
+        self.assertNotIn("BestSize", manager_components)
+        self.assertNotIn("MinSize", manager_components)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_objectlistview_empty_state_contract.py
+++ b/tests/test_objectlistview_empty_state_contract.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+"""Contrats de l'état vide commun des ObjectListView Repens."""
+
+import ast
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ObjectListViewEmptyStateContractTests(unittest.TestCase):
+    def _read(self, relative_path):
+        text = (ROOT / relative_path).read_text(encoding="utf-8")
+        ast.parse(text)
+        return text
+
+    def test_wrapper_restores_empty_state_after_legacy_phoenix_resize(self):
+        text = self._read("noethys/ObjectListView/__init__.py")
+        self.assertIn("def _synchroniser_etat_vide(ctrl):", text)
+        self.assertIn('message.Show(vide)', text)
+        self.assertIn("wx.CallAfter(_synchroniser_etat_vide, ctrl)", text)
+        self.assertIn("ctrl.Bind(wx.EVT_SIZE, _apres_resize)", text)
+        self.assertNotIn("'phoenix' in wx.PlatformInfo", text)
+
+    def test_empty_state_waits_for_real_list_columns_before_becoming_visible(self):
+        text = self._read("noethys/ObjectListView/__init__.py")
+        self.assertIn("if ctrl.GetColumnCount() <= 0:", text)
+        self.assertIn("message.Hide()", text)
+        # Un contrôle tout juste construit ne doit pas afficher fugitivement
+        # « Aucun élément » avant que l'écran métier ait installé ses colonnes.
+        self.assertNotIn("_synchroniser_etat_vide(self)", text)
+
+    def test_vendor_default_message_is_localized_without_overwriting_business_text(self):
+        text = self._read("noethys/ObjectListView/__init__.py")
+        self.assertIn('_MESSAGE_VIDE_VENDOR = "This list is empty"', text)
+        self.assertIn('if message.GetLabel() != _MESSAGE_VIDE_VENDOR:', text)
+        self.assertIn('message.SetLabel(_(u"Aucun élément"))', text)
+
+    def test_repens_replaces_vendor_fixed_24pt_empty_font(self):
+        text = self._read("noethys/Utils/UTILS_StyleRepens.py")
+        self.assertIn('message_vide.SetFont(police("body_small"))', text)
+        self.assertNotIn("wx.Font(24", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_objectlistview_repens_contract.py
+++ b/tests/test_objectlistview_repens_contract.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+"""Contrats statiques du raccord ObjectListView -> Repens Design."""
+
+import ast
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+STYLE = ROOT / "noethys" / "Utils" / "UTILS_StyleRepens.py"
+INTERFACE = ROOT / "noethys" / "Utils" / "UTILS_Interface.py"
+OLV_INIT = ROOT / "noethys" / "ObjectListView" / "__init__.py"
+
+
+def _source(path):
+    return path.read_text(encoding="utf-8")
+
+
+def _fonction(source, nom):
+    arbre = ast.parse(source)
+    for noeud in arbre.body:
+        if isinstance(noeud, (ast.FunctionDef, ast.AsyncFunctionDef)) and noeud.name == nom:
+            return ast.get_source_segment(source, noeud) or ""
+    raise AssertionError("Fonction %s introuvable" % nom)
+
+
+class ObjectListViewRepensContractTests(unittest.TestCase):
+    def test_rich_list_reuses_existing_cautious_palette_policy(self):
+        source = _source(STYLE)
+        liste = _fonction(source, "appliquer_liste_riche")
+
+        self.assertIn("UTILS_Interface._appliquer_palette_liste", liste)
+        self.assertIn("UTILS_Interface.EstSombre()", liste)
+        self.assertNotIn("evenRowsBackColor =", liste)
+        self.assertNotIn("oddRowsBackColor =", liste)
+        self.assertNotIn("SetColumnWidth", liste)
+        self.assertNotIn("SetItem", liste)
+        self.assertNotIn("wx.Colour", liste)
+
+    def test_existing_palette_policy_preserves_business_colours(self):
+        source = _source(INTERFACE)
+        palette = _fonction(source, "_appliquer_palette_liste")
+
+        self.assertIn("_peut_remplacer_surface_liste", palette)
+        self.assertIn('GetCouleurRole("surface_container_lowest"', palette)
+        self.assertIn('GetCouleurRole("surface_container_low"', palette)
+        self.assertIn('GetCouleurRole("surface_container_high"', palette)
+        self.assertIn("groupBackgroundColour", palette)
+        self.assertIn("stEmptyListMsg", palette)
+
+    def test_group_compatibility_uses_same_palette_policy(self):
+        source = _source(STYLE)
+        groupes = _fonction(source, "appliquer_groupes_liste")
+        self.assertIn("appliquer_liste_riche(ctrl)", groupes)
+        self.assertNotIn("wx.Colour", groupes)
+
+    def test_vendored_olv_adapter_stays_thin_and_lazy(self):
+        source = _source(OLV_INIT)
+
+        self.assertIn("def _appliquer_repens", source)
+        self.assertIn("from Utils import UTILS_StyleRepens as Style", source)
+        self.assertIn("Style.appliquer_liste_riche(ctrl)", source)
+        self.assertIn("def SetObjects", source)
+        self.assertIn("def _InitializeImages", source)
+        self.assertNotIn("SetColumnWidth", source)
+        self.assertNotIn("SetItemBackgroundColour", source)
+        self.assertNotIn("wx.Colour", source)
+
+    def test_existing_business_adapter_remains_the_owner_of_columns(self):
+        ctrl = _source(ROOT / "noethys" / "Ctrl" / "CTRL_ObjectListView.py")
+        self.assertIn("class ColumnDefn", ctrl)
+        self.assertIn("def SetColumns", ctrl)
+        self.assertIn("def Filtrer", ctrl)
+        self.assertIn("def GenerationContextMenu", ctrl)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_table_grid_repens_contract.py
+++ b/tests/test_table_grid_repens_contract.py
@@ -12,6 +12,15 @@ AUI = ROOT / "noethys" / "Utils" / "UTILS_Aui.py"
 TABLEAU = ROOT / "noethys" / "Ctrl" / "CTRL_TableauResponsive.py"
 
 
+def _fonction(source, nom):
+    """Extrait une fonction top-level sans dépendre de l'ordre des helpers voisins."""
+    arbre = ast.parse(source)
+    for noeud in arbre.body:
+        if isinstance(noeud, (ast.FunctionDef, ast.AsyncFunctionDef)) and noeud.name == nom:
+            return ast.get_source_segment(source, noeud) or ""
+    raise AssertionError("Fonction %s introuvable" % nom)
+
+
 class TableGridRepensContractTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -30,9 +39,7 @@ class TableGridRepensContractTests(unittest.TestCase):
         self.assertNotIn("wx.Colour(", self.style_text)
 
     def test_aui_grid_adapter_delegates_without_business_geometry(self):
-        debut = self.aui_text.index("def ConfigurerGrille")
-        fin = self.aui_text.index("\ndef ConfigurerNotebook", debut)
-        bloc = self.aui_text[debut:fin]
+        bloc = _fonction(self.aui_text, "ConfigurerGrille")
         self.assertIn("UTILS_StyleRepens as Style", bloc)
         self.assertIn("Style.appliquer_grille(grille)", bloc)
         self.assertNotIn("UTILS_Interface", bloc)

--- a/tests/test_table_grid_repens_contract.py
+++ b/tests/test_table_grid_repens_contract.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""Contrats statiques de la couche tableaux/grilles Repens."""
+
+import ast
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+STYLE = ROOT / "noethys" / "Utils" / "UTILS_StyleRepens.py"
+AUI = ROOT / "noethys" / "Utils" / "UTILS_Aui.py"
+TABLEAU = ROOT / "noethys" / "Ctrl" / "CTRL_TableauResponsive.py"
+
+
+class TableGridRepensContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.style_text = STYLE.read_text(encoding="utf-8")
+        cls.aui_text = AUI.read_text(encoding="utf-8")
+        cls.tableau_text = TABLEAU.read_text(encoding="utf-8")
+        for texte in (cls.style_text, cls.aui_text, cls.tableau_text):
+            ast.parse(texte)
+
+    def test_grid_style_is_owned_by_repens_facade(self):
+        self.assertIn("def appliquer_grille", self.style_text)
+        self.assertIn('SetLabelFont", police("label")', self.style_text)
+        self.assertIn('SetSelectionBackground", couleur("selection")', self.style_text)
+        self.assertIn('SetSelectionForeground", couleur("selection_text")', self.style_text)
+        self.assertIn('hauteur_ligne("table")', self.style_text)
+        self.assertNotIn("wx.Colour(", self.style_text)
+
+    def test_aui_grid_adapter_delegates_without_business_geometry(self):
+        debut = self.aui_text.index("def ConfigurerGrille")
+        fin = self.aui_text.index("\ndef ConfigurerNotebook", debut)
+        bloc = self.aui_text[debut:fin]
+        self.assertIn("UTILS_StyleRepens as Style", bloc)
+        self.assertIn("Style.appliquer_grille(grille)", bloc)
+        self.assertNotIn("UTILS_Interface", bloc)
+        self.assertNotIn("UTILS_UIMetrics", bloc)
+        self.assertNotIn("SetColSize", bloc)
+        self.assertNotIn("SetRowSize", bloc)
+
+    def test_responsive_table_uses_semantic_zebra_rows(self):
+        self.assertIn("def _StyliserLigne", self.tableau_text)
+        self.assertIn('"surface_container_lowest" if index % 2 == 0 else "surface_container_low"', self.tableau_text)
+        self.assertIn('Style.couleur("on_surface")', self.tableau_text)
+        self.assertNotIn("wx.Colour(", self.tableau_text)
+
+    def test_search_and_count_are_above_the_data_surface(self):
+        self.assertIn("self.barre_donnees = wx.Panel", self.tableau_text)
+        self.assertIn("self.recherche.SetMaxSize((Style.px(360), -1))", self.tableau_text)
+        position_barre = self.tableau_text.index("sizer.Add(self.barre_donnees")
+        position_tableau = self.tableau_text.index("sizer.Add(self.tableau", position_barre)
+        self.assertLess(position_barre, position_tableau)
+        self.assertNotIn("wx.FlexGridSizer(", self.tableau_text)
+        self.assertNotIn("wx.GridSizer(", self.tableau_text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Cette PR remplace les chantiers UI transverses empilés #73, #74 et #75 par un lot unique, reconstruit proprement sur le `master` courant.

Périmètre :
- raccord commun des `ObjectListView` à la palette Repens, en préservant les couleurs métier ;
- état vide ObjectListView restauré sous Phoenix, sans flash pendant la construction ;
- façade commune des `wx.Grid` et tableau responsive ;
- barre de recherche / filtres / cochage compacte avec actions Repens et icônes Fluent ;
- navigation commune AUI + Notebook / Choicebook / Listbook / Treebook, sans reprendre la géométrie native ;
- inventaire mesurable des écrans encore dépendants des anciens outils de listes ;
- tests de contrat associés ;
- documentation de la ligne d'arrivée du chantier UI transverse.

Contraintes conservées :
- aucune modification de logique métier ;
- aucune migration de données ;
- aucune nouvelle dépendance lourde ;
- aucune surcouche pour masquer les assertions wxPython ;
- densité desktop et comportement natif conservés.

La branche contient un seul commit au-dessus du `master` intégrant déjà la correction CI #76.