### PR TITLE
Vanilla+ — isoler les collecteurs d’enfants des arbres

### DIFF
--- a/noethys/Ctrl/CTRL_Etiquettes.py
+++ b/noethys/Ctrl/CTRL_Etiquettes.py
@@ -380,7 +380,9 @@ class CTRL(CT.CustomTreeCtrl):
         self.MAJ()
         self.SetID(IDetiquette)
     
-    def GetItemsEnfants(self, liste=[], item=None, recursif=True):
+    def GetItemsEnfants(self, liste=None, item=None, recursif=True):
+        if liste is None:
+            liste = []
         itemTemp, cookie = self.GetFirstChild(item)
         for index in range(0, self.GetChildrenCount(item, recursively=False)) :
             dictDataTemp = self.GetPyData(itemTemp)

--- a/noethys/Ctrl/CTRL_Evenements.py
+++ b/noethys/Ctrl/CTRL_Evenements.py
@@ -291,7 +291,9 @@ class CTRL(CT.CustomTreeCtrl):
             
         dlg.Destroy()
 
-    def GetItemsEnfants(self, liste=[], item=None, recursif=True):
+    def GetItemsEnfants(self, liste=None, item=None, recursif=True):
+        if liste is None:
+            liste = []
         itemTemp, cookie = self.GetFirstChild(item)
         for index in range(0, self.GetChildrenCount(item, recursively=False)) :
             dictDataTemp = self.GetPyData(itemTemp)

--- a/noethys/Ctrl/CTRL_Portail_pages.py
+++ b/noethys/Ctrl/CTRL_Portail_pages.py
@@ -332,7 +332,9 @@ class CTRL(wx.TreeCtrl):
                 self.MemoriseDateModification()
             dlg.Destroy()
 
-    def GetItemsEnfants(self, liste=[], item=None, recursif=True):
+    def GetItemsEnfants(self, liste=None, item=None, recursif=True):
+        if liste is None:
+            liste = []
         itemTemp, cookie = self.GetFirstChild(item)
         for index in range(0, self.GetChildrenCount(item, recursively=False)) :
             if 'phoenix' in wx.PlatformInfo:

--- a/tests/test_tree_items_mutable_default_contract.py
+++ b/tests/test_tree_items_mutable_default_contract.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+import ast
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FICHIERS = (
+    ROOT / "noethys" / "Ctrl" / "CTRL_Evenements.py",
+    ROOT / "noethys" / "Ctrl" / "CTRL_Etiquettes.py",
+    ROOT / "noethys" / "Ctrl" / "CTRL_Portail_pages.py",
+)
+
+
+def _get_items_enfants(path):
+    arbre = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    fonctions = [
+        noeud
+        for noeud in ast.walk(arbre)
+        if isinstance(noeud, ast.FunctionDef) and noeud.name == "GetItemsEnfants"
+    ]
+    assert len(fonctions) == 1
+    return fonctions[0]
+
+
+class TreeItemsMutableDefaultTests(unittest.TestCase):
+    def test_get_items_enfants_ne_conserve_pas_de_liste_dans_sa_signature(self):
+        for path in FICHIERS:
+            with self.subTest(path=path):
+                fonction = _get_items_enfants(path)
+                parametres = [argument.arg for argument in fonction.args.args]
+                defauts = [None] * (len(parametres) - len(fonction.args.defaults)) + list(fonction.args.defaults)
+                defaut_liste = dict(zip(parametres, defauts))["liste"]
+
+                self.assertIsInstance(defaut_liste, ast.Constant)
+                self.assertIsNone(defaut_liste.value)
+
+    def test_get_items_enfants_cree_une_liste_locale_si_elle_manque(self):
+        for path in FICHIERS:
+            with self.subTest(path=path):
+                fonction = _get_items_enfants(path)
+                premiere_instruction = fonction.body[0]
+
+                self.assertIsInstance(premiere_instruction, ast.If)
+                self.assertIsInstance(premiere_instruction.test, ast.Compare)
+                self.assertIsInstance(premiere_instruction.test.left, ast.Name)
+                self.assertEqual(premiere_instruction.test.left.id, "liste")
+                self.assertIsInstance(premiere_instruction.test.ops[0], ast.Is)
+                self.assertIsInstance(premiere_instruction.test.comparators[0], ast.Constant)
+                self.assertIsNone(premiere_instruction.test.comparators[0].value)
+
+                affectation = premiere_instruction.body[0]
+                self.assertIsInstance(affectation, ast.Assign)
+                self.assertIsInstance(affectation.targets[0], ast.Name)
+                self.assertEqual(affectation.targets[0].id, "liste")
+                self.assertIsInstance(affectation.value, ast.List)
+
+    def test_get_items_enfants_continue_de_muter_la_liste_fournie(self):
+        for path in FICHIERS:
+            with self.subTest(path=path):
+                fonction = _get_items_enfants(path)
+                appels_append = [
+                    noeud
+                    for noeud in ast.walk(fonction)
+                    if isinstance(noeud, ast.Call)
+                    and isinstance(noeud.func, ast.Attribute)
+                    and isinstance(noeud.func.value, ast.Name)
+                    and noeud.func.value.id == "liste"
+                    and noeud.func.attr == "append"
+                ]
+
+                self.assertTrue(appels_append)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Défaut\n\nLes trois variantes historiques de GetItemsEnfants(liste=[]) modifient récursivement une liste créée une seule fois à la définition de la méthode. Cette liste persiste donc entre appels qui omettent l’argument.\n\n## Correction\n\n- remplace le défaut mutable par None ;\n- crée une liste locale lorsque l’argument manque ;\n- conserve la mutation de la liste explicitement fournie et le parcours récursif existant.\n\n## Périmètre Vanilla+\n\nRobustesse Python uniquement, sans fonction métier ni changement d’interface visible. Le motif est attesté dans l’historique Noethys 2015–2018 (HISTORIQUE_UPSTREAM).\n\n## Vérifications\n\n- compilation Python des trois modules ;\n- 3 tests de contrat ciblés ;\n- audit sémantique : les trois signaux GetItemsEnfants ont disparu.