### PR TITLE
Docs : aligner le suivi après consolidation pré-RC

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Ce dépôt est le fork `fr4nck/Noethys`, consacré à la **modernisation progres
 
 Le projet d'origine et sa documentation fonctionnelle restent les références historiques pour Noethys. Ce fork ne cherche pas à effacer cette origine ni à imposer une réécriture ou un basculement vers NoethysWeb.
 
-## État du projet — 22 août 2026
+## État du projet — 24 août 2026
 
 Le chantier a dépassé la seule remise à niveau Python/wxPython. Il comporte maintenant deux axes complémentaires.
 
@@ -25,11 +25,12 @@ Les principales portes automatisées d'une première Release Candidate conservat
 - portable Windows PyInstaller `onedir` réellement exécuté en CI ;
 - mode historique `Portable/` qualifié ;
 - préflight lecture seule des bases existantes ;
+- inventaires statiques pré-RC SQL/wx/listes regroupés par `scripts/audit_pre_rc.py` ;
 - sas RC manuel protégé.
 
-La publication d'une RC validée reste volontairement bloquée jusqu'à une **recette humaine sur une copie d'une base réellement utilisée** et une validation visuelle/métier Windows du SHA candidat.
+La publication d'une RC validée reste volontairement bloquée jusqu'à une **recette humaine sur une copie d'une base réellement utilisée** et une validation visuelle/métier Windows du SHA candidat. Le suivi opérationnel de ce chemin critique est centralisé dans l'issue #19.
 
-### 2. Modernisation métier et UI en cours
+### 2. Modernisation métier et UI
 
 Le fork porte également désormais :
 
@@ -40,8 +41,10 @@ Le fork porte également désormais :
 - commandes de repas par points de livraison ;
 - chantier de rapports métier fiables et rapports d'activité ;
 - architecture tiers / conventions / mises à disposition / EPS ;
-- portail Connecthys avec contenus dynamiques, RSS/Atom et barèmes Noethys en cours de développement ;
-- expérimentation d'un registre minimal d'extensions optionnelles.
+- chantier Connecthys suivi de façon consolidée dans l'issue #62 ;
+- piste d'extensions optionnelles conservée comme architecture dormante, à rouvrir seulement lorsqu'un usage concret la justifie.
+
+Le socle UI transverse Repens est considéré comme consolidé : les travaux d'interface suivants partent d'un défaut concret de recette ou d'un besoin métier, pas d'un restylage générique.
 
 ## Principes du fork
 

--- a/docs/NOE-BACKLOG.md
+++ b/docs/NOE-BACKLOG.md
@@ -19,6 +19,7 @@ Pour éviter de disperser à nouveau le chantier, le suivi courant se lit désor
 Le **cockpit pré-RC est l'issue #19 (Noe-042)**. Elle rassemble les dernières étapes qui exigent encore une action concrète avant publication :
 
 - choisir le SHA candidat sur `master` ;
+- relancer les inventaires statiques consolidés sur ce SHA ;
 - lancer la qualification complète du même SHA ;
 - exécuter le préflight sur une copie de base réellement utilisée ;
 - effectuer la recette métier Noe-030 ;
@@ -29,7 +30,13 @@ Le **cockpit pré-RC est l'issue #19 (Noe-042)**. Elle rassemble les dernières 
 
 Les lots techniques historiques **#5 (Noe-002)**, **#6 (Noe-003)**, **#7 (Noe-004)** et **#14 (Noe-030)** sont clos comme lots d'implémentation/outillage. Leurs opérations de qualification sur copie réelle sont désormais suivies dans **#19**. **#40 (Noe-005)** reste une dette SQL progressive et non un blocage générique de RC.
 
-Avant de figer un SHA candidat, les inventaires statiques doivent être relus sur le `master` courant (`audit_sql_strict.py`, `audit_wx_lifecycle.py`, `audit_legacy_list_tools.py`) afin de ne pas baser une décision sur des chiffres anciens. Une occurrence d'audit n'est corrigée que si sa sémantique ou son risque concret est établi.
+Avant de figer un SHA candidat, lancer :
+
+```bash
+python scripts/audit_pre_rc.py
+```
+
+Cette commande, ajoutée via PR #81, regroupe les inventaires SQL strict, cycle de vie/parentage wxPython et anciens outils de listes, avec rapports sous `tmp/pre-rc-audits/`. Une occurrence d'audit n'est corrigée que si sa sémantique ou son risque concret est établi.
 
 ### 2. Chantiers métier après / à côté de la RC
 
@@ -37,8 +44,9 @@ Ils restent suivis par leurs issues, sans PR de travail ancienne laissée ouvert
 
 - **Noe-060 / 061 — reporting et pilotage** : #51, #54, #55, #56, #57, #58, #59 ;
 - **Noe-062 — conventions et mises à disposition** : #60 ;
-- **Noe-063 — portail Connecthys** : suivi consolidé dans #62 ;
-- **extensions optionnelles** : #80.
+- **Noe-063 — portail Connecthys** : suivi consolidé dans #62.
+
+La piste **extensions optionnelles** n'est plus un chantier actif : l'issue #80 est close comme `not planned` tant qu'aucun premier consommateur concret ne justifie de la rouvrir.
 
 Les anciennes PR de ces chantiers ont été fermées sans fusion lorsqu'elles étaient trop éloignées du `master`. Elles restent des références historiques de conception ; toute reprise doit repartir du `master` courant.
 
@@ -226,13 +234,13 @@ Règles :
 - pas d'identifiant famille exposé en clair comme pseudo-personnalisation ;
 - aucune migration destructive.
 
-## Extensions optionnelles — piste d'architecture
+## Extensions optionnelles — piste dormante
 
-L'ancienne PR #64 a exploré un registre minimal d'extensions, sans chargement automatique et sans modification du comportement historique. Elle a été fermée car sa branche était devenue trop en retard sur `master`.
+L'ancienne PR #64 a exploré un registre minimal d'extensions, sans chargement automatique et sans modification du comportement historique. Elle reste une référence de conception, pas du code livré.
 
-Le besoin futur est désormais conservé dans **l'issue #80**. Une reprise ne doit avoir lieu que lorsqu'un premier usage concret le justifie et doit repartir du `master` courant.
+L'issue #80 est désormais **close comme `not planned`**. Le sujet ne doit être rouvert que lorsqu'un premier usage concret le justifie ; toute reprise repartira alors du `master` courant.
 
-Usages envisagés : fournisseurs de communication, exports/reporting et connecteurs externes.
+Usages envisagés si le besoin réapparaît : fournisseurs de communication, exports/reporting et connecteurs externes.
 
 ## CI — boucle rapide et qualification lourde
 
@@ -245,15 +253,16 @@ La consolidation CI a été fusionnée via PR #70.
 - `workflow_dispatch` mode `complete` : recette synthétique, smokes Windows/macOS/Linux et packaging ;
 - `windows-package.yml` est réutilisable ;
 - l'ancien workflow UI séparé a été supprimé ;
-- les diagnostics indépendants sont collectés avant le verdict final lorsque possible.
+- les diagnostics indépendants sont collectés avant le verdict final lorsque possible ;
+- `scripts/audit_pre_rc.py`, fusionné via #81, fournit l'inventaire consolidé à relire avant le gel d'un SHA candidat.
 
 Le comportement réel des workflows présents sur `master` reste la référence exécutable.
 
 ## Situation pré-RC
 
-Le verrou pré-RC reste unique : **validation du SHA candidat sur une copie de base réellement utilisée puis recette métier/visuelle Windows**.
+Le verrou pré-RC reste unique : **validation du SHA candidat sur une copie de base réellement utilisée puis recette métier/visuelle Windows**, suivie dans #19.
 
-Noe-005, Noe-060, Noe-061, Noe-062, Noe-063 et l'issue #80 sont des chantiers parallèles ou post-socle ; ils ne doivent pas être confondus avec le minimum technique historiquement requis pour fabriquer la première RC. En revanche, tout code déjà fusionné dans `master` au moment du gel RC fait naturellement partie du SHA à qualifier.
+Noe-005, Noe-060, Noe-061, Noe-062 et Noe-063 sont des chantiers parallèles ou post-socle ; ils ne doivent pas être confondus avec le minimum technique historiquement requis pour fabriquer la première RC. La piste extensions/#80 est dormante et n'appartient plus au backlog actif. En revanche, tout code déjà fusionné dans `master` au moment du gel RC fait naturellement partie du SHA à qualifier.
 
 ## Règle de suivi
 

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -57,10 +57,11 @@ Références principales :
 - `docs/DEVELOPMENT.md` ;
 - `docs/CI-WINDOWS-AUDIT.md` ;
 - `docs/RC-CHECKLIST.md` ;
-- Noe-030 / issue #14 : recette sur copie de base existante ;
-- Noe-042 / issue #19 : sas de Release Candidate ;
-- Noe-005 / issue #40 : reliquat SQL strict ;
-- Noe-004 / issue #7 : mesures/index base de données.
+- `docs/NOE-030-RECETTE-BASE-EXISTANTE.md` — procédure de recette sur copie réelle ;
+- Noe-042 / issue #19 — **cockpit unique pré-RC** ;
+- Noe-005 / issue #40 — reliquat SQL strict.
+
+Les anciens lots Noe-002/#5, Noe-003/#6, Noe-004/#7 et Noe-030/#14 sont clos comme lots d’implémentation/outillage. Leurs opérations de validation réelle sont absorbées par le cockpit #19.
 
 État courant de la CI :
 
@@ -69,7 +70,8 @@ Références principales :
 - lancement manuel `complete` : recette synthétique, smokes Windows/macOS/Linux et packaging Windows ;
 - `windows-package.yml` est réutilisable ;
 - les audits UI font partie de la validation commune ;
-- les diagnostics indépendants sont collectés avant le verdict final lorsque possible.
+- les diagnostics indépendants sont collectés avant le verdict final lorsque possible ;
+- `scripts/audit_pre_rc.py` regroupe les inventaires SQL strict, cycle de vie wxPython et anciens outils de listes avant gel d’un SHA candidat.
 
 Règles durables :
 
@@ -209,11 +211,11 @@ L’ancienne PR #61 a été fermée sans fusion car sa branche était devenue tr
 
 ## 12. Portail Connecthys et contenus dynamiques
 
-Références :
+Référence opérationnelle unique :
 
-- #62 — contenus dynamiques et source unique ;
-- #65 — RSS/Atom natif ;
-- #67 — barèmes Noethys dans le portail.
+- #62 — contenus dynamiques, RSS/Atom, barèmes Noethys et source unique.
+
+Les anciennes sous-issues #65 (RSS/Atom) et #67 (barèmes) sont closes après consolidation de leurs exigences dans #62.
 
 Principes :
 
@@ -223,13 +225,13 @@ Principes :
 - afficher un barème applicable plutôt qu’un faux « prix personnel » lorsque la consommation réelle est nécessaire au calcul ;
 - les intégrations web doivent être une vue sécurisée des données, pas un accès direct à la base locale.
 
-Les anciennes PR #63/#66/#68/#69/#71/#72 ont été fermées sans fusion après inspection. Elles restent des références historiques ; les besoins continuent d’être suivis dans les issues et toute reprise repart du `master` courant.
+Les anciennes PR #63/#66/#68/#69/#71/#72 ont été fermées sans fusion après inspection. Elles restent des références historiques ; toute reprise repart du `master` courant.
 
 ## 13. Extensions optionnelles
 
-Le besoin d’un registre d’extensions opt-in est conservé dans **l’issue #80**.
+Le besoin d’un registre d’extensions opt-in reste une **piste dormante**, pas un chantier actif. L’issue #80 est close comme `not planned` tant qu’aucun premier consommateur concret ne justifie de rouvrir le sujet.
 
-La règle est de ne pas construire une architecture générique sans consommateur réel : le socle doit être repris uniquement lorsqu’un premier usage concret le justifie, sans chargement arbitraire, sans dépendance Internet obligatoire et sans migration implicite.
+Si un besoin réel apparaît, conserver ces règles : pas de chargement arbitraire, pas de dépendance Internet obligatoire et pas de migration implicite.
 
 L’ancienne PR #64 a été fermée et reste une référence historique de conception.
 
@@ -261,8 +263,10 @@ Les points qui étaient encore particulièrement dépendants des échanges ont d
 - filtrage des journées des commandes de repas ;
 - frontières Noethys / Teamworks / PMSL-Équipe / Connecthys ;
 - consolidation CI rapide/lourde ;
+- agrégation des inventaires pré-RC via `scripts/audit_pre_rc.py` ;
 - ligne d’arrivée du chantier UI transverse ;
-- politique de fermeture/reconstruction des branches de chantier devenues obsolètes.
+- politique de fermeture/reconstruction des branches de chantier devenues obsolètes ;
+- regroupement du suivi pré-RC dans #19 et du suivi portail dans #62.
 
 À partir de ce point, ces décisions ne doivent plus dépendre de la conservation d’un chat.
 

--- a/docs/RC-CHECKLIST.md
+++ b/docs/RC-CHECKLIST.md
@@ -8,13 +8,15 @@ Cette checklist sépare les garanties automatisées des vérifications qui néce
 
 ## Lecture rapide : un seul chemin critique
 
-Le suivi pré-RC est centralisé dans **l'issue #19 (Noe-042)**. Les anciens lots SQL déjà implémentés **#5 / Noe-002** et **#6 / Noe-003** sont clos ; leurs vérifications réelles sont intégrées au parcours Noe-030.
+Le suivi pré-RC est centralisé dans **l'issue #19 (Noe-042)**. Les anciens lots techniques **#5 / Noe-002**, **#6 / Noe-003**, **#7 / Noe-004** et **#14 / Noe-030** sont clos comme lots d'implémentation/outillage ; leurs vérifications réelles sont intégrées au cockpit #19.
 
-Avant de figer le SHA candidat, relire également les inventaires statiques sur le `master` courant :
+Avant de figer le SHA candidat, relire les inventaires statiques sur le `master` courant avec une seule commande :
 
-- `python scripts/audit_sql_strict.py --root noethys --format text --only review` ;
-- `python scripts/audit_wx_lifecycle.py` ;
-- `python scripts/audit_legacy_list_tools.py --root noethys`.
+```bash
+python scripts/audit_pre_rc.py
+```
+
+Elle regroupe l'audit SQL strict, l'audit du cycle de vie/parentage wxPython et l'inventaire des anciens outils de listes. Les rapports sont écrits dans `tmp/pre-rc-audits/`.
 
 Ces audits servent à **localiser** les zones à examiner. Ils ne doivent jamais déclencher une correction mécanique sans cause démontrée.
 
@@ -37,24 +39,26 @@ Ces audits servent à **localiser** les zones à examiner. Ils ne doivent jamais
 - smoke tests représentatifs Windows, macOS et Linux/GTK3 ;
 - tests de contrat UI/DB ajoutés au fil des corrections lorsqu'ils sont automatisables ;
 - socle transverse Repens des listes/ObjectListView, grilles, outils de liste, navigation et états vides ;
-- CI rapide unifiée sur PR/push, qualification multi-OS et packaging réservés au mode manuel `complete`.
+- CI rapide unifiée sur PR/push, qualification multi-OS et packaging réservés au mode manuel `complete` ;
+- agrégateur d'inventaires pré-RC fusionné via PR #81.
 
 ## Avant de déclarer une RC validée
 
 1. choisir un SHA candidat sur `master` ;
-2. lancer `CI Noethys` en mode `complete` pour ce SHA ;
-3. utiliser l'artefact construit depuis **ce même SHA** ;
-4. vérifier `BUILD-INFO.txt` ;
-5. conserver une sauvegarde indépendante et une copie de recette ;
-6. exécuter `scripts/rc_db_preflight.py` sur la copie avant ouverture ;
-7. lancer `Noethys.exe` manuellement ;
-8. vérifier l'accueil et l'absence de ressource/module manquant ;
-9. exécuter la recette métier complète ;
-10. effectuer la recette visuelle Windows ;
-11. fermer/réouvrir l'application ;
-12. exécuter le contrôle final de schéma/empreinte ;
-13. corriger tout défaut bloquant puis recommencer sur un nouvel artefact si le SHA change ;
-14. seulement ensuite déclencher le workflow `Release Candidate` et relire la release brouillon.
+2. exécuter `python scripts/audit_pre_rc.py` et relire les rapports ;
+3. lancer `CI Noethys` en mode `complete` pour ce SHA ;
+4. utiliser l'artefact construit depuis **ce même SHA** ;
+5. vérifier `BUILD-INFO.txt` ;
+6. conserver une sauvegarde indépendante et une copie de recette ;
+7. exécuter `scripts/rc_db_preflight.py` sur la copie avant ouverture ;
+8. lancer `Noethys.exe` manuellement ;
+9. vérifier l'accueil et l'absence de ressource/module manquant ;
+10. exécuter la recette métier complète ;
+11. effectuer la recette visuelle Windows ;
+12. fermer/réouvrir l'application ;
+13. exécuter le contrôle final de schéma/empreinte ;
+14. corriger tout défaut bloquant puis recommencer sur un nouvel artefact si le SHA change ;
+15. seulement ensuite déclencher le workflow `Release Candidate` et relire la release brouillon.
 
 ## Recette métier minimale historique
 
@@ -158,8 +162,9 @@ Les chantiers suivants restent suivis, mais ne bloquent pas la première RC tant
 - **Noe-005 / #40** — dette SQL progressive ;
 - **Noe-060 / 061** — #51, #54, #55, #56, #57, #58, #59 ;
 - **Noe-062** — #60 ;
-- **Noe-063** — #62, #65, #67 ;
-- **extensions optionnelles** — #80.
+- **Noe-063** — #62.
+
+Les sous-issues portail #65 et #67 sont closes après consolidation dans #62. L'issue #80 « extensions optionnelles » est close comme **non planifiée** tant qu'aucun premier consommateur concret ne justifie de rouvrir ce chantier.
 
 Les anciennes PR de ces chantiers sont des références historiques de conception. Toute reprise doit repartir du `master` courant.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -41,21 +41,26 @@ La modernisation technique nécessaire à une première Release Candidate conser
 - portable Windows PyInstaller construit, extrait et réellement exécuté en qualification ;
 - mode `Portable/` isolant configuration et données qualifié ;
 - préflight Noe-002/003/004/030 regroupé en une seule commande ;
+- inventaires statiques SQL/wx/listes regroupés via `scripts/audit_pre_rc.py` ;
 - sas RC manuel protégé : aucune RC ne peut être fabriquée sans confirmation explicite de la recette réelle et la release reste en brouillon ;
 - CI consolidée : boucle rapide unique sur PR/push, qualification lourde multi-OS et packaging uniquement en lancement manuel `complete`.
 
 ### Verrou restant avant une RC validée
 
-Il ne reste pas de chantier technique caché obligatoire. La validation reste volontairement bloquée par l'exploitation réelle :
+Il ne reste pas de chantier technique caché obligatoire. Le **seul suivi opérationnel pré-RC est l'issue #19**. La validation reste volontairement bloquée par l'exploitation réelle :
 
-1. exécuter `scripts/rc_db_preflight.py` sur une **copie** d'une base Noethys réellement utilisée ;
-2. effectuer le parcours métier de `NOE-030-RECETTE-BASE-EXISTANTE.md` ;
-3. valider visuellement l'interface Windows selon `CI-WINDOWS-AUDIT.md` ;
-4. corriger uniquement les anomalies réellement observées ;
-5. déclencher le workflow `Release Candidate` depuis `master` ;
-6. relire la release GitHub créée en brouillon avant publication.
+1. exécuter `python scripts/audit_pre_rc.py` sur le `master` candidat et relire les inventaires ;
+2. lancer la CI en mode manuel `complete` sur le même SHA ;
+3. exécuter `scripts/rc_db_preflight.py` sur une **copie** d'une base Noethys réellement utilisée ;
+4. effectuer le parcours métier de `NOE-030-RECETTE-BASE-EXISTANTE.md` ;
+5. valider visuellement l'interface Windows selon `CI-WINDOWS-AUDIT.md` ;
+6. corriger uniquement les anomalies réellement observées ;
+7. déclencher le workflow `Release Candidate` depuis `master` ;
+8. relire la release GitHub créée en brouillon avant publication.
 
 Depuis la préparation initiale de la RC, plusieurs correctifs et fonctions ont été intégrés au fork. La recette finale doit donc porter sur **le SHA candidat réellement publié**, pas sur un ancien artefact déjà qualifié.
+
+Les anciens lots #5/Noe-002, #6/Noe-003, #7/Noe-004 et #14/Noe-030 sont clos comme lots d'implémentation/outillage. Leurs opérations de validation réelle sont absorbées par le cockpit #19.
 
 ---
 
@@ -220,7 +225,7 @@ Référence : [`ARCHITECTURE-TIERS-PRESTATIONS-PLANNING.md`](ARCHITECTURE-TIERS-
 
 Objectif : faire du portail une vue de données et contenus déjà maintenus ailleurs, sans double saisie et sans exposer directement la base locale.
 
-Lots suivis :
+Lots conservés dans **l'issue unique #62** :
 
 - contenu externe compatible avec le Connecthys hébergé ;
 - RSS / Atom natif avec cache sûr ;
@@ -236,15 +241,15 @@ Principes :
 - aucune migration destructive ;
 - compatibilité avec un Connecthys hébergé non modifié pour les premiers lots.
 
-Les anciennes PR #63/#66/#68/#69/#71/#72 ont été fermées sans fusion après inspection. Elles restent des références historiques de conception/diff. Les besoins sont conservés dans les issues #62, #65 et #67 ; toute reprise doit reconstruire un lot propre depuis le `master` courant.
+Les anciennes PR #63/#66/#68/#69/#71/#72 ont été fermées sans fusion après inspection. Elles restent des références historiques de conception/diff. Les anciennes sous-issues #65 et #67 ont été closes après consolidation de leurs exigences dans #62. Toute reprise reconstruit un lot propre depuis le `master` courant.
 
 ---
 
-## Phase 8 — Extensions et intégrations optionnelles
+## Phase 8 — Extensions optionnelles : piste dormante
 
-Le besoin d'un registre minimal d'extensions reste une piste d'architecture, suivie par **l'issue #80**.
+Le registre minimal d'extensions reste une **piste d'architecture**, pas un chantier actif. L'issue #80 a été close comme `not planned` tant qu'aucun consommateur concret ne justifie de rouvrir le sujet.
 
-Contraintes :
+Contraintes si le besoin réapparaît :
 
 - opt-in ;
 - aucun chargement arbitraire automatique ;
@@ -262,13 +267,13 @@ L'ancienne PR #64 a été fermée et sert uniquement de référence historique.
 
 Les issues GitHub constituent la source de vérité pour le travail restant. Au 24 août 2026, les grands groupes encore ouverts sont :
 
-- validation réelle pré-RC : Noe-004 / Noe-030 / Noe-042 ;
-- dette SQL progressive : Noe-005 ;
-- reporting : Noe-060 et sous-lots restants ;
-- rapport annuel : Noe-061 ;
-- conventions / mises à disposition : Noe-062 ;
-- portail Connecthys : Noe-063 et sous-lots ;
-- extensions optionnelles : issue #80, uniquement si un cas d'usage concret apparaît.
+- **pré-RC : #19 / Noe-042 uniquement** ;
+- dette SQL progressive : #40 / Noe-005 ;
+- reporting et pilotage : #51, #54, #55, #56, #57, #58, #59 ;
+- conventions / mises à disposition : #60 / Noe-062 ;
+- portail Connecthys : #62 / Noe-063.
+
+Les issues #5, #6, #7, #14, #53, #65, #67 et #80 sont closes. Leur contenu utile est soit intégré au code, soit absorbé dans un suivi parent, soit conservé comme référence non planifiée.
 
 Le détail et les numéros d'issues sont maintenus dans [`NOE-BACKLOG.md`](NOE-BACKLOG.md).
 


### PR DESCRIPTION
## Objet

Terminer le rassemblement du suivi après la consolidation pré-RC et la fusion de #81.

## Changements

- `README.md` reflète l'état du 24 août et distingue clairement socle intégré, chantiers actifs et piste extensions dormante ;
- `NOE-BACKLOG.md` utilise désormais `scripts/audit_pre_rc.py`, garde #19 comme seul chemin critique et retire #80 du backlog actif ;
- `RC-CHECKLIST.md` suit la même procédure unique et le même ensemble d'issues actives ;
- `ROADMAP.md` ne présente plus #7/#14/#65/#67/#80 comme travaux opérationnels ouverts ;
- `PROJECT_STATE.md` fixe #19 comme cockpit pré-RC et #62 comme suivi Connecthys unique.

## Portée

Documentation uniquement. Aucun changement runtime, workflow, schéma, dépendance ou comportement métier.

La source de vérité opérationnelle reste : code/tests pour le livré, issues pour le travail restant, documentation pour les décisions et procédures.