### PR TITLE
Badgeage : ne plus lire les dialogues détruits

### DIFF
--- a/noethys/Dlg/DLG_Badgeage_interface.py
+++ b/noethys/Dlg/DLG_Badgeage_interface.py
@@ -413,7 +413,7 @@ class CTRL_Interface(wx.Panel):
     def CacherControleActif(self):
         self.listeIndividus.Cacher() 
         self.barreNum.Cacher() 
-        self.clavierNum.Cacher() 
+        self.clavierNum.Cacher()
         self.importation.Cacher()
     
     def ValidationIdentification(self, IDindividu=None):
@@ -562,7 +562,7 @@ class CTRL_Interface(wx.Panel):
                 if str(heure) > str(criteres) : valide = True
             if choix == "SUPEGAL" : 
                 if str(heure) >= str(criteres) : valide = True
-            if choix == "INF" : 
+            if choix == "INF" :
                 if str(heure) < str(criteres) : valide = True
             if choix == "INFEGAL" : 
                 if str(heure) <= str(criteres) : valide = True
@@ -723,9 +723,10 @@ class CTRL_Interface(wx.Panel):
                 listeNomsTitulaires.append(self.infosIndividus.GetNomsTitulaires(IDfamille))
             dlg = DIALOGUES.DLG_Choix(self, message=_(u"Sur quel dossier faut-il facturer l'activité '%s' ?") % dictActivite["nom"], listeItems=listeNomsTitulaires, multiSelection=False)
             reponse = dlg.ShowModal()
+            selections = list(dlg.GetSelections()) if reponse == wx.ID_YES else []
             dlg.Destroy()
             if reponse == wx.ID_YES :
-                index = dlg.GetSelections()[0]
+                index = selections[0]
                 IDfamille, IDgroupe = listeIDfamille[index]
                 self.log.AjouterAction(individu=nomIndividu, IDindividu=IDindividu, action=_(u"Choix d'une famille à facturer sur l'activité '%s' : %s.") % (dictActivite["nom"], listeNomsTitulaires[index]), resultat=True)
             else :
@@ -782,9 +783,10 @@ class CTRL_Interface(wx.Panel):
             listeChoix = [_(u"J'arrive"), _(u"Je pars")]
             dlg = DIALOGUES.DLG_Choix(self, message=texte, listeItems=listeChoix, multiSelection=False)
             reponse = dlg.ShowModal()
+            selections = list(dlg.GetSelections()) if reponse == wx.ID_YES else []
             dlg.Destroy()
             if reponse == wx.ID_YES :
-                selection = dlg.GetSelections()[0]
+                selection = selections[0]
                 if selection == 0 :
                     # J'arrive
                     heureDebut = heure
@@ -958,10 +960,11 @@ class CTRL_Interface(wx.Panel):
             texte = self.RemplacementVariablesMessages(question, heure, IDindividu, dateTmp)
             dlg = DIALOGUES.DLG_Choix(self, message=texte, listeItems=listeLabelsUnites, multiSelection=True)
             reponse = dlg.ShowModal()
+            selections = list(dlg.GetSelections()) if reponse == wx.ID_YES else []
             dlg.Destroy()
             if reponse == wx.ID_YES :
                 listeUnitesChoisies = []
-                for index in dlg.GetSelections() :
+                for index in selections :
                     listeUnitesChoisies.append(listeUnitesOuvertes[index])
                 self.log.AjouterAction(individu=nomIndividu, IDindividu=IDindividu, action=nomAction, resultat=True)
             else :

--- a/tests/test_audit_wx_lifecycle.py
+++ b/tests/test_audit_wx_lifecycle.py
@@ -205,6 +205,14 @@ class Dialog(wx.Dialog):
         self.assertEqual(len(risky), 1)
         self.assertEqual(risky[0]["member"], "self.popup")
 
+    def test_badgeage_interface_has_no_use_after_destroy(self):
+        path = audit.NOETHYS / "Dlg" / "DLG_Badgeage_interface.py"
+        source = path.read_text(encoding="utf-8", errors="replace")
+        tree = ast.parse(source)
+        findings = audit._scan_use_after_destroy(path, tree, source.splitlines())
+        risky = [item for item in findings if item["kind"] == "use_after_destroy"]
+        self.assertEqual(risky, [])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Défaut

Trois parcours de badgeage lisaient encore `GetSelections()` après `dlg.Destroy()` : choix de la famille à facturer, arrivée/départ et choix de plusieurs unités.

## Correction

- copie des sélections dans une liste Python avant destruction du dialogue ;
- destruction conservée immédiatement après la lecture ;
- aucune modification des règles métier ou des réponses utilisateur ;
- test AST ciblé garantissant que `DLG_Badgeage_interface.py` ne contient plus de `use_after_destroy` détectable.

Closes #93.