### PR TITLE
Factures : transmettre l’ID exact au règlement

### DIFF
--- a/noethys/Ctrl/CTRL_Numfacture.py
+++ b/noethys/Ctrl/CTRL_Numfacture.py
@@ -23,9 +23,10 @@ class CTRL(wx.SearchCtrl):
     sa toolbar parente : le shell reste propriétaire de son alignement.
     """
 
-    def __init__(self, parent, size=wx.DefaultSize, IDfamille=None):
+    def __init__(self, parent, size=wx.DefaultSize, IDfamille=None, controller=None):
         wx.SearchCtrl.__init__(self, parent, size=size, style=wx.TE_PROCESS_ENTER)
         self.parent = parent
+        self.controller = controller
         self.IDfamille = IDfamille
         self.IDutilisateurActif = None
         self.SetDescriptiveText(_(u"N° de facture"))
@@ -149,7 +150,7 @@ class CTRL(wx.SearchCtrl):
             return
 
         if self.IDfamille is not None:
-            self.GetGrandParent().ReglerFacture()
+            self.controller.ReglerFacture(IDfacture)
         else:
             from Dlg import DLG_Famille
             dlg = DLG_Famille.Dialog(self, IDfamille=IDfamille, AfficherMessagesOuverture=False)
@@ -194,7 +195,7 @@ class Dialog(wx.Dialog):
 
         self.label = wx.StaticText(self, -1, _(u"Saisissez le numéro de la facture à régler ou scannez directement son code-barres."))
         Style.appliquer_texte(self.label, role="body", role_texte="on_surface", role_fond="surface")
-        self.ctrl_mdp = CTRL(self, IDfamille=self.IDfamille)
+        self.ctrl_mdp = CTRL(self, IDfamille=self.IDfamille, controller=parent)
         self.bouton_annuler = CTRL_Bouton_image.CTRL(self, id=wx.ID_CANCEL, texte=_(u"Annuler"), iconeFluent="dismiss")
 
         self.bouton_annuler.SetToolTip(wx.ToolTip(_(u"Annuler")))

--- a/tests/test_numfacture_forwarding_contract.py
+++ b/tests/test_numfacture_forwarding_contract.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import ast
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "noethys" / "Ctrl" / "CTRL_Numfacture.py"
+
+
+def _method_source(text, tree, class_name, method_name):
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for child in node.body:
+                if isinstance(child, ast.FunctionDef) and child.name == method_name:
+                    return ast.get_source_segment(text, child) or ""
+    raise AssertionError("%s.%s introuvable" % (class_name, method_name))
+
+
+class NumfactureForwardingContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.text = SOURCE.read_text(encoding="utf-8")
+        cls.tree = ast.parse(cls.text)
+
+    def test_family_invoice_forwards_exact_invoice_id(self):
+        method = _method_source(self.text, self.tree, "CTRL", "ReglerFacture")
+        self.assertIn("self.controller.ReglerFacture(IDfacture)", method)
+        self.assertNotIn("self.GetGrandParent().ReglerFacture()", method)
+
+    def test_dialog_wires_family_controller_explicitly(self):
+        init = _method_source(self.text, self.tree, "Dialog", "__init__")
+        self.assertIn("CTRL(self, IDfamille=self.IDfamille, controller=parent)", init)
+
+    def test_non_family_path_also_forwards_exact_invoice_id(self):
+        method = _method_source(self.text, self.tree, "CTRL", "ReglerFacture")
+        self.assertIn("dlg.ReglerFacture(IDfacture)", method)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Défaut identifié

Dans la recherche/scanneur de numéro de facture ouvert depuis une fiche famille, `CTRL_Numfacture` retrouvait bien l'`IDfacture`, puis appelait `ReglerFacture()` sur la fiche familiale **sans lui transmettre cet ID**. Le chemin hors fiche famille transmettait, lui, correctement `IDfacture`.

Conséquence possible : après avoir saisi ou scanné une facture précise depuis une famille, l'écran de règlement pouvait être ouvert sans la facture effectivement recherchée.

## Correction

- le contrôle reçoit explicitement le contrôleur métier de la fiche famille ;
- le chemin famille appelle `controller.ReglerFacture(IDfacture)` ;
- suppression du `GetGrandParent()` fragile sur ce chemin ;
- le chemin hors famille reste inchangé et continue de transmettre le même `IDfacture` ;
- ajout d'un test de contrat pour empêcher la perte future de l'identifiant.

## Portée

Aucune requête SQL, donnée, ventilation ou règle de règlement n'est modifiée. Le correctif ne change que la transmission de l'identifiant déjà résolu.