### PR TITLE
Docs : cadrer la recette Windows post-Repens

### DIFF
--- a/docs/CI-WINDOWS-AUDIT.md
+++ b/docs/CI-WINDOWS-AUDIT.md
@@ -1,12 +1,12 @@
 # Audit CI Windows — Noethys
 
-Ce document décrit l'état **actuel** de la validation runtime/UI de Noethys. Il remplace l'ancien état initial du dépôt, désormais obsolète.
+Ce document décrit l'état **actuel** de la validation runtime/UI de Noethys et la recette manuelle à appliquer après la consolidation Repens.
 
 ## Objectif
 
-La CI doit détecter les régressions qui produisent des fenêtres vides, des freezes à l'ouverture, des dialogues partiellement construits, des assertions wxPython, des erreurs de sizer et des incompatibilités runtime Python 3/Windows.
+La qualification doit détecter les régressions qui produisent des fenêtres vides, des freezes à l'ouverture, des dialogues partiellement construits, des assertions wxPython, des erreurs de sizer, des régressions clair/sombre ou de scaling et des incompatibilités runtime Python 3/Windows.
 
-Le principe est simple : **corriger à la source, ne jamais masquer le défaut**.
+Le principe reste simple : **corriger à la source, ne jamais masquer le défaut**.
 
 ## Règles wxPython
 
@@ -39,31 +39,39 @@ Le parent wx reste `contenu`; les appels métier passent par `self.controller`.
 
 ### `.github/workflows/ci.yml`
 
-La CI générale valide notamment :
+C'est l'unique porte d'entrée de qualification générale.
 
-- compilation Python ;
+Sur une PR ou un push `master`, un seul job Ubuntu rapide exécute notamment :
+
+- compilation des sources et outils ;
 - audits runtime ;
-- tests métier purs Python ;
-- tests de migration/restauration/portable/RC ;
-- smoke tests wxPython sur Windows ;
-- smoke layout wxPython sur Windows, macOS et Linux lorsque le job le permet.
+- tests métier et contrats UI ;
+- surveillance des imports dynamiques PyInstaller ;
+- garde des perspectives AUI ;
+- audit layout wxPython ;
+- audit du cycle de vie wxPython ;
+- contrôle de compatibilité de schéma ;
+- conservation des diagnostics UI.
 
-Le job Windows possède un `timeout-minutes: 10` afin qu'un freeze de dialogue devienne un échec CI au lieu de bloquer indéfiniment le runner.
+Les contrôles indépendants continuent autant que possible après un échec, puis le bilan final rend le job rouge si nécessaire. La CI automatique ne lance pas de matrice multi-OS ni de packaging.
 
-### `.github/workflows/ui-audit.yml`
+En lancement manuel `workflow_dispatch` avec le mode `complete`, le même workflow ajoute :
 
-Le workflow UI exécute :
+- recette synthétique et inventaires complets ;
+- smoke test Windows ;
+- smoke test macOS ;
+- smoke test Linux GTK3 ;
+- fabrication du package Windows portable via le workflow réutilisable.
 
-- `scripts/audit_ui_layout.py` ;
-- `scripts/audit_wx_lifecycle.py` ;
-- les tests unitaires de l'audit de cycle de vie wxPython ;
-- l'upload des inventaires JSON pour analyse et comparaison.
+### `.github/workflows/windows-package.yml`
 
-L'audit bloque explicitement les mécanismes de suppression d'assertions de sizer.
+Ce workflow est désormais un **workflow réutilisable** appelé par `ci.yml` en qualification complète. Il ne constitue plus une porte d'entrée autonome déclenchée à chaque PR.
+
+L'ancien workflow séparé `ui-audit.yml` a été supprimé : les audits UI font désormais partie du job rapide unique de `ci.yml`.
 
 ## Audit layout
 
-`scripts/audit_ui_layout.py` produit un inventaire des motifs historiques et modernes. Les catégories informatives servent à prioriser les migrations ; les suppressions d'assertions sont structurellement bloquantes.
+`scripts/audit_ui_layout.py` produit un inventaire des motifs historiques et modernes. Les catégories informatives servent à prioriser les corrections ; les suppressions d'assertions sont structurellement bloquantes.
 
 Catégories suivies notamment :
 
@@ -91,7 +99,7 @@ Catégories :
 - `constructor_callback_before_dependency` : callback lisant un attribut initialisé plus tard ; risque élevé ;
 - `constructor_parent_callback` : callback métier lancé sur le parent depuis un constructeur wx explicite ; bloquant dans l'audit UI.
 
-Les faux positifs provenant de classes métier non-wx comme certains `Track` ont été exclus de la détection forte.
+Les faux positifs provenant de classes métier non-wx comme certains `Track` sont exclus de la détection forte.
 
 ## Smoke test wxPython structurel
 
@@ -112,24 +120,78 @@ Pour les interfaces critiques, le test doit :
 11. restaurer proprement la sélection ;
 12. appeler `Destroy()` proprement.
 
-Une fenêtre vide, figée, partiellement construite ou déclenchant une assertion doit faire échouer la CI.
+Une fenêtre vide, figée, partiellement construite ou déclenchant une assertion doit faire échouer la qualification.
 
 ## Dialogues prioritaires
 
-La couverture structurelle doit progresser en priorité sur les fenêtres utilisées régulièrement :
+La couverture structurelle et la recette manuelle doivent privilégier les fenêtres utilisées régulièrement :
 
 - Préférences ;
 - paramétrages ;
 - fiches individuelles/familles ;
 - inscriptions ;
-- contrats ;
-- recrutement ;
-- présences ;
+- présences/consommations ;
+- impressions ;
 - autres dialogues métier ouverts depuis le shell principal.
 
-Le dialogue Préférences est désormais testé depuis son module réel `DLG_Preferences.py`. L'ancien adaptateur `DLG_Preferences_stable.py` a été supprimé : les corrections de layout doivent vivre dans le module métier d'origine.
+Le dialogue Préférences est testé depuis son module réel `DLG_Preferences.py`. L'ancien adaptateur `DLG_Preferences_stable.py` a été supprimé : les corrections de layout doivent vivre dans le module métier d'origine.
 
 `DLG_Impression_conso_differe.py` reste un chargement spécialisé distinct tant qu'il n'est pas démontré qu'il masque un défaut wxPython ; il doit être évalué séparément et non supprimé par analogie.
+
+## Recette manuelle Windows post-Repens
+
+La CI structurelle ne remplace pas l'observation de l'application réelle. Après un lot UI transverse, la recette locale Windows devient la source des prochains tickets : **on ne reprend pas une modernisation générale tant qu'aucun défaut concret n'est observé**.
+
+### 1. Préparer la session
+
+- synchroniser le dépôt sur le `master` courant et noter le SHA testé ;
+- fermer les anciennes instances de Noethys ;
+- lancer `DEV-Noethys.cmd` depuis la racine du dépôt.
+
+`DEV-Noethys.cmd` appelle `scripts/dev_windows.ps1`, qui :
+
+- crée si nécessaire un environnement `.venv` Python 3.10 ;
+- met à jour les dépendances uniquement lorsque les fichiers requirements changent ;
+- applique les correctifs Python 3/wxPhoenix validés ;
+- lance Noethys depuis les sources avec diagnostics complets.
+
+Les journaux utiles sont placés dans `noethys/Portable/`, notamment `journal.log`, `noethys_actions.log`, `noethys_crash.log` et `noethys_hang.log`.
+
+### 2. Parcours minimal obligatoire
+
+Tester au minimum :
+
+1. démarrage et shell principal : aucune zone vide anormale, aucun freeze, panes AUI manipulables ;
+2. recherche individus/familles : recherche, sélection, redimensionnement, actions principales ;
+3. fiche famille puis fiche individu : navigation entre pages et fermeture propre ;
+4. inscription : ouverture complète, changement de page, contrôles imbriqués ;
+5. une liste métier ObjectListView : recherche, filtre, cochage et regroupement lorsqu'ils sont disponibles ;
+6. un écran `wx.Grid` métier : sélection, scrolling, édition si autorisée, redimensionnement ;
+7. Préférences : apparence, thème et échelle ;
+8. présences/consommations puis un parcours d'impression représentatif ;
+9. fermeture de l'application sans assertion ni processus bloqué.
+
+### 3. Clair, sombre et scaling
+
+Le parcours doit être répété sur les contrôles critiques :
+
+- en thème clair puis sombre ;
+- à l'échelle normale puis au moins à une échelle agrandie courante (120/125 % ou 150 %).
+
+À contrôler visuellement : texte non tronqué, absence de grands blocs blancs en sombre, focus visible, boutons accessibles, lignes et sélections lisibles, aucune perte de densité desktop injustifiée.
+
+### 4. Format d'un défaut recevable
+
+Pour chaque anomalie, relever :
+
+- écran et chemin précis pour la reproduire ;
+- thème et échelle utilisés ;
+- résultat attendu / résultat observé ;
+- capture d'écran si le défaut est visuel ;
+- extrait du journal si une assertion, une exception ou un freeze apparaît ;
+- SHA du `master` testé.
+
+Un défaut visuel concret devient alors un lot ciblé. On recherche le même motif dans la famille de contrôles avant correction, mais on n'ouvre pas un nouveau chantier générique « moderniser Noethys ».
 
 ## wxAUI et Repens
 
@@ -152,21 +214,19 @@ Pour chaque défaut confirmé :
 6. relancer les chemins Windows critiques ;
 7. répéter jusqu'au vert.
 
-Les tests ne doivent pas être assouplis pour faire passer une implémentation cassée. En revanche, un test statique devenu obsolète après une évolution volontaire de l'architecture doit être réaligné sur le contrat réellement voulu, comme pour la séparation wxAUI/Repens ou la suppression de l'adaptateur Préférences.
+Les tests ne doivent pas être assouplis pour faire passer une implémentation cassée. En revanche, un test statique devenu obsolète après une évolution volontaire de l'architecture doit être réaligné sur le contrat réellement voulu.
 
 ## Risques runtime non-UI encore suivis
 
 Les audits continuent de signaler notamment :
 
 - accès à des résultats SQL par index sans garde suffisante ;
-- connexions DB potentiellement non fermées ;
 - `except:` trop larges ;
-- séquences d'échappement invalides ;
-- usages `eval()` / `exec()` à qualifier ;
 - dépendances/chemins spécifiques à Windows ;
-- packaging et modules COM.
+- packaging et modules COM ;
+- autres frontières runtime inventoriées par les scripts de qualification.
 
-Ces sujets restent distincts du nettoyage wxPython mais sont exécutés dans la même stratégie de stabilisation runtime.
+Ces sujets restent distincts du nettoyage wxPython mais participent à la même stratégie de stabilisation runtime.
 
 ## Critère de sortie
 
@@ -178,4 +238,5 @@ Une zone UI peut être considérée stabilisée lorsque :
 - les contrôles ne déclenchent pas de callbacks avant leurs dépendances ;
 - les pages internes sont réellement construites et dimensionnées ;
 - le smoke Windows passe ;
+- la recette manuelle clair/sombre/scaling ne révèle pas de défaut bloquant ;
 - les tests métier associés restent inchangés ou explicitement justifiés.


### PR DESCRIPTION
Met à jour `docs/CI-WINDOWS-AUDIT.md` pour refléter la CI consolidée actuelle et supprimer la référence obsolète à `ui-audit.yml`.

Ajoute surtout une recette manuelle Windows post-Repens : lancement via `DEV-Noethys.cmd`, parcours minimal des écrans critiques, vérification clair/sombre et scaling, collecte des logs et format attendu pour transformer chaque anomalie observée en correctif ciblé.

Aucun code runtime ni workflow n'est modifié. Cette PR prépare la phase suivante : recette réelle Windows puis corrections uniquement sur défauts concrets.