### PR TITLE
CI : archiver les inventaires pré-RC en qualification complète

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
           python -m py_compile scripts/build_synthetic_recette_db.py || status=1
           python -m py_compile scripts/recette_existing_db_readonly.py || status=1
           python -m py_compile scripts/rc_db_preflight.py || status=1
+          python -m py_compile scripts/audit_pre_rc.py || status=1
           exit "$status"
 
       - name: Audit runtime bloquant
@@ -296,6 +297,18 @@ jobs:
           python scripts/audit_csv_boundaries.py
           python scripts/audit_utf8_boundaries.py
           python scripts/audit_dependency_usage.py
+
+      - name: Consolider les inventaires statiques pré-RC
+        run: python scripts/audit_pre_rc.py --output-dir tmp/pre-rc-audits
+
+      - name: Conserver les inventaires pré-RC
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: diagnostics-pre-rc
+          path: tmp/pre-rc-audits/*.json
+          if-no-files-found: error
+          retention-days: 14
 
   windows-smoke:
     name: Smoke test Windows


### PR DESCRIPTION
## Objet

Raccorder l'agrégateur `scripts/audit_pre_rc.py` fusionné via #81 au mode manuel `complete` de la CI consolidée.

## Changements

- compile explicitement `audit_pre_rc.py` dans le fast gate ;
- en mode `workflow_dispatch` `complete`, exécute l'agrégateur après les inventaires de compatibilité ;
- archive les quatre rapports JSON sous l'artefact `diagnostics-pre-rc` pendant 14 jours.

## Doctrine

Les inventaires restent informatifs : cette PR ne transforme ni les `REVIEW` SQL ni les dettes wx/listes historiques en bloqueurs automatiques. La qualification complète conserve simplement une photographie reproductible du SHA candidat pour la revue #19.

Aucun changement runtime, métier, schéma ou packaging.