### PR TITLE
Audit wx : détecter les accès après Destroy

### DIFF
--- a/scripts/audit_wx_lifecycle.py
+++ b/scripts/audit_wx_lifecycle.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Audit statique des contrats de construction wxPython.
+"""Audit statique des contrats de construction et de cycle de vie wxPython.
 
 Objectif : repérer les contrôles qui confondent encore leur parent visuel wx
-avec un contrôleur métier, ainsi que les callbacks exécutés trop tôt pendant
-``__init__``. L'audit reste informatif pour les familles historiques larges,
-mais distingue désormais des signaux structurels plus précis avant de rendre
-une catégorie bloquante.
+avec un contrôleur métier, les callbacks exécutés trop tôt pendant ``__init__``
+et les accès directs à un objet wx local après son ``Destroy()``. L'audit reste
+informatif pour les familles historiques larges, mais distingue des signaux
+structurels précis avant de rendre une catégorie bloquante.
 """
 
 from __future__ import annotations
@@ -38,6 +38,7 @@ EARLY_SELF_CALLS = {
     "MAJ", "Actualise", "Actualiser", "Importation", "Refresh", "Update",
 }
 LAYOUT_MARKERS = {"__do_layout", "DoLayout", "Layout", "SetSizer", "SetSizerAndFit"}
+TERMINAL_STATEMENTS = (ast.Return, ast.Raise, ast.Break, ast.Continue)
 
 
 def _ui_file(path: Path) -> bool:
@@ -275,6 +276,145 @@ def _scan_constructor_order(path: Path, tree: ast.AST, lines: list[str]) -> list
     return findings
 
 
+def _target_key(node: ast.AST) -> str | None:
+    """Retourne une cible locale simple suivie par l'audit de destruction."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "self"
+    ):
+        return "self.%s" % node.attr
+    return None
+
+
+def _runtime_nodes(node: ast.AST):
+    """Parcourt ce qui s'exécute maintenant, sans descendre dans une définition."""
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)):
+            continue
+        yield child
+        yield from _runtime_nodes(child)
+
+
+def _loaded_targets(statement: ast.stmt) -> set[str]:
+    loaded: set[str] = set()
+    for node in _runtime_nodes(statement):
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
+            loaded.add(node.id)
+        elif isinstance(node, ast.Attribute) and isinstance(node.ctx, ast.Load):
+            key = _target_key(node)
+            if key:
+                loaded.add(key)
+    return loaded
+
+
+def _assigned_targets(statement: ast.stmt) -> set[str]:
+    assigned: set[str] = set()
+    for node in _runtime_nodes(statement):
+        if isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
+            assigned.add(node.id)
+        elif isinstance(node, ast.Attribute) and isinstance(node.ctx, (ast.Store, ast.Del)):
+            key = _target_key(node)
+            if key:
+                assigned.add(key)
+    return assigned
+
+
+def _direct_destroy_target(statement: ast.stmt) -> str | None:
+    """Reconnaît uniquement ``objet.Destroy()`` exécuté sans condition."""
+    if not isinstance(statement, ast.Expr) or not isinstance(statement.value, ast.Call):
+        return None
+    call = statement.value
+    if not isinstance(call.func, ast.Attribute) or call.func.attr != "Destroy":
+        return None
+    return _target_key(call.func.value)
+
+
+def _nested_statement_blocks(statement: ast.stmt):
+    """Renvoie les blocs exécutables internes, chacun analysé indépendamment."""
+    for attr in ("body", "orelse", "finalbody"):
+        block = getattr(statement, attr, None)
+        if isinstance(block, list) and block:
+            yield block
+    handlers = getattr(statement, "handlers", None)
+    if handlers:
+        for handler in handlers:
+            if handler.body:
+                yield handler.body
+    cases = getattr(statement, "cases", None)
+    if cases:
+        for case in cases:
+            if case.body:
+                yield case.body
+
+
+def _scan_destroy_block(
+    path: Path,
+    statements: list[ast.stmt],
+    lines: list[str],
+    class_name: str,
+    method_name: str,
+) -> list[dict]:
+    findings: list[dict] = []
+    rel = str(path.relative_to(ROOT)).replace("\\", "/")
+    destroyed: dict[str, int] = {}
+
+    for statement in statements:
+        # Un usage dans une instruction ultérieure au Destroy est risqué. On
+        # inspecte avant de considérer les réaffectations de cette instruction,
+        # afin de ne pas masquer ``dlg = transformer(dlg)``.
+        for target in sorted(_loaded_targets(statement).intersection(destroyed)):
+            findings.append({
+                "kind": "use_after_destroy",
+                "file": rel,
+                "class": class_name,
+                "method": method_name,
+                "line": statement.lineno,
+                "member": target,
+                "destroy_line": destroyed[target],
+                "snippet": _line(lines, statement.lineno),
+            })
+
+        # Les branches sont analysées dans leur propre ordre séquentiel. Un
+        # Destroy conditionnel ne contamine donc pas artificiellement le bloc
+        # parent.
+        for block in _nested_statement_blocks(statement):
+            findings.extend(
+                _scan_destroy_block(path, block, lines, class_name, method_name)
+            )
+
+        for target in _assigned_targets(statement):
+            destroyed.pop(target, None)
+
+        target = _direct_destroy_target(statement)
+        if target:
+            destroyed[target] = statement.lineno
+
+        # Rien situé après un terminal direct du bloc n'est atteignable depuis
+        # ce chemin ; inutile de propager l'état de destruction.
+        if isinstance(statement, TERMINAL_STATEMENTS):
+            break
+
+    return findings
+
+
+def _scan_use_after_destroy(path: Path, tree: ast.AST, lines: list[str]) -> list[dict]:
+    """Détecte le motif Phoenix ``Destroy()`` puis réutilisation du même objet."""
+    findings: list[dict] = []
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            findings.extend(_scan_destroy_block(path, node.body, lines, "", node.name))
+        elif isinstance(node, ast.ClassDef):
+            for method in node.body:
+                if isinstance(method, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    findings.extend(
+                        _scan_destroy_block(path, method.body, lines, node.name, method.name)
+                    )
+    return findings
+
+
 def _dedupe(findings: list[dict]) -> list[dict]:
     result: list[dict] = []
     seen: set[tuple] = set()
@@ -303,6 +443,7 @@ def scan() -> list[dict]:
         lines = text.splitlines()
         findings.extend(_scan_parent_coupling(path, tree, lines))
         findings.extend(_scan_constructor_order(path, tree, lines))
+        findings.extend(_scan_use_after_destroy(path, tree, lines))
     return _dedupe(findings)
 
 
@@ -320,6 +461,7 @@ def main() -> int:
         "constructor_callback_before_layout",
         "constructor_callback_before_dependency",
         "constructor_parent_callback",
+        "use_after_destroy",
     }
 
     print("Audit contrats wxPython")
@@ -338,6 +480,8 @@ def main() -> int:
         detail = ""
         if item.get("dependencies"):
             detail = " dépend de " + ", ".join(item["dependencies"])
+        if item.get("destroy_line"):
+            detail += " détruit ligne %s" % item["destroy_line"]
         print(
             "  {kind}  {file}:{line}  {class}.{method} -> {member}{detail}  {snippet}".format(
                 detail=detail, **item

--- a/scripts/audit_wx_lifecycle.py
+++ b/scripts/audit_wx_lifecycle.py
@@ -290,9 +290,15 @@ def _target_key(node: ast.AST) -> str | None:
 
 
 def _runtime_nodes(node: ast.AST):
-    """Parcourt ce qui s'exécute maintenant, sans descendre dans une définition."""
+    """Parcourt seulement l'expression exécutée par l'instruction courante.
+
+    Les sous-blocs ``if``/``try``/``for`` sont analysés séparément par
+    ``_scan_destroy_block``. Ne pas y descendre ici évite qu'une réutilisation
+    légitime du nom ``dlg`` dans une branche soit attribuée au ``Destroy()`` du
+    bloc extérieur.
+    """
     for child in ast.iter_child_nodes(node):
-        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)):
+        if isinstance(child, ast.stmt) or isinstance(child, ast.Lambda):
             continue
         yield child
         yield from _runtime_nodes(child)

--- a/tests/test_audit_wx_lifecycle.py
+++ b/tests/test_audit_wx_lifecycle.py
@@ -149,6 +149,34 @@ def ouvrir(ok):
         findings = audit._scan_use_after_destroy(self._path(), tree, source.splitlines())
         self.assertEqual(findings, [])
 
+    def test_reusing_same_variable_name_in_nested_branch_is_not_old_object_use(self):
+        source = '''
+def ouvrir(mode):
+    dlg = Fabrique()
+    dlg.Destroy()
+    if mode == "creation":
+        dlg = Fabrique()
+        dlg.ShowModal()
+        dlg.Destroy()
+'''
+        tree = ast.parse(source)
+        findings = audit._scan_use_after_destroy(self._path(), tree, source.splitlines())
+        self.assertEqual(findings, [])
+
+    def test_direct_use_in_if_condition_after_destroy_is_reported(self):
+        source = '''
+def ouvrir():
+    dlg = Fabrique()
+    dlg.Destroy()
+    if dlg.GetSelection() == 0:
+        return
+'''
+        tree = ast.parse(source)
+        findings = audit._scan_use_after_destroy(self._path(), tree, source.splitlines())
+        risky = [item for item in findings if item["kind"] == "use_after_destroy"]
+        self.assertEqual(len(risky), 1)
+        self.assertEqual(risky[0]["member"], "dlg")
+
     def test_self_attribute_used_after_destroy_is_reported(self):
         source = '''
 class Dialog(wx.Dialog):

--- a/tests/test_audit_wx_lifecycle.py
+++ b/tests/test_audit_wx_lifecycle.py
@@ -97,6 +97,71 @@ class Page(wx.Panel):
         self.assertEqual(len(ancestry), 1)
         self.assertEqual(ancestry[0]["member"], "ctrl_famille")
 
+    def test_local_object_used_after_destroy_is_reported(self):
+        source = '''
+class Dialog(wx.Dialog):
+    def OnChoice(self):
+        dlg = wx.SingleChoiceDialog(self, "x", "y", [])
+        if dlg.ShowModal() == wx.ID_OK:
+            dlg.Destroy()
+            selection = dlg.GetSelection()
+'''
+        tree = ast.parse(source)
+        findings = audit._scan_use_after_destroy(self._path(), tree, source.splitlines())
+        risky = [item for item in findings if item["kind"] == "use_after_destroy"]
+        self.assertEqual(len(risky), 1)
+        self.assertEqual(risky[0]["member"], "dlg")
+        self.assertEqual(risky[0]["destroy_line"], 6)
+
+    def test_return_after_destroy_does_not_create_false_positive(self):
+        source = '''
+def ouvrir():
+    dlg = Fabrique()
+    dlg.Destroy()
+    return
+    dlg.GetSelection()
+'''
+        tree = ast.parse(source)
+        findings = audit._scan_use_after_destroy(self._path(), tree, source.splitlines())
+        self.assertEqual(findings, [])
+
+    def test_reassignment_after_destroy_resets_tracking(self):
+        source = '''
+def ouvrir():
+    dlg = Fabrique()
+    dlg.Destroy()
+    dlg = Fabrique()
+    return dlg.GetSelection()
+'''
+        tree = ast.parse(source)
+        findings = audit._scan_use_after_destroy(self._path(), tree, source.splitlines())
+        self.assertEqual(findings, [])
+
+    def test_destroy_in_one_branch_does_not_poison_parent_block(self):
+        source = '''
+def ouvrir(ok):
+    dlg = Fabrique()
+    if ok:
+        dlg.Destroy()
+    return dlg.GetSelection()
+'''
+        tree = ast.parse(source)
+        findings = audit._scan_use_after_destroy(self._path(), tree, source.splitlines())
+        self.assertEqual(findings, [])
+
+    def test_self_attribute_used_after_destroy_is_reported(self):
+        source = '''
+class Dialog(wx.Dialog):
+    def fermer(self):
+        self.popup.Destroy()
+        self.popup.Layout()
+'''
+        tree = ast.parse(source)
+        findings = audit._scan_use_after_destroy(self._path(), tree, source.splitlines())
+        risky = [item for item in findings if item["kind"] == "use_after_destroy"]
+        self.assertEqual(len(risky), 1)
+        self.assertEqual(risky[0]["member"], "self.popup")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Objet

Étendre l'audit wxPython pour détecter un défaut de cycle de vie concret révélé lors de la correction des demandes de location : l'accès à un objet wx local après son `Destroy()`.

## Détection ajoutée

La nouvelle catégorie `use_after_destroy` repère notamment :

```python
dlg.Destroy()
selection = dlg.GetSelection()
```

Le suivi reste volontairement conservateur :
- objets locaux simples et attributs directs de `self` ;
- uniquement les `Destroy()` exécutés directement dans un bloc ;
- les branches sont analysées indépendamment afin qu'un `Destroy()` conditionnel ne contamine pas le flux parent ;
- une réaffectation réinitialise le suivi ;
- `return`, `raise`, `break` et `continue` interrompent le chemin analysé.

## Tests

Ajout de contrats couvrant :
- détection du motif réel ;
- absence de faux positif après `return` ;
- réaffectation après destruction ;
- destruction conditionnelle ;
- attribut direct de `self`.

La catégorie reste informative comme les autres inventaires historiques : le but est d'identifier les cas concrets avant correction, pas de transformer automatiquement toute dette wx en blocage CI.