### PR TITLE
Hardening UI — sécuriser les contrôles tarifaires partagés

### DIFF
--- a/noethys/Ctrl/CTRL_Tarification_generalites.py
+++ b/noethys/Ctrl/CTRL_Tarification_generalites.py
@@ -92,10 +92,10 @@ class CTRL_Categories(wx.CheckListBox):
 # --------------------------------------------------------------------------------------------------------
 
 class CTRL_Label_prestation(wx.Panel):
-    def __init__(self, parent, listeChoix=[]):
+    def __init__(self, parent, listeChoix=None):
         wx.Panel.__init__(self, parent, id=-1, style=wx.TAB_TRAVERSAL)
         self.parent = parent
-        self.listeChoix = listeChoix
+        self.listeChoix = list(listeChoix) if listeChoix is not None else []
         self.listeChoix.append(("autre:", _(u"Le label suivant")))
 
         choices = []
@@ -106,8 +106,8 @@ class CTRL_Label_prestation(wx.Panel):
         self.ctrl_autre = wx.TextCtrl(self, -1, "")
 
         grid_sizer_base = wx.FlexGridSizer(rows=1, cols=2, vgap=5, hgap=5)
-        grid_sizer_base.Add(self.ctrl_choix, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL | wx.EXPAND, 0)
-        grid_sizer_base.Add(self.ctrl_autre, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL | wx.EXPAND, 0)
+        grid_sizer_base.Add(self.ctrl_choix, 0, wx.ALL | wx.EXPAND, 0)
+        grid_sizer_base.Add(self.ctrl_autre, 0, wx.ALL | wx.EXPAND, 0)
         grid_sizer_base.AddGrowableCol(0)
         grid_sizer_base.AddGrowableCol(1)
         self.SetSizer(grid_sizer_base)

--- a/noethys/Ctrl/CTRL_Tarification_type.py
+++ b/noethys/Ctrl/CTRL_Tarification_type.py
@@ -26,10 +26,10 @@ from Ctrl import CTRL_Tarification_calcul
 
 
 class CTRL_Date_facturation(wx.Panel):
-    def __init__(self, parent, listeChoix=[]):
+    def __init__(self, parent, listeChoix=None):
         wx.Panel.__init__(self, parent, id=-1, style=wx.TAB_TRAVERSAL)
         self.parent = parent
-        self.listeChoix = listeChoix
+        self.listeChoix = list(listeChoix) if listeChoix is not None else []
         self.listeChoix.append(("date:", _(u"La date suivante")))
         
         choices = []
@@ -40,7 +40,7 @@ class CTRL_Date_facturation(wx.Panel):
         self.ctrl_date = CTRL_Saisie_date.Date2(self)
 
         grid_sizer_base = wx.FlexGridSizer(rows=1, cols=3, vgap=5, hgap=5)
-        grid_sizer_base.Add(self.ctrl_choix, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL|wx.EXPAND, 0)
+        grid_sizer_base.Add(self.ctrl_choix, 0, wx.ALL|wx.EXPAND, 0)
         grid_sizer_base.Add(self.ctrl_date, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 0)
         grid_sizer_base.AddGrowableCol(0)
         self.SetSizer(grid_sizer_base)
@@ -120,7 +120,7 @@ class Panel_type_sans_parametres(wx.Panel):
 ##        self.CreationPages()
 ##    
 ##    def CreationPages(self):
-##        liste_pages = [
+##        self.liste_pages = [
 ##            ("SIMPLE", _(u"Prestation simple"), Panel_type_sans_parametres(self, self.nouveauTarif)),
 ##            ("JOURN", _(u"Prestation journalière"), CTRL_Tarification_journ.Panel(self, self.IDactivite, self.IDtarif, self.nouveauTarif)),
 ##            ("FORFAIT", _(u"Forfait daté"), CTRL_Tarification_forfait.Panel(self, self.IDactivite, self.IDtarif, self.nouveauTarif)),
@@ -128,7 +128,7 @@ class Panel_type_sans_parametres(wx.Panel):
 ##            ]
 ##        self.dictPages = {}
 ##        index = 0
-##        for code, label, ctrl in liste_pages :
+##        for code, label, ctrl in self.liste_pages :
 ##            self.AddPage(ctrl, label)
 ##            self.dictPages[code] = {"index":index, "ctrl":ctrl}
 ##            index += 1

--- a/noethys/Ctrl/CTRL_Tarification_type.py
+++ b/noethys/Ctrl/CTRL_Tarification_type.py
@@ -120,7 +120,7 @@ class Panel_type_sans_parametres(wx.Panel):
 ##        self.CreationPages()
 ##    
 ##    def CreationPages(self):
-##        self.liste_pages = [
+##        liste_pages = [
 ##            ("SIMPLE", _(u"Prestation simple"), Panel_type_sans_parametres(self, self.nouveauTarif)),
 ##            ("JOURN", _(u"Prestation journalière"), CTRL_Tarification_journ.Panel(self, self.IDactivite, self.IDtarif, self.nouveauTarif)),
 ##            ("FORFAIT", _(u"Forfait daté"), CTRL_Tarification_forfait.Panel(self, self.IDactivite, self.IDtarif, self.nouveauTarif)),
@@ -128,7 +128,7 @@ class Panel_type_sans_parametres(wx.Panel):
 ##            ]
 ##        self.dictPages = {}
 ##        index = 0
-##        for code, label, ctrl in self.liste_pages :
+##        for code, label, ctrl in liste_pages :
 ##            self.AddPage(ctrl, label)
 ##            self.dictPages[code] = {"index":index, "ctrl":ctrl}
 ##            index += 1

--- a/noethys/Utils/UTILS_Texte.py
+++ b/noethys/Utils/UTILS_Texte.py
@@ -45,10 +45,10 @@ def Supprime_accent(texte):
         texte = texte.replace(a.upper(), b.upper())
     return texte
 
-def ConvertStrToListe(texte=None, siVide=[], separateur=";", typeDonnee="entier"):
+def ConvertStrToListe(texte=None, siVide=None, separateur=";", typeDonnee="entier"):
     """ Convertit un texte "1;2;3;4" en [1, 2, 3, 4] """
     if texte == None or texte == "" :
-        return siVide
+        return list(siVide) if siVide is not None else []
     listeResultats = []
     temp = texte.split(separateur)
     for ID in temp :

--- a/tests/test_tarification_date_control_contract.py
+++ b/tests/test_tarification_date_control_contract.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FICHIER = ROOT / "noethys" / "Ctrl" / "CTRL_Tarification_type.py"
+
+
+def _source_et_constructeur():
+    source = FICHIER.read_text(encoding="utf-8")
+    arbre = ast.parse(source)
+    for noeud in arbre.body:
+        if isinstance(noeud, ast.ClassDef) and noeud.name == "CTRL_Date_facturation":
+            for membre in noeud.body:
+                if isinstance(membre, (ast.FunctionDef, ast.AsyncFunctionDef)) and membre.name == "__init__":
+                    return source, membre
+    raise AssertionError("CTRL_Date_facturation.__init__ introuvable")
+
+
+def test_date_facturation_ne_partage_pas_la_liste_de_choix_par_defaut():
+    source, constructeur = _source_et_constructeur()
+    assert constructeur.args.defaults
+    valeur_defaut = constructeur.args.defaults[-1]
+    assert isinstance(valeur_defaut, ast.Constant)
+    assert valeur_defaut.value is None
+    assert "self.listeChoix = list(listeChoix) if listeChoix is not None else []" in source
+
+
+def test_date_facturation_ne_mutile_pas_la_liste_fournie_par_l_appelant():
+    source, _ = _source_et_constructeur()
+    assert "self.listeChoix = listeChoix\n" not in source
+    assert "self.listeChoix.append((\"date:\"" in source
+
+
+def test_date_facturation_ne_combine_pas_expand_et_alignement_sur_le_choix():
+    source, _ = _source_et_constructeur()
+    ligne = next(
+        ligne
+        for ligne in source.splitlines()
+        if "grid_sizer_base.Add(self.ctrl_choix" in ligne
+    )
+    assert "wx.EXPAND" in ligne
+    assert "wx.ALIGN_" not in ligne

--- a/tests/test_tarification_label_control_contract.py
+++ b/tests/test_tarification_label_control_contract.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FICHIER = ROOT / "noethys" / "Ctrl" / "CTRL_Tarification_generalites.py"
+
+
+def _source_et_constructeur():
+    source = FICHIER.read_text(encoding="utf-8")
+    arbre = ast.parse(source)
+    for noeud in arbre.body:
+        if isinstance(noeud, ast.ClassDef) and noeud.name == "CTRL_Label_prestation":
+            for membre in noeud.body:
+                if isinstance(membre, (ast.FunctionDef, ast.AsyncFunctionDef)) and membre.name == "__init__":
+                    return source, membre
+    raise AssertionError("CTRL_Label_prestation.__init__ introuvable")
+
+
+def test_label_prestation_ne_partage_pas_la_liste_de_choix_par_defaut():
+    source, constructeur = _source_et_constructeur()
+    assert constructeur.args.defaults
+    valeur_defaut = constructeur.args.defaults[-1]
+    assert isinstance(valeur_defaut, ast.Constant)
+    assert valeur_defaut.value is None
+    assert "self.listeChoix = list(listeChoix) if listeChoix is not None else []" in source
+
+
+def test_label_prestation_ne_mutile_pas_la_liste_fournie_par_l_appelant():
+    source, _ = _source_et_constructeur()
+    assert "self.listeChoix = listeChoix\n" not in source
+    assert "self.listeChoix.append((\"autre:\"" in source
+
+
+def test_label_prestation_ne_combine_pas_expand_et_alignement():
+    source, _ = _source_et_constructeur()
+    lignes = [
+        ligne
+        for ligne in source.splitlines()
+        if "grid_sizer_base.Add(self.ctrl_choix" in ligne
+        or "grid_sizer_base.Add(self.ctrl_autre" in ligne
+    ]
+    assert len(lignes) == 2
+    for ligne in lignes:
+        assert "wx.EXPAND" in ligne
+        assert "wx.ALIGN_" not in ligne

--- a/tests/test_utils_texte_mutable_default_contract.py
+++ b/tests/test_utils_texte_mutable_default_contract.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FICHIER = ROOT / "noethys" / "Utils" / "UTILS_Texte.py"
+
+
+def _charger_module():
+    spec = importlib.util.spec_from_file_location("utils_texte_contract", FICHIER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_convert_str_to_liste_ne_partage_pas_un_repli_vide():
+    module = _charger_module()
+    premier = module.ConvertStrToListe(None)
+    second = module.ConvertStrToListe("")
+
+    assert premier == []
+    assert second == []
+    assert premier is not second
+
+    premier.append(1)
+    assert second == []
+
+
+def test_convert_str_to_liste_copie_le_repli_fourni_par_l_appelant():
+    module = _charger_module()
+    repli = [7]
+    resultat = module.ConvertStrToListe(None, siVide=repli)
+
+    assert resultat == [7]
+    assert resultat is not repli
+
+    resultat.append(8)
+    assert repli == [7]
+
+
+def test_convert_str_to_liste_conserve_la_conversion_normale():
+    module = _charger_module()
+    assert module.ConvertStrToListe("1;2;3") == [1, 2, 3]


### PR DESCRIPTION
## Contexte

Suite de la passe #97 après le merge de #98, en privilégiant les défauts démontrables sans recette manuelle ni base réelle.

## Défauts corrigés

Trois défauts de même famille sont corrigés :

- `CTRL_Date_facturation` (`CTRL_Tarification_type.py`) utilisait `listeChoix=[]` puis modifiait cette liste avec `append()` ;
- `CTRL_Label_prestation` (`CTRL_Tarification_generalites.py`) faisait de même ;
- `ConvertStrToListe` (`UTILS_Texte.py`) utilisait `siVide=[]` et retournait directement cet objet lorsque le texte était vide, ce qui permettait à un appelant de modifier le repli partagé entre appels.

Les deux contrôles tarifaires modifiaient également la liste fournie par l'appelant. Les mêmes contrôles contenaient trois associations `wx.EXPAND` + `wx.ALIGN_CENTER_VERTICAL` sur des items de `wx.FlexGridSizer`, motifs remontés par l'audit `align_expand_conflict` et incompatibles avec les contrôles de cohérence wxWidgets modernes.

## Correction

- défauts mutables remplacés par `None` ;
- copies défensives des listes/replis fournis par l'appelant ;
- suppression des drapeaux d'alignement redondants lorsque `wx.EXPAND` est demandé ;
- ajout de contrats ciblés, sans dépendance à une base réelle.

## Provenance

**HISTORIQUE_UPSTREAM — confirmé.** Les motifs fautifs sont attestés dans le dépôt upstream `Noethys/Noethys`. Cette qualification décrit uniquement la provenance du code dans l'historique du projet Noethys ; elle n'attribue pas le défaut à une personne. Les corrections sont candidates à un retour upstream indépendant de Repens.

## Validation

La CI rapide avait validé le premier lot ; une nouvelle exécution doit maintenant valider également le correctif `UTILS_Texte`. Aucune recette métier manuelle n'est requise pour démontrer ces défauts.