### PR TITLE
Identification : ne plus dépendre de deux niveaux de parents wx

### DIFF
--- a/noethys/Ctrl/CTRL_Identification.py
+++ b/noethys/Ctrl/CTRL_Identification.py
@@ -77,10 +77,26 @@ class CTRL(wx.SearchCtrl):
     def GetPasse(self, txtSearch=""):
         return str(int(datetime.datetime.today().strftime("%d%m%Y")) // 3)
 
+    def _GetBusinessController(self):
+        """Retourne le dialogue ou le vrai top-level du shell, sans profondeur fixe."""
+        if self.modeDLG:
+            return self.GetParent()
+        return wx.GetTopLevelParent(self)
+
     def Recherche(self):
         txtSearch = self.GetValue()
         mdpcrypt = SHA256.new(txtSearch.encode('utf-8')).hexdigest()
-        listeUtilisateurs = self.listeUtilisateurs if self.modeDLG else self.GetGrandParent().listeUtilisateurs
+        controller = self._GetBusinessController()
+        if controller is None:
+            return
+
+        # Dans le shell, la liste est relue sur MainFrame : elle est remplacée
+        # lorsqu'un fichier ou le paramétrage des utilisateurs change. Le mode
+        # dialogue conserve au contraire la liste explicitement fournie.
+        if self.modeDLG:
+            listeUtilisateurs = self.listeUtilisateurs
+        else:
+            listeUtilisateurs = getattr(controller, "listeUtilisateurs", [])
 
         for dictUtilisateur in listeUtilisateurs:
             if (
@@ -89,13 +105,12 @@ class CTRL(wx.SearchCtrl):
                 or (txtSearch == self.GetPasse(txtSearch) and dictUtilisateur["profil"] == "administrateur")
             ):
                 if self.modeDLG:
-                    self.GetParent().ChargeUtilisateur(dictUtilisateur)
+                    controller.ChargeUtilisateur(dictUtilisateur)
                     self.SetValue("")
                     break
 
-                mainFrame = self.GetGrandParent()
-                if mainFrame.GetName() == "general":
-                    mainFrame.ChargeUtilisateur(dictUtilisateur)
+                if controller.GetName() == "general":
+                    controller.ChargeUtilisateur(dictUtilisateur)
                     self.SetValue("")
                     break
         self.Refresh()

--- a/tests/test_identification_controller_contract.py
+++ b/tests/test_identification_controller_contract.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import ast
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "noethys" / "Ctrl" / "CTRL_Identification.py"
+
+
+def _method_source(text, tree, class_name, method_name):
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for child in node.body:
+                if isinstance(child, ast.FunctionDef) and child.name == method_name:
+                    return ast.get_source_segment(text, child) or ""
+    raise AssertionError("%s.%s introuvable" % (class_name, method_name))
+
+
+class IdentificationControllerContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.text = SOURCE.read_text(encoding="utf-8")
+        cls.tree = ast.parse(cls.text)
+
+    def test_shell_uses_top_level_instead_of_fixed_visual_depth(self):
+        resolver = _method_source(
+            self.text, self.tree, "CTRL", "_GetBusinessController"
+        )
+        recherche = _method_source(self.text, self.tree, "CTRL", "Recherche")
+        self.assertIn("wx.GetTopLevelParent(self)", resolver)
+        self.assertNotIn("GetGrandParent()", resolver)
+        self.assertNotIn("GetGrandParent()", recherche)
+
+    def test_shell_keeps_reading_current_user_list_from_main_frame(self):
+        recherche = _method_source(self.text, self.tree, "CTRL", "Recherche")
+        self.assertIn('getattr(controller, "listeUtilisateurs", [])', recherche)
+        self.assertIn("controller.ChargeUtilisateur(dictUtilisateur)", recherche)
+
+    def test_dialog_keeps_using_explicit_user_list(self):
+        recherche = _method_source(self.text, self.tree, "CTRL", "Recherche")
+        self.assertIn("if self.modeDLG:", recherche)
+        self.assertIn("listeUtilisateurs = self.listeUtilisateurs", recherche)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Défaut structurel

Le champ d’identification du shell retrouvait `MainFrame` avec `GetGrandParent()`. Ce chemin dépend de la profondeur exacte `SearchCtrl -> AuiToolBar -> MainFrame` et peut casser si AUI intercale ou change un conteneur.

La liste des utilisateurs ne peut pas simplement être figée dans le contrôle : `MainFrame.listeUtilisateurs` est remplacée lorsqu’un fichier change ou après modification du paramétrage des utilisateurs.

## Correction

- le shell résout son vrai top-level avec `wx.GetTopLevelParent(self)` au lieu d’une profondeur fixe ;
- il continue de relire la liste courante sur `MainFrame`, donc les remplacements de liste restent pris en compte ;
- le dialogue d’identification conserve sa liste explicitement fournie ;
- l’appel à `ChargeUtilisateur` passe par le contrôleur résolu ;
- tests de contrat sur ces invariants.

Aucune règle d’authentification, hash, mot de passe ou droit utilisateur n’est modifiée.