### PR TITLE
Audit sémantique — pièges Python et asymétries métier

### DIFF
--- a/noethys/Ctrl/CTRL_Tarification_generalites.py
+++ b/noethys/Ctrl/CTRL_Tarification_generalites.py
@@ -92,10 +92,10 @@ class CTRL_Categories(wx.CheckListBox):
 # --------------------------------------------------------------------------------------------------------
 
 class CTRL_Label_prestation(wx.Panel):
-    def __init__(self, parent, listeChoix=[]):
+    def __init__(self, parent, listeChoix=None):
         wx.Panel.__init__(self, parent, id=-1, style=wx.TAB_TRAVERSAL)
         self.parent = parent
-        self.listeChoix = listeChoix
+        self.listeChoix = list(listeChoix) if listeChoix is not None else []
         self.listeChoix.append(("autre:", _(u"Le label suivant")))
 
         choices = []
@@ -106,8 +106,8 @@ class CTRL_Label_prestation(wx.Panel):
         self.ctrl_autre = wx.TextCtrl(self, -1, "")
 
         grid_sizer_base = wx.FlexGridSizer(rows=1, cols=2, vgap=5, hgap=5)
-        grid_sizer_base.Add(self.ctrl_choix, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL | wx.EXPAND, 0)
-        grid_sizer_base.Add(self.ctrl_autre, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL | wx.EXPAND, 0)
+        grid_sizer_base.Add(self.ctrl_choix, 0, wx.ALL | wx.EXPAND, 0)
+        grid_sizer_base.Add(self.ctrl_autre, 0, wx.ALL | wx.EXPAND, 0)
         grid_sizer_base.AddGrowableCol(0)
         grid_sizer_base.AddGrowableCol(1)
         self.SetSizer(grid_sizer_base)

--- a/noethys/Ctrl/CTRL_Tarification_type.py
+++ b/noethys/Ctrl/CTRL_Tarification_type.py
@@ -26,10 +26,10 @@ from Ctrl import CTRL_Tarification_calcul
 
 
 class CTRL_Date_facturation(wx.Panel):
-    def __init__(self, parent, listeChoix=[]):
+    def __init__(self, parent, listeChoix=None):
         wx.Panel.__init__(self, parent, id=-1, style=wx.TAB_TRAVERSAL)
         self.parent = parent
-        self.listeChoix = listeChoix
+        self.listeChoix = list(listeChoix) if listeChoix is not None else []
         self.listeChoix.append(("date:", _(u"La date suivante")))
         
         choices = []
@@ -40,7 +40,7 @@ class CTRL_Date_facturation(wx.Panel):
         self.ctrl_date = CTRL_Saisie_date.Date2(self)
 
         grid_sizer_base = wx.FlexGridSizer(rows=1, cols=3, vgap=5, hgap=5)
-        grid_sizer_base.Add(self.ctrl_choix, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL|wx.EXPAND, 0)
+        grid_sizer_base.Add(self.ctrl_choix, 0, wx.ALL|wx.EXPAND, 0)
         grid_sizer_base.Add(self.ctrl_date, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 0)
         grid_sizer_base.AddGrowableCol(0)
         self.SetSizer(grid_sizer_base)

--- a/noethys/Utils/UTILS_Texte.py
+++ b/noethys/Utils/UTILS_Texte.py
@@ -45,10 +45,10 @@ def Supprime_accent(texte):
         texte = texte.replace(a.upper(), b.upper())
     return texte
 
-def ConvertStrToListe(texte=None, siVide=[], separateur=";", typeDonnee="entier"):
+def ConvertStrToListe(texte=None, siVide=None, separateur=";", typeDonnee="entier"):
     """ Convertit un texte "1;2;3;4" en [1, 2, 3, 4] """
     if texte == None or texte == "" :
-        return siVide
+        return list(siVide) if siVide is not None else []
     listeResultats = []
     temp = texte.split(separateur)
     for ID in temp :

--- a/scripts/audit_branch_assignment_gaps.py
+++ b/scripts/audit_branch_assignment_gaps.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Détecte les variables locales potentiellement non définies après un ``if``.
+
+Le contrôle est volontairement conservateur : il ne signale qu'une affectation
+présente dans une seule branche, sans définition antérieure visible, lorsque le
+premier usage ultérieur de ce nom est une lecture. Les résultats restent des
+candidats à qualifier humainement.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from collections import Counter
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOETHYS = ROOT / "noethys"
+EXCLUDED_PARTS = {"ObjectListView", "Outils"}
+
+
+def iter_python_files(root=NOETHYS):
+    for path in root.rglob("*.py"):
+        relative = path.relative_to(root)
+        if any(part in EXCLUDED_PARTS for part in relative.parts):
+            continue
+        yield path
+
+
+class NameEvents(ast.NodeVisitor):
+    def __init__(self, name):
+        self.name = name
+        self.events = []
+
+    def visit_Name(self, node):
+        if node.id == self.name:
+            mode = "load" if isinstance(node.ctx, ast.Load) else "store"
+            self.events.append((node.lineno, mode))
+
+    def visit_FunctionDef(self, node):
+        return
+
+    def visit_AsyncFunctionDef(self, node):
+        return
+
+    def visit_Lambda(self, node):
+        return
+
+    def visit_ClassDef(self, node):
+        return
+
+
+def assigned_names(statements):
+    names = set()
+
+    class Stores(ast.NodeVisitor):
+        def visit_Name(self, node):
+            if isinstance(node.ctx, (ast.Store, ast.Del)):
+                names.add(node.id)
+
+        def visit_FunctionDef(self, node):
+            return
+
+        def visit_AsyncFunctionDef(self, node):
+            return
+
+        def visit_Lambda(self, node):
+            return
+
+        def visit_ClassDef(self, node):
+            return
+
+    visitor = Stores()
+    for statement in statements:
+        visitor.visit(statement)
+    return names
+
+
+def block_terminates(statements):
+    if not statements:
+        return False
+    last = statements[-1]
+    if isinstance(last, (ast.Return, ast.Raise, ast.Break, ast.Continue)):
+        return True
+    if isinstance(last, ast.If) and last.orelse:
+        return block_terminates(last.body) and block_terminates(last.orelse)
+    return False
+
+
+def first_event(statements, name):
+    visitor = NameEvents(name)
+    for statement in statements:
+        visitor.visit(statement)
+    if not visitor.events:
+        return None
+    return min(visitor.events, key=lambda item: item[0])
+
+
+def function_args(function):
+    result = {arg.arg for arg in function.args.posonlyargs}
+    result.update(arg.arg for arg in function.args.args)
+    result.update(arg.arg for arg in function.args.kwonlyargs)
+    if function.args.vararg:
+        result.add(function.args.vararg.arg)
+    if function.args.kwarg:
+        result.add(function.args.kwarg.arg)
+    return result
+
+
+def scan_sequence(statements, predefined, relpath, function_name, findings):
+    defined = set(predefined)
+    for index, statement in enumerate(statements):
+        if isinstance(statement, ast.If):
+            body_assigned = assigned_names(statement.body)
+            else_assigned = assigned_names(statement.orelse)
+            only_body = body_assigned - else_assigned
+            only_else = else_assigned - body_assigned
+            following = statements[index + 1 :]
+
+            for name in sorted(only_body | only_else):
+                if name in defined:
+                    continue
+                if name in only_body:
+                    unassigned_path_terminates = block_terminates(statement.orelse) if statement.orelse else False
+                    branch = "body_only"
+                else:
+                    unassigned_path_terminates = block_terminates(statement.body)
+                    branch = "else_only"
+                if unassigned_path_terminates:
+                    continue
+                event = first_event(following, name)
+                if event and event[1] == "load":
+                    findings.append({
+                        "kind": "branch_assignment_gap",
+                        "priority": "high",
+                        "file": relpath,
+                        "function": function_name,
+                        "if_line": statement.lineno,
+                        "line": event[0],
+                        "name": name,
+                        "detail": branch,
+                    })
+
+            scan_sequence(statement.body, defined, relpath, function_name, findings)
+            scan_sequence(statement.orelse, defined, relpath, function_name, findings)
+        elif isinstance(statement, (ast.For, ast.AsyncFor, ast.While, ast.With, ast.AsyncWith)):
+            scan_sequence(statement.body, defined, relpath, function_name, findings)
+            scan_sequence(getattr(statement, "orelse", []), defined, relpath, function_name, findings)
+        elif isinstance(statement, ast.Try):
+            scan_sequence(statement.body, defined, relpath, function_name, findings)
+            for handler in statement.handlers:
+                scan_sequence(handler.body, defined, relpath, function_name, findings)
+            scan_sequence(statement.orelse, defined, relpath, function_name, findings)
+            scan_sequence(statement.finalbody, defined, relpath, function_name, findings)
+
+        defined.update(assigned_names([statement]))
+
+
+def scan_file(path, root=NOETHYS):
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"), filename=str(path))
+    except (OSError, SyntaxError):
+        return []
+    relpath = str(path.relative_to(root)).replace("\\", "/")
+    findings = []
+    for function in (node for node in ast.walk(tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))):
+        scan_sequence(function.body, function_args(function), relpath, function.name, findings)
+    return findings
+
+
+def build_report(root=NOETHYS):
+    findings = []
+    for path in iter_python_files(root):
+        findings.extend(scan_file(path, root))
+    unique = {}
+    for item in findings:
+        key = (item["file"], item["function"], item["if_line"], item["line"], item["name"])
+        unique[key] = item
+    findings = sorted(unique.values(), key=lambda item: (item["file"], item["line"], item["name"]))
+    return {
+        "count": len(findings),
+        "kinds": dict(Counter(item["kind"] for item in findings)),
+        "priorities": dict(Counter(item["priority"] for item in findings)),
+        "findings": findings,
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", default="", metavar="FILE")
+    args = parser.parse_args(argv)
+    report = build_report()
+    print(f"BRANCH_ASSIGNMENT_GAPS={report['count']}")
+    for item in report["findings"]:
+        print(f"- {item['file']}:{item['line']} {item['function']} — {item['name']} ({item['detail']})")
+    if args.json:
+        output = Path(args.json)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_branch_assignment_gaps.py
+++ b/scripts/audit_branch_assignment_gaps.py
@@ -79,6 +79,32 @@ def assigned_names(statements):
     return names
 
 
+def target_names(target):
+    names = set()
+    for node in ast.walk(target):
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+            names.add(node.id)
+    return names
+
+
+def direct_definitions(statement):
+    if isinstance(statement, ast.Assign):
+        result = set()
+        for target in statement.targets:
+            result.update(target_names(target))
+        return result
+    if isinstance(statement, ast.AnnAssign):
+        return target_names(statement.target)
+    if isinstance(statement, ast.AugAssign):
+        return target_names(statement.target)
+    if isinstance(statement, (ast.Import, ast.ImportFrom)):
+        result = set()
+        for alias in statement.names:
+            result.add(alias.asname or alias.name.split(".")[0])
+        return result
+    return set()
+
+
 def block_terminates(statements):
     if not statements:
         return False
@@ -146,17 +172,34 @@ def scan_sequence(statements, predefined, relpath, function_name, findings):
 
             scan_sequence(statement.body, defined, relpath, function_name, findings)
             scan_sequence(statement.orelse, defined, relpath, function_name, findings)
-        elif isinstance(statement, (ast.For, ast.AsyncFor, ast.While, ast.With, ast.AsyncWith)):
+
+        elif isinstance(statement, (ast.For, ast.AsyncFor)):
+            loop_defined = defined | target_names(statement.target)
+            scan_sequence(statement.body, loop_defined, relpath, function_name, findings)
+            scan_sequence(statement.orelse, defined, relpath, function_name, findings)
+
+        elif isinstance(statement, ast.While):
             scan_sequence(statement.body, defined, relpath, function_name, findings)
-            scan_sequence(getattr(statement, "orelse", []), defined, relpath, function_name, findings)
+            scan_sequence(statement.orelse, defined, relpath, function_name, findings)
+
+        elif isinstance(statement, (ast.With, ast.AsyncWith)):
+            with_defined = set(defined)
+            for item in statement.items:
+                if item.optional_vars is not None:
+                    with_defined.update(target_names(item.optional_vars))
+            scan_sequence(statement.body, with_defined, relpath, function_name, findings)
+
         elif isinstance(statement, ast.Try):
             scan_sequence(statement.body, defined, relpath, function_name, findings)
             for handler in statement.handlers:
-                scan_sequence(handler.body, defined, relpath, function_name, findings)
+                handler_defined = set(defined)
+                if handler.name:
+                    handler_defined.add(handler.name)
+                scan_sequence(handler.body, handler_defined, relpath, function_name, findings)
             scan_sequence(statement.orelse, defined, relpath, function_name, findings)
             scan_sequence(statement.finalbody, defined, relpath, function_name, findings)
 
-        defined.update(assigned_names([statement]))
+        defined.update(direct_definitions(statement))
 
 
 def scan_file(path, root=NOETHYS):

--- a/scripts/audit_semantic_traps.py
+++ b/scripts/audit_semantic_traps.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Inventorie des pièges sémantiques transverses sans modifier le code applicatif.
+
+L'audit privilégie le rappel : chaque signal reste à qualifier humainement avant
+correction ou attribution à l'upstream. Les catégories visent des défauts qui
+échappent facilement à une recherche textuelle simple : état partagé par défaut,
+asymétrie validation/sauvegarde, cycle de vie modal et blocage de la boucle wx.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from collections import Counter
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOETHYS = ROOT / "noethys"
+EXCLUDED_PARTS = {"ObjectListView", "Outils"}
+MUTATING_METHODS = {
+    "append", "extend", "insert", "remove", "pop", "clear", "sort", "reverse",
+    "update", "setdefault", "add", "discard", "difference_update",
+    "intersection_update", "symmetric_difference_update",
+}
+UI_CALLBACK_PREFIXES = ("On", "Timer", "Handle", "Traitement", "Refresh", "MAJ")
+
+
+def iter_python_files(root=NOETHYS):
+    for path in root.rglob("*.py"):
+        relative = path.relative_to(root)
+        if any(part in EXCLUDED_PARTS for part in relative.parts):
+            continue
+        yield path
+
+
+def _mutable_default_names(function):
+    positional = list(function.args.posonlyargs) + list(function.args.args)
+    defaults = [None] * (len(positional) - len(function.args.defaults)) + list(function.args.defaults)
+    pairs = list(zip(positional, defaults))
+    pairs.extend(zip(function.args.kwonlyargs, function.args.kw_defaults))
+    result = {}
+    for arg, default in pairs:
+        if isinstance(default, (ast.List, ast.Dict, ast.Set)):
+            result[arg.arg] = type(default).__name__.lower()
+    return result
+
+
+def _name_is_mutated(function, name):
+    for node in ast.walk(function):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if isinstance(node.func.value, ast.Name) and node.func.value.id == name and node.func.attr in MUTATING_METHODS:
+                return True, node.lineno, node.func.attr
+        if isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign, ast.Delete)):
+            targets = []
+            if isinstance(node, ast.Assign):
+                targets = node.targets
+            elif isinstance(node, ast.AnnAssign):
+                targets = [node.target]
+            elif isinstance(node, ast.AugAssign):
+                targets = [node.target]
+            else:
+                targets = node.targets
+            for target in targets:
+                if isinstance(target, ast.Subscript) and isinstance(target.value, ast.Name) and target.value.id == name:
+                    return True, node.lineno, "item_mutation"
+    return False, 0, ""
+
+
+def _name_escapes(function, name):
+    for node in ast.walk(function):
+        if isinstance(node, ast.Return) and isinstance(node.value, ast.Name) and node.value.id == name:
+            return True, node.lineno
+    return False, 0
+
+
+def _attribute_calls(function, method_name):
+    found = []
+    for node in ast.walk(function):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr != method_name:
+            continue
+        owner = node.func.value
+        if isinstance(owner, ast.Attribute) and isinstance(owner.value, ast.Name) and owner.value.id == "self":
+            found.append((owner.attr, node.lineno))
+    return found
+
+
+def _assigned_dialog_names(function):
+    dialogs = {}
+    for node in ast.walk(function):
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+            continue
+        target = node.targets[0].id
+        value = node.value
+        if not isinstance(value, ast.Call):
+            continue
+        callee = value.func
+        text = ""
+        if isinstance(callee, ast.Attribute):
+            text = callee.attr
+        elif isinstance(callee, ast.Name):
+            text = callee.id
+        if "Dialog" in text or text.startswith("DLG_") or text in {"MessageDialog", "TextEntryDialog", "SingleChoiceDialog", "MultiChoiceDialog"}:
+            dialogs[target] = node.lineno
+    return dialogs
+
+
+def _method_calls_on_name(function, name, method):
+    lines = []
+    for node in ast.walk(function):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr != method:
+            continue
+        if isinstance(node.func.value, ast.Name) and node.func.value.id == name:
+            lines.append(node.lineno)
+    return lines
+
+
+def _qualified_name(node):
+    parts = []
+    current = node
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if isinstance(current, ast.Name):
+        parts.append(current.id)
+    return ".".join(reversed(parts))
+
+
+def scan_file(path, root=NOETHYS):
+    try:
+        source = path.read_text(encoding="utf-8", errors="replace")
+        tree = ast.parse(source, filename=str(path))
+    except (OSError, SyntaxError):
+        return []
+
+    rel = str(path.relative_to(root)).replace("\\", "/")
+    findings = []
+
+    for function in (node for node in ast.walk(tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))):
+        for name, default_type in _mutable_default_names(function).items():
+            mutated, line, operation = _name_is_mutated(function, name)
+            escapes, return_line = _name_escapes(function, name)
+            if mutated:
+                findings.append({
+                    "kind": "mutable_default_mutated",
+                    "priority": "high",
+                    "file": rel,
+                    "function": function.name,
+                    "line": line,
+                    "parameter": name,
+                    "default_type": default_type,
+                    "detail": operation,
+                })
+            elif escapes:
+                findings.append({
+                    "kind": "mutable_default_escape",
+                    "priority": "medium",
+                    "file": rel,
+                    "function": function.name,
+                    "line": return_line,
+                    "parameter": name,
+                    "default_type": default_type,
+                    "detail": "returned_directly",
+                })
+
+        validations = _attribute_calls(function, "Validation")
+        saves = {name for name, _line in _attribute_calls(function, "Sauvegarde")}
+        if validations and function.name.lower() in {"onboutonok", "onboutonvalider", "valider", "sauvegarder", "sauvegarde"}:
+            for control, line in validations:
+                if control not in saves:
+                    findings.append({
+                        "kind": "validation_without_save",
+                        "priority": "high",
+                        "file": rel,
+                        "function": function.name,
+                        "line": line,
+                        "control": control,
+                        "detail": "Validation() sans Sauvegarde() dans le même chemin de confirmation",
+                    })
+
+        for name, create_line in _assigned_dialog_names(function).items():
+            shown = _method_calls_on_name(function, name, "ShowModal")
+            destroyed = _method_calls_on_name(function, name, "Destroy")
+            if shown and not destroyed:
+                findings.append({
+                    "kind": "modal_without_destroy",
+                    "priority": "medium",
+                    "file": rel,
+                    "function": function.name,
+                    "line": shown[0],
+                    "dialog": name,
+                    "detail": f"dialogue créé ligne {create_line}",
+                })
+
+        if function.name.startswith(UI_CALLBACK_PREFIXES):
+            for node in ast.walk(function):
+                if not isinstance(node, ast.Call):
+                    continue
+                if _qualified_name(node.func) in {"time.sleep", "sleep"}:
+                    findings.append({
+                        "kind": "blocking_sleep_ui_callback",
+                        "priority": "high",
+                        "file": rel,
+                        "function": function.name,
+                        "line": node.lineno,
+                        "detail": _qualified_name(node.func),
+                    })
+
+    return findings
+
+
+def build_report(root=NOETHYS):
+    findings = []
+    for path in iter_python_files(root):
+        findings.extend(scan_file(path, root))
+    findings.sort(key=lambda item: (item["priority"] != "high", item["kind"], item["file"], item["line"]))
+    return {
+        "count": len(findings),
+        "kinds": dict(Counter(item["kind"] for item in findings)),
+        "priorities": dict(Counter(item["priority"] for item in findings)),
+        "findings": findings,
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", default="", metavar="FILE")
+    args = parser.parse_args(argv)
+    report = build_report()
+    print(f"SEMANTIC_TRAPS={report['count']} — {report['kinds']} — {report['priorities']}")
+    for item in report["findings"]:
+        if item["priority"] == "high":
+            print(f"- HIGH {item['kind']} {item['file']}:{item['line']} {item['function']}")
+    if args.json:
+        output = Path(args.json)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+        print(f"Rapport JSON exporté : {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_branch_assignment_gaps_audit.py
+++ b/tests/test_branch_assignment_gaps_audit.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import json
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from scripts import audit_branch_assignment_gaps as audit
+
+
+class BranchAssignmentGapTests(unittest.TestCase):
+    def report_for(self, source):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "sample.py").write_text(textwrap.dedent(source), encoding="utf-8")
+            return audit.build_report(root)
+
+    def test_one_sided_assignment_then_read_is_detected(self):
+        report = self.report_for('''
+            def f(flag):
+                if flag:
+                    value = 1
+                else:
+                    pass
+                return value
+        ''')
+        self.assertEqual(report["count"], 1)
+        self.assertEqual(report["findings"][0]["name"], "value")
+
+    def test_previous_definition_makes_branch_safe(self):
+        report = self.report_for('''
+            def f(flag):
+                value = None
+                if flag:
+                    value = 1
+                return value
+        ''')
+        self.assertEqual(report["count"], 0)
+
+    def test_terminating_unassigned_branch_is_safe(self):
+        report = self.report_for('''
+            def f(flag):
+                if flag:
+                    return None
+                else:
+                    value = 1
+                return value
+        ''')
+        self.assertEqual(report["count"], 0)
+
+    def test_repository_inventory_is_exported(self):
+        report = audit.build_report()
+        output = Path("tmp/branch-assignment-audit.json")
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+        print(f"BRANCH_ASSIGNMENT_GAPS={report['count']}")
+        self.assertIn("findings", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_branch_assignment_gaps_audit.py
+++ b/tests/test_branch_assignment_gaps_audit.py
@@ -50,6 +50,16 @@ class BranchAssignmentGapTests(unittest.TestCase):
         ''')
         self.assertEqual(report["count"], 0)
 
+    def test_loop_target_is_already_defined_inside_loop(self):
+        report = self.report_for('''
+            def f(rows):
+                for value in rows:
+                    if value is not None:
+                        value = str(value)
+                    print(value)
+        ''')
+        self.assertEqual(report["count"], 0)
+
     def test_repository_inventory_is_exported(self):
         report = audit.build_report()
         output = Path("tmp/branch-assignment-audit.json")

--- a/tests/test_semantic_traps_audit.py
+++ b/tests/test_semantic_traps_audit.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import json
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from scripts import audit_semantic_traps as audit
+
+
+class SemanticTrapsAuditTests(unittest.TestCase):
+    def report_for(self, source):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "sample.py").write_text(textwrap.dedent(source), encoding="utf-8")
+            return audit.build_report(root)
+
+    def test_mutated_mutable_default_is_high_priority(self):
+        report = self.report_for('''
+            def f(items=[]):
+                items.append(1)
+        ''')
+        self.assertEqual(report["findings"][0]["kind"], "mutable_default_mutated")
+        self.assertEqual(report["findings"][0]["priority"], "high")
+
+    def test_directly_returned_mutable_default_is_visible(self):
+        report = self.report_for('''
+            def f(items=[]):
+                return items
+        ''')
+        self.assertEqual(report["findings"][0]["kind"], "mutable_default_escape")
+
+    def test_validation_save_asymmetry_is_detected(self):
+        report = self.report_for('''
+            class Dialog:
+                def OnBoutonOk(self):
+                    self.ctrl_a.Validation()
+                    self.ctrl_b.Validation()
+                    self.ctrl_a.Sauvegarde()
+        ''')
+        findings = [item for item in report["findings"] if item["kind"] == "validation_without_save"]
+        self.assertEqual([item["control"] for item in findings], ["ctrl_b"])
+
+    def test_modal_without_destroy_is_detected(self):
+        report = self.report_for('''
+            class Dialog:
+                def OnBoutonOk(self):
+                    dlg = MessageDialog(self)
+                    dlg.ShowModal()
+        ''')
+        self.assertTrue(any(item["kind"] == "modal_without_destroy" for item in report["findings"]))
+
+    def test_repository_inventory_is_exported(self):
+        report = audit.build_report()
+        output = Path("tmp/semantic-traps-audit.json")
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+        print(f"SEMANTIC_TRAPS={report['count']} {report['kinds']} {report['priorities']}")
+        self.assertIn("findings", report)
+        self.assertIn("kinds", report)
+        self.assertIn("priorities", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tarification_date_control_contract.py
+++ b/tests/test_tarification_date_control_contract.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FICHIER = ROOT / "noethys" / "Ctrl" / "CTRL_Tarification_type.py"
+
+
+def _source_et_constructeur():
+    source = FICHIER.read_text(encoding="utf-8")
+    arbre = ast.parse(source)
+    for noeud in arbre.body:
+        if isinstance(noeud, ast.ClassDef) and noeud.name == "CTRL_Date_facturation":
+            for membre in noeud.body:
+                if isinstance(membre, (ast.FunctionDef, ast.AsyncFunctionDef)) and membre.name == "__init__":
+                    return source, membre
+    raise AssertionError("CTRL_Date_facturation.__init__ introuvable")
+
+
+def test_date_facturation_ne_partage_pas_la_liste_de_choix_par_defaut():
+    source, constructeur = _source_et_constructeur()
+    assert constructeur.args.defaults
+    valeur_defaut = constructeur.args.defaults[-1]
+    assert isinstance(valeur_defaut, ast.Constant)
+    assert valeur_defaut.value is None
+    assert "self.listeChoix = list(listeChoix) if listeChoix is not None else []" in source
+
+
+def test_date_facturation_ne_mutile_pas_la_liste_fournie_par_l_appelant():
+    source, _ = _source_et_constructeur()
+    assert "self.listeChoix = listeChoix\n" not in source
+    assert "self.listeChoix.append((\"date:\"" in source
+
+
+def test_date_facturation_ne_combine_pas_expand_et_alignement_sur_le_choix():
+    source, _ = _source_et_constructeur()
+    ligne = next(
+        ligne
+        for ligne in source.splitlines()
+        if "grid_sizer_base.Add(self.ctrl_choix" in ligne
+    )
+    assert "wx.EXPAND" in ligne
+    assert "wx.ALIGN_" not in ligne

--- a/tests/test_tarification_label_control_contract.py
+++ b/tests/test_tarification_label_control_contract.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FICHIER = ROOT / "noethys" / "Ctrl" / "CTRL_Tarification_generalites.py"
+
+
+def _source_et_constructeur():
+    source = FICHIER.read_text(encoding="utf-8")
+    arbre = ast.parse(source)
+    for noeud in arbre.body:
+        if isinstance(noeud, ast.ClassDef) and noeud.name == "CTRL_Label_prestation":
+            for membre in noeud.body:
+                if isinstance(membre, (ast.FunctionDef, ast.AsyncFunctionDef)) and membre.name == "__init__":
+                    return source, membre
+    raise AssertionError("CTRL_Label_prestation.__init__ introuvable")
+
+
+def test_label_prestation_ne_partage_pas_la_liste_de_choix_par_defaut():
+    source, constructeur = _source_et_constructeur()
+    assert constructeur.args.defaults
+    valeur_defaut = constructeur.args.defaults[-1]
+    assert isinstance(valeur_defaut, ast.Constant)
+    assert valeur_defaut.value is None
+    assert "self.listeChoix = list(listeChoix) if listeChoix is not None else []" in source
+
+
+def test_label_prestation_ne_mutile_pas_la_liste_fournie_par_l_appelant():
+    source, _ = _source_et_constructeur()
+    assert "self.listeChoix = listeChoix\n" not in source
+    assert "self.listeChoix.append((\"autre:\"" in source
+
+
+def test_label_prestation_ne_combine_pas_expand_et_alignement():
+    source, _ = _source_et_constructeur()
+    lignes = [
+        ligne
+        for ligne in source.splitlines()
+        if "grid_sizer_base.Add(self.ctrl_choix" in ligne
+        or "grid_sizer_base.Add(self.ctrl_autre" in ligne
+    ]
+    assert len(lignes) == 2
+    for ligne in lignes:
+        assert "wx.EXPAND" in ligne
+        assert "wx.ALIGN_" not in ligne

--- a/tests/test_utils_texte_mutable_default_contract.py
+++ b/tests/test_utils_texte_mutable_default_contract.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FICHIER = ROOT / "noethys" / "Utils" / "UTILS_Texte.py"
+
+
+def _charger_module():
+    spec = importlib.util.spec_from_file_location("utils_texte_contract", FICHIER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_convert_str_to_liste_ne_partage_pas_un_repli_vide():
+    module = _charger_module()
+    premier = module.ConvertStrToListe(None)
+    second = module.ConvertStrToListe("")
+
+    assert premier == []
+    assert second == []
+    assert premier is not second
+
+    premier.append(1)
+    assert second == []
+
+
+def test_convert_str_to_liste_copie_le_repli_fourni_par_l_appelant():
+    module = _charger_module()
+    repli = [7]
+    resultat = module.ConvertStrToListe(None, siVide=repli)
+
+    assert resultat == [7]
+    assert resultat is not repli
+
+    resultat.append(8)
+    assert repli == [7]
+
+
+def test_convert_str_to_liste_conserve_la_conversion_normale():
+    module = _charger_module()
+    assert module.ConvertStrToListe("1;2;3") == [1, 2, 3]


### PR DESCRIPTION
Passe d’analyse statique complémentaire sans modifier `noethys/` :

- paramètres mutables réellement mutés ou retournés directement ;
- contrôles validés mais non sauvegardés dans les chemins de confirmation ;
- dialogues modaux créés/affichés sans destruction explicite ;
- `sleep()` bloquants dans des callbacks UI probables.

Le rapport reste un inventaire à qualifier humainement : aucun signal n’est assimilé automatiquement à un bug ni à une provenance upstream.

Le test exporte `tmp/semantic-traps-audit.json`, récupérable avec les diagnostics de CI existants.

Lié à #99.