### PR TITLE
CI : rassembler les inventaires statiques pré-RC

### DIFF
--- a/scripts/audit_pre_rc.py
+++ b/scripts/audit_pre_rc.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Rassemble les inventaires statiques à relire avant de figer une RC.
+
+Ce script ne modifie ni le code ni les bases. Il regroupe en une commande les
+inventaires SQL strict, cycle de vie wxPython et anciens outils de listes afin
+d'éviter trois procédures parallèles et des chiffres recopiés à la main.
+
+Les résultats restent des diagnostics : une occurrence n'est pas un bug par
+elle-même. Les catégories wxPython structurelles à risque sont simplement
+signalées explicitement dans le résumé pour faciliter la revue pré-RC.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts import audit_legacy_list_tools  # noqa: E402
+from scripts import audit_sql_strict  # noqa: E402
+from scripts import audit_wx_lifecycle  # noqa: E402
+
+DEFAULT_ROOT = ROOT / "noethys"
+DEFAULT_OUTPUT = ROOT / "tmp" / "pre-rc-audits"
+WX_HIGH_RISK = (
+    "constructor_parent_callback",
+    "constructor_callback_before_dependency",
+)
+
+
+def _relative(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _serialise_sql(item, root: Path) -> dict:
+    return {
+        "classification": item.classification,
+        "risk": item.risk,
+        "path": _relative(item.path, root),
+        "line": item.line,
+        "reason": item.reason,
+        "ungrouped_items": list(item.ungrouped_items),
+        "summary": item.summary(),
+    }
+
+
+def _write_json(path: Path, payload) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+def collect(root: Path = DEFAULT_ROOT) -> dict:
+    root = root.resolve()
+
+    sql_candidates = audit_sql_strict.scan(root)
+    sql_counts = Counter(item.classification for item in sql_candidates)
+    sql_review = [
+        _serialise_sql(item, root)
+        for item in sql_candidates
+        if item.classification == "REVIEW"
+    ]
+
+    wx_findings = audit_wx_lifecycle.scan()
+    wx_counts = Counter(item["kind"] for item in wx_findings)
+    wx_high_risk = {
+        kind: wx_counts.get(kind, 0)
+        for kind in WX_HIGH_RISK
+    }
+
+    legacy_findings = audit_legacy_list_tools.scan(root)
+    legacy_counts = audit_legacy_list_tools.summarize(legacy_findings)
+    legacy_screens = audit_legacy_list_tools.screens(legacy_findings)
+
+    return {
+        "summary": {
+            "sql": {
+                "total": len(sql_candidates),
+                "REVIEW": sql_counts.get("REVIEW", 0),
+                "DEDUPE": sql_counts.get("DEDUPE", 0),
+                "SAFE": sql_counts.get("SAFE", 0),
+            },
+            "wx_lifecycle": {
+                "total": len(wx_findings),
+                "counts": dict(sorted(wx_counts.items())),
+                "high_risk": wx_high_risk,
+            },
+            "legacy_list_tools": {
+                "screens": len(legacy_screens),
+                "counts": legacy_counts,
+            },
+        },
+        "sql_review": sql_review,
+        "wx_findings": wx_findings,
+        "legacy_findings": legacy_findings,
+        "legacy_screens": legacy_screens,
+    }
+
+
+def write_reports(data: dict, output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _write_json(output_dir / "pre-rc-summary.json", data["summary"])
+    _write_json(
+        output_dir / "sql-strict-review.json",
+        {
+            "summary": data["summary"]["sql"],
+            "findings": data["sql_review"],
+        },
+    )
+    _write_json(
+        output_dir / "wx-lifecycle-audit.json",
+        {
+            "summary": data["summary"]["wx_lifecycle"],
+            "findings": data["wx_findings"],
+        },
+    )
+    _write_json(
+        output_dir / "legacy-list-tools-audit.json",
+        {
+            "summary": data["summary"]["legacy_list_tools"],
+            "screens": data["legacy_screens"],
+            "findings": data["legacy_findings"],
+        },
+    )
+
+
+def print_summary(data: dict, output_dir: Path) -> None:
+    summary = data["summary"]
+    sql = summary["sql"]
+    wx = summary["wx_lifecycle"]
+    legacy = summary["legacy_list_tools"]
+
+    print("Inventaires statiques pré-RC")
+    print("===========================")
+    print(
+        "SQL strict : {total} candidats — REVIEW={REVIEW}, DEDUPE={DEDUPE}, SAFE={SAFE}".format(
+            **sql
+        )
+    )
+    print("wxPython    : %d occurrences" % wx["total"])
+    for kind in WX_HIGH_RISK:
+        print("  %-40s %d" % (kind + ":", wx["high_risk"].get(kind, 0)))
+    print(
+        "Listes      : %d écran(s) métier encore raccordé(s) aux outils historiques"
+        % legacy["screens"]
+    )
+    print("Rapports    : %s" % output_dir)
+    print("")
+    print("Ces nombres sont des inventaires. Corriger uniquement après revue du risque concret.")
+
+
+def run(root: Path = DEFAULT_ROOT, output_dir: Path = DEFAULT_OUTPUT) -> dict:
+    data = collect(root)
+    write_reports(data, output_dir)
+    print_summary(data, output_dir)
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Regroupe les inventaires SQL/wx/listes à relire avant une RC"
+    )
+    parser.add_argument("--root", type=Path, default=DEFAULT_ROOT)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT)
+    args = parser.parse_args()
+
+    run(args.root, args.output_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_pre_rc.py
+++ b/scripts/audit_pre_rc.py
@@ -42,16 +42,30 @@ def _relative(path: Path, root: Path) -> str:
         return path.as_posix()
 
 
-def _serialise_sql(item, root: Path) -> dict:
+def _display_path(path: Path) -> str:
+    """Privilégie un chemin relatif au dépôt dans les rapports partageables."""
+    return _relative(path, ROOT)
+
+
+def _serialise_sql(item) -> dict:
     return {
         "classification": item.classification,
         "risk": item.risk,
-        "path": _relative(item.path, root),
+        "path": _display_path(item.path),
         "line": item.line,
         "reason": item.reason,
         "ungrouped_items": list(item.ungrouped_items),
         "summary": item.summary(),
     }
+
+
+def _normalise_legacy_findings(findings: list[dict]) -> list[dict]:
+    normalised = []
+    for item in findings:
+        current = dict(item)
+        current["path"] = _display_path(Path(str(current["path"])))
+        normalised.append(current)
+    return normalised
 
 
 def _write_json(path: Path, payload) -> None:
@@ -68,7 +82,7 @@ def collect(root: Path = DEFAULT_ROOT) -> dict:
     sql_candidates = audit_sql_strict.scan(root)
     sql_counts = Counter(item.classification for item in sql_candidates)
     sql_review = [
-        _serialise_sql(item, root)
+        _serialise_sql(item)
         for item in sql_candidates
         if item.classification == "REVIEW"
     ]
@@ -80,7 +94,9 @@ def collect(root: Path = DEFAULT_ROOT) -> dict:
         for kind in WX_HIGH_RISK
     }
 
-    legacy_findings = audit_legacy_list_tools.scan(root)
+    legacy_findings = _normalise_legacy_findings(
+        audit_legacy_list_tools.scan(root)
+    )
     legacy_counts = audit_legacy_list_tools.summarize(legacy_findings)
     legacy_screens = audit_legacy_list_tools.screens(legacy_findings)
 

--- a/tests/test_audit_pre_rc.py
+++ b/tests/test_audit_pre_rc.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from scripts import audit_pre_rc
+
+
+class AuditPreRcTests(unittest.TestCase):
+    def test_collect_and_write_reports_keep_inventories_separate(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "noethys"
+            root.mkdir()
+            output = Path(tmp) / "reports"
+
+            sql_items = [
+                SimpleNamespace(
+                    classification="REVIEW",
+                    risk="HIGH",
+                    path=root / "Ol" / "OL_Test.py",
+                    line=12,
+                    reason="revue",
+                    ungrouped_items=["libelle"],
+                    summary=lambda: "SELECT libelle FROM test GROUP BY id",
+                ),
+                SimpleNamespace(
+                    classification="SAFE",
+                    risk="SAFE",
+                    path=root / "Ol" / "OL_Safe.py",
+                    line=8,
+                    reason="ok",
+                    ungrouped_items=[],
+                    summary=lambda: "SELECT id, COUNT(*) FROM test GROUP BY id",
+                ),
+            ]
+            wx_items = [
+                {
+                    "kind": "constructor_callback_before_dependency",
+                    "file": "noethys/Ctrl/CTRL_Test.py",
+                    "line": 10,
+                },
+                {
+                    "kind": "visual_parent_business_coupling",
+                    "file": "noethys/Ctrl/CTRL_Test.py",
+                    "line": 20,
+                },
+            ]
+            legacy_items = [
+                {
+                    "code": "ctrl_outils_historique",
+                    "path": "noethys/Ol/OL_Test.py",
+                    "line": 3,
+                    "text": "CTRL_ObjectListView.CTRL_Outils",
+                }
+            ]
+
+            with mock.patch.object(audit_pre_rc.audit_sql_strict, "scan", return_value=sql_items), \
+                    mock.patch.object(audit_pre_rc.audit_wx_lifecycle, "scan", return_value=wx_items), \
+                    mock.patch.object(audit_pre_rc.audit_legacy_list_tools, "scan", return_value=legacy_items):
+                data = audit_pre_rc.run(root, output)
+
+            self.assertEqual(data["summary"]["sql"]["REVIEW"], 1)
+            self.assertEqual(data["summary"]["sql"]["SAFE"], 1)
+            self.assertEqual(
+                data["summary"]["wx_lifecycle"]["high_risk"][
+                    "constructor_callback_before_dependency"
+                ],
+                1,
+            )
+            self.assertEqual(data["summary"]["legacy_list_tools"]["screens"], 1)
+
+            summary = json.loads((output / "pre-rc-summary.json").read_text(encoding="utf-8"))
+            sql_report = json.loads((output / "sql-strict-review.json").read_text(encoding="utf-8"))
+            wx_report = json.loads((output / "wx-lifecycle-audit.json").read_text(encoding="utf-8"))
+            legacy_report = json.loads((output / "legacy-list-tools-audit.json").read_text(encoding="utf-8"))
+
+            self.assertEqual(summary["sql"]["REVIEW"], 1)
+            self.assertEqual(len(sql_report["findings"]), 1)
+            self.assertEqual(len(wx_report["findings"]), 2)
+            self.assertEqual(legacy_report["screens"], ["noethys/Ol/OL_Test.py"])
+
+    def test_high_risk_wx_categories_are_explicit_even_when_zero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "noethys"
+            root.mkdir()
+
+            with mock.patch.object(audit_pre_rc.audit_sql_strict, "scan", return_value=[]), \
+                    mock.patch.object(audit_pre_rc.audit_wx_lifecycle, "scan", return_value=[]), \
+                    mock.patch.object(audit_pre_rc.audit_legacy_list_tools, "scan", return_value=[]):
+                data = audit_pre_rc.collect(root)
+
+            self.assertEqual(
+                data["summary"]["wx_lifecycle"]["high_risk"],
+                {
+                    "constructor_parent_callback": 0,
+                    "constructor_callback_before_dependency": 0,
+                },
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Objet

Regrouper en une seule commande les trois inventaires que le cockpit #19 demande de relire avant de figer un SHA RC : SQL strict, cycle de vie wxPython et raccords aux anciens outils de listes.

## Changements

- ajoute `scripts/audit_pre_rc.py` ;
- produit un résumé unique et trois rapports JSON détaillés sous `tmp/pre-rc-audits/` ;
- garde SQL et dette de listes informatifs : une occurrence n'est pas assimilée à un bug ;
- met explicitement en évidence les deux catégories wxPython structurelles les plus fortes : `constructor_parent_callback` et `constructor_callback_before_dependency` ;
- ajoute des tests unitaires de l'agrégateur sans scanner tout le dépôt dans le test.

## Intention

Pas de changement runtime, base, schéma ou UI. Cette PR réduit la procédure pré-RC de trois commandes/inventaires séparés à une commande reproductible :

```bash
python scripts/audit_pre_rc.py
```

L'étape suivante, après CI verte, sera de raccorder cette commande au mode manuel `complete` de la CI et d'aligner #19 sur ce point, sans rendre les dettes historiques massives bloquantes.