### PR TITLE
Vanilla+ — fermer les dialogues modaux restants de l’audit

### DIFF
--- a/noethys/Ctrl/CTRL_Editeur_email.py
+++ b/noethys/Ctrl/CTRL_Editeur_email.py
@@ -1062,6 +1062,7 @@ class CTRL(wx.Panel):
         sizer.Fit(dlg)
 
         dlg.ShowModal()
+        dlg.Destroy()
 
         handler.DeleteTemporaryImages()
 

--- a/noethys/Ctrl/CTRL_Timeline.py
+++ b/noethys/Ctrl/CTRL_Timeline.py
@@ -1911,6 +1911,7 @@ def _display_error_message(message, parent=None):
     """Display an error message in a modal dialog box"""
     dial = wx.MessageDialog(parent, message, "Error", wx.OK | wx.ICON_ERROR)
     dial.ShowModal()
+    dial.Destroy()
 
 
 def _ask_question(question, parent=None):

--- a/noethys/Dlg/DLG_Mailer.py
+++ b/noethys/Dlg/DLG_Mailer.py
@@ -572,7 +572,9 @@ class Dialog(wx.Dialog):
                 message += _(u"   - Ainsi que %d autres...\n") % (len(listeResultats) - affichageMax)
             message += _(u"\nSouhaitez-vous tout de même continuer l'envoi ?")
             dlgErreur = wx.MessageDialog(self, message, _(u"Anomalies"), wx.YES_NO|wx.NO_DEFAULT|wx.CANCEL|wx.ICON_EXCLAMATION)
-            if dlgErreur.ShowModal() == wx.ID_YES :
+            reponse = dlgErreur.ShowModal()
+            dlgErreur.Destroy()
+            if reponse == wx.ID_YES :
                 return True
             else :
                 return False

--- a/noethys/Dlg/DLG_Nbre_inscrits.py
+++ b/noethys/Dlg/DLG_Nbre_inscrits.py
@@ -448,6 +448,7 @@ class Panel(wx.Panel):
         from Dlg import DLG_Parametres_nbre_inscrits
         dlg = DLG_Parametres_nbre_inscrits.Dialog(self)
         reponse = dlg.ShowModal()
+        dlg.Destroy()
         if reponse == wx.ID_OK :
             self.ctrl_inscriptions.MAJ(forcerActualisation=True) 
         

--- a/noethys/Dlg/DLG_Nbre_inscrits_2.py
+++ b/noethys/Dlg/DLG_Nbre_inscrits_2.py
@@ -784,6 +784,7 @@ class Panel(wx.Panel):
         from Dlg import DLG_Parametres_nbre_inscrits
         dlg = DLG_Parametres_nbre_inscrits.Dialog(self)
         reponse = dlg.ShowModal()
+        dlg.Destroy()
         if reponse == wx.ID_OK :
             self.ctrl_inscriptions.MAJ(forcerActualisation=True) 
         

--- a/noethys/Noethys.py
+++ b/noethys/Noethys.py
@@ -3665,6 +3665,7 @@ class MainFrame(wx.Frame):
         fichier.close()
         dlg = wx.lib.dialogs.ScrolledMessageDialog(self, msg, _(u"Licence"), size=(500, 500))
         dlg.ShowModal()
+        dlg.Destroy()
 
     def On_propos_soutenir(self, event):
         """ A propos : Soutenir Noethys """

--- a/noethys/Utils/UTILS_Procedures.py
+++ b/noethys/Utils/UTILS_Procedures.py
@@ -1581,6 +1581,7 @@ def A9062():
         u"Modification du type d'un champ"), "")
     reponse = dlg.ShowModal()
     parametres = dlg.GetValue()
+    dlg.Destroy()
     if reponse != wx.ID_OK:
         return
     try:

--- a/tests/test_semantic_modal_destroy_contract.py
+++ b/tests/test_semantic_modal_destroy_contract.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+import ast
+import unittest
+from pathlib import Path
+
+from scripts import audit_semantic_traps
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CAS = (
+    ("Ctrl/CTRL_Editeur_email.py", "OnFileViewHTML", "dlg"),
+    ("Ctrl/CTRL_Timeline.py", "_display_error_message", "dial"),
+    ("Dlg/DLG_Mailer.py", "VerifieFusion", "dlgErreur"),
+    ("Dlg/DLG_Nbre_inscrits.py", "OnBoutonParametres", "dlg"),
+    ("Dlg/DLG_Nbre_inscrits_2.py", "OnBoutonParametres", "dlg"),
+    ("Noethys.py", "On_propos_licence", "dlg"),
+    ("Utils/UTILS_Procedures.py", "A9062", "dlg"),
+)
+
+
+def _fonction(path, nom):
+    arbre = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    fonctions = [
+        noeud
+        for noeud in ast.walk(arbre)
+        if isinstance(noeud, ast.FunctionDef) and noeud.name == nom
+    ]
+    if len(fonctions) != 1:
+        raise AssertionError("Fonction %s introuvable ou ambiguë dans %s" % (nom, path))
+    return fonctions[0]
+
+
+def _lignes_appel(fonction, variable, methode):
+    return sorted(
+        noeud.lineno
+        for noeud in ast.walk(fonction)
+        if isinstance(noeud, ast.Call)
+        and isinstance(noeud.func, ast.Attribute)
+        and noeud.func.attr == methode
+        and isinstance(noeud.func.value, ast.Name)
+        and noeud.func.value.id == variable
+    )
+
+
+class SemanticModalDestroyTests(unittest.TestCase):
+    def test_chaque_dialogue_modal_est_detruit_apres_affichage(self):
+        for chemin, nom_fonction, variable in CAS:
+            path = ROOT / "noethys" / chemin
+            with self.subTest(path=chemin, fonction=nom_fonction):
+                fonction = _fonction(path, nom_fonction)
+                affichages = _lignes_appel(fonction, variable, "ShowModal")
+                destructions = _lignes_appel(fonction, variable, "Destroy")
+
+                self.assertTrue(affichages)
+                self.assertTrue(destructions)
+                self.assertLess(affichages[-1], destructions[0])
+
+    def test_l_audit_semantique_ne_signale_plus_ces_dialogues(self):
+        for chemin, nom_fonction, variable in CAS:
+            path = ROOT / "noethys" / chemin
+            with self.subTest(path=chemin, fonction=nom_fonction):
+                signaux = [
+                    signal
+                    for signal in audit_semantic_traps.scan_file(path)
+                    if signal["kind"] == "modal_without_destroy"
+                    and signal["function"] == nom_fonction
+                    and signal["dialog"] == variable
+                ]
+
+                self.assertEqual(signaux, [])
+
+    def test_les_valeurs_utiles_sont_lues_avant_destruction(self):
+        cas = (
+            ("Dlg/DLG_Mailer.py", "VerifieFusion", "dlgErreur", "ShowModal"),
+            ("Utils/UTILS_Procedures.py", "A9062", "dlg", "GetValue"),
+        )
+        for chemin, nom_fonction, variable, methode_lecture in cas:
+            path = ROOT / "noethys" / chemin
+            with self.subTest(path=chemin, fonction=nom_fonction):
+                fonction = _fonction(path, nom_fonction)
+                lectures = _lignes_appel(fonction, variable, methode_lecture)
+                destructions = _lignes_appel(fonction, variable, "Destroy")
+
+                self.assertTrue(lectures)
+                self.assertTrue(destructions)
+                self.assertLess(lectures[-1], destructions[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Défaut\n\nSept dialogues créés puis affichés avec ShowModal() n’étaient jamais détruits : aperçu HTML, erreur Timeline, anomalie de fusion mail, paramètres des deux écrans d’inscrits, licence et procédure A9062. Les objets wx et leurs contrôles restaient donc retenus après fermeture.\n\n## Correction\n\n- ajoute Destroy() aux sept cycles de vie ;\n- lit la réponse ou la valeur avant destruction ;\n- détruit avant les retours anticipés dans VerifieFusion et A9062.\n\n## Périmètre Vanilla+\n\nRobustesse/cycle de vie wx uniquement, sans fonction métier. Les sept motifs sont attestés dans l’historique Noethys (HISTORIQUE_UPSTREAM).\n\n## Vérifications\n\n- compilation des sept modules ;\n- 3 contrats ciblés couvrant les sept fonctions ;\n- audit sémantique : modal_without_destroy passe de 7 à 0.