### PR TITLE
CI : verrouiller l'absence de use-after-destroy wx

### DIFF
--- a/tests/test_wx_lifecycle_zero_debt.py
+++ b/tests/test_wx_lifecycle_zero_debt.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from scripts import audit_wx_lifecycle as audit
+
+
+class WxLifecycleZeroDebtTests(unittest.TestCase):
+    def test_no_use_after_destroy_remains_in_noethys_ui(self):
+        risky = [
+            item for item in audit.scan()
+            if item["kind"] == "use_after_destroy"
+        ]
+        self.assertEqual(risky, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Objet

Le diagnostic wx est désormais à zéro pour la catégorie `use_after_destroy`. Ce lot transforme cette dette nulle en contrat de non-régression.

## Principe

Le nouveau test global appelle `audit_wx_lifecycle.scan()` et échoue dès qu'un `use_after_destroy` réapparaît dans les couches UI analysées. Comme la CI exécute déjà tous les `test_*.py`, la catégorie devient bloquante sans alourdir ni dupliquer le workflow consolidé.

Aucune règle métier ni dépendance supplémentaire.