### PR TITLE
Locations : sécuriser le cycle de vie de la demande

### DIFF
--- a/noethys/Dlg/DLG_Saisie_location_demande.py
+++ b/noethys/Dlg/DLG_Saisie_location_demande.py
@@ -620,7 +620,7 @@ class Dialog(wx.Dialog):
         self.ctrl_date_demande = CTRL_Saisie_date.Date2(self)
         self.ctrl_heure_demande = CTRL_Saisie_heure.Heure(self)
 
-        self.label_observations = wx.StaticText(self, -1, u"Notes :", style=wx.ALIGN_RIGHT)
+        self.label_observations = wx.StaticText(self, -1, _(u"Notes :"))
         self.ctrl_observations = wx.TextCtrl(self, -1, u"", style=wx.TE_MULTILINE)
 
         # Notebook

--- a/noethys/Dlg/DLG_Saisie_location_demande.py
+++ b/noethys/Dlg/DLG_Saisie_location_demande.py
@@ -141,9 +141,10 @@ class CTRL_Produits(wx.TextCtrl):
 
 
 class PAGE_Criteres(wx.Panel):
-    def __init__(self, parent, IDdemande=None):
+    def __init__(self, parent, IDdemande=None, controller=None):
         wx.Panel.__init__(self, parent, id=-1, style=wx.TAB_TRAVERSAL)
         self.parent = parent
+        self.controller = controller
         self.IDdemande = IDdemande
 
         self.label_categories = wx.StaticText(self, -1, _(u"Catégories :"))
@@ -258,8 +259,9 @@ class PAGE_Criteres(wx.Panel):
 
         # Recherche les produits disponibles à proposer
         dictPropositions = UTILS_Locations.GetPropositionsLocations(dictFiltresSelection=dictFiltres, dictDemandeSelection=dictDemande, uniquement_disponibles=False)
-        texte = self.GetGrandParent().ctrl_statut.GetPageByCode("attente").ctrl_propositions.SetDictPropositions(dictPropositions, IDdemande=self.IDdemande)
-        self.GetGrandParent().ctrl_statut.GetPageByCode("attente").label_propositions.SetLabel(texte)
+        page_attente = self.controller.ctrl_statut.GetPageByCode("attente")
+        texte = page_attente.ctrl_propositions.SetDictPropositions(dictPropositions, IDdemande=self.IDdemande)
+        page_attente.label_propositions.SetLabel(texte)
 
 
 
@@ -283,12 +285,12 @@ class PAGE_Questionnaire(wx.Panel):
 
 
 class Notebook(wx.Notebook):
-    def __init__(self, parent, IDdemande=None):
+    def __init__(self, parent, IDdemande=None, controller=None):
         wx.Notebook.__init__(self, parent, id=-1, style=wx.BK_DEFAULT)
         self.dictPages = {}
 
         self.listePages = [
-            ("criteres", _(u"Critères"), PAGE_Criteres(self, IDdemande=IDdemande)),
+            ("criteres", _(u"Critères"), PAGE_Criteres(self, IDdemande=IDdemande, controller=controller)),
             ("questionnaire", _(u"Questionnaire"), PAGE_Questionnaire(self, IDdemande=IDdemande)),
         ]
 
@@ -325,9 +327,10 @@ class Notebook(wx.Notebook):
 # ---------------------------------------------------------------------------------------------
 
 class PAGE_Statut_attente(wx.Panel):
-    def __init__(self, parent):
+    def __init__(self, parent, controller=None):
         wx.Panel.__init__(self, parent, id=-1, style=wx.TAB_TRAVERSAL)
         self.parent = parent
+        self.controller = controller
 
         # Propositions
         self.label_propositions = wx.StaticText(self, -1, _(u"Produits proposés :"))
@@ -373,7 +376,7 @@ class PAGE_Statut_attente(wx.Panel):
 
     def OnRadioProduits(self, event=None):
         self.ctrl_propositions.afficher_uniquement_disponibles = self.radio_produits_disponibles.GetValue()
-        self.GetGrandParent().notebook.GetPage("criteres").MAJListePropositions()
+        self.controller.notebook.GetPage("criteres").MAJListePropositions()
 
     def Validation(self):
         return True
@@ -387,7 +390,7 @@ class PAGE_Statut_attente(wx.Panel):
             return
 
         # Création d'une location
-        self.GetGrandParent().Attribution(IDproduit)
+        self.controller.Attribution(IDproduit)
 
 
 class PAGE_Statut_refusee(wx.Panel):
@@ -548,13 +551,13 @@ class PAGE_Statut_attribuee(wx.Panel):
 
 class CTRL_Statut(wx.Choicebook):
     """ Choicebook Statut """
-    def __init__(self, parent):
+    def __init__(self, parent, controller=None):
         wx.Choicebook.__init__(self, parent, id=-1)
         self.parent = parent
         self.SetToolTip(wx.ToolTip(_(u"Sélectionnez ici le statut de la demande")))
 
         self.listePanels = [
-            ("attente", _(u"En attente"), PAGE_Statut_attente(self)),
+            ("attente", _(u"En attente"), PAGE_Statut_attente(self, controller=controller)),
             ("refusee", _(u"Demande refusée"), PAGE_Statut_refusee(self)),
             #("attribuee", _(u"Demande satisfaite"), PAGE_Statut_attribuee(self)),
         ]
@@ -617,15 +620,15 @@ class Dialog(wx.Dialog):
         self.ctrl_date_demande = CTRL_Saisie_date.Date2(self)
         self.ctrl_heure_demande = CTRL_Saisie_heure.Heure(self)
 
-        self.label_observations = wx.StaticText(self, -1, _(u"Notes :"))
+        self.label_observations = wx.StaticText(self, -1, u"Notes :", style=wx.ALIGN_RIGHT)
         self.ctrl_observations = wx.TextCtrl(self, -1, u"", style=wx.TE_MULTILINE)
 
         # Notebook
-        self.notebook = Notebook(self, IDdemande=IDdemande)
+        self.notebook = Notebook(self, IDdemande=IDdemande, controller=self)
 
         # Statut
         self.staticbox_statut_staticbox = wx.StaticBox(self, -1, _(u"Statut"))
-        self.ctrl_statut = CTRL_Statut(self)
+        self.ctrl_statut = CTRL_Statut(self, controller=self)
         self.ctrl_statut.SetMinSize((50, 100))
 
         # Attribution
@@ -796,8 +799,9 @@ class Dialog(wx.Dialog):
 
             dlg = wx.SingleChoiceDialog(self, _(u"Sélectionnez la donnée qui vous intéresse :"), _(u"Sélection d'une donnée"), liste_labels, wx.CHOICEDLG_STYLE)
             if dlg.ShowModal() == wx.ID_OK:
+                selection = dlg.GetSelection()
                 dlg.Destroy()
-                donnees = liste_donnees[dlg.GetSelection()]
+                donnees = liste_donnees[selection]
                 if donnees[0] == "categories" :
                     IDcategorie = donnees[1]
                 if donnees[0] == "produits" :

--- a/tests/test_location_request_wx_lifecycle_contract.py
+++ b/tests/test_location_request_wx_lifecycle_contract.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import ast
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "noethys" / "Dlg" / "DLG_Saisie_location_demande.py"
+
+
+def _method_source(text, tree, class_name, method_name):
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for child in node.body:
+                if isinstance(child, ast.FunctionDef) and child.name == method_name:
+                    return ast.get_source_segment(text, child) or ""
+    raise AssertionError("%s.%s introuvable" % (class_name, method_name))
+
+
+class LocationRequestWxLifecycleContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.text = SOURCE.read_text(encoding="utf-8")
+        cls.tree = ast.parse(cls.text)
+
+    def test_nested_pages_use_explicit_business_controller(self):
+        self.assertNotIn("GetGrandParent()", self.text)
+        self.assertIn("PAGE_Criteres(self, IDdemande=IDdemande, controller=controller)", self.text)
+        self.assertIn("PAGE_Statut_attente(self, controller=controller)", self.text)
+        self.assertIn("Notebook(self, IDdemande=IDdemande, controller=self)", self.text)
+        self.assertIn("CTRL_Statut(self, controller=self)", self.text)
+
+    def test_distance_choice_is_read_before_dialog_is_destroyed(self):
+        method = _method_source(self.text, self.tree, "Dialog", "Mesurer_distance")
+        selection = method.index("selection = dlg.GetSelection()")
+        destroy = method.index("dlg.Destroy()", selection)
+        consume = method.index("liste_donnees[selection]", destroy)
+        self.assertLess(selection, destroy)
+        self.assertLess(destroy, consume)
+        self.assertNotIn("liste_donnees[dlg.GetSelection()]", method)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Défauts identifiés

L'inspection du dialogue de demande de location a révélé deux problèmes structurels concrets :

1. quatre callbacks métier remontaient l'arbre visuel via `GetGrandParent()` pour atteindre le dialogue ;
2. dans « Mesurer une distance », le `SingleChoiceDialog` était détruit **avant** l'appel à `GetSelection()`, ce qui peut accéder à un objet wx déjà détruit sous Phoenix.

## Correction

- `PAGE_Criteres` et `PAGE_Statut_attente` reçoivent explicitement le dialogue comme contrôleur métier ;
- `Notebook` et `CTRL_Statut` transmettent ce contrôleur sans changer le parent wx réel ;
- les quatre accès par ascendance visuelle disparaissent ;
- la sélection du `SingleChoiceDialog` est lue avant `Destroy()` ;
- tests de contrat sur ces deux invariants.

## Portée

Aucune règle de location, proposition, questionnaire, base ou attribution n'est modifiée. Le comportement métier reste identique ; le lot corrige uniquement le cycle de vie wxPython et un accès après destruction.