### PR TITLE
Vanilla+ — isoler les derniers paramètres partagés confirmés

### DIFF
--- a/noethys/Dlg/DLG_Saisie_transport.py
+++ b/noethys/Dlg/DLG_Saisie_transport.py
@@ -25,7 +25,11 @@ from Ctrl import CTRL_Saisie_date
 import GestionDB
 
 
-def MelangeDictionnaires(d1={}, d2={}):
+def MelangeDictionnaires(d1=None, d2=None):
+    if d1 is None:
+        d1 = {}
+    if d2 is None:
+        d2 = {}
     for key, value in d2.items() :
         d1[key] = value
     return d1

--- a/noethys/Utils/UTILS_Config.py
+++ b/noethys/Utils/UTILS_Config.py
@@ -236,8 +236,10 @@ def GetParametres(dictParametres={}):
 
 
 
-def SetParametres(dictParametres={}):
+def SetParametres(dictParametres=None):
     """ dictParametres = {nom : valeur, nom: valeur...} """
+    if dictParametres is None:
+        dictParametres = {}
     try :
         topWindow = wx.GetApp().GetTopWindow()
         nomWindow = topWindow.GetName()

--- a/noethys/Utils/UTILS_Parametres.py
+++ b/noethys/Utils/UTILS_Parametres.py
@@ -20,10 +20,12 @@ else:
     TYPE_COULEUR = wx._gdi.Colour
 
 
-def ParametresCategorie(mode="get", categorie="", dictParametres={}, nomFichier=""):
+def ParametresCategorie(mode="get", categorie="", dictParametres=None, nomFichier=""):
     """ Pour mémoriser ou récupérer des paramètres dans la base de données """
     """ Renseigner categorie et dictParametres obligatoirement !!!  (pour avoir les valeurs par défaut et deviner les types de valeur) """
     """ dictParametres = {nom:valeur, nom:valeur, ....} """
+    if dictParametres is None:
+        dictParametres = {}
     # Recherche du parametre
     DB = GestionDB.DB(nomFichier=nomFichier)
     
@@ -185,5 +187,3 @@ if __name__ == u"__main__":
     #print(ParametresCategorie(mode="get", categorie="parametres_grille_conso", dictParametres={"affiche_colonne_memo":True, "test":u"ça marche !"}, nomFichier=""))
     reponse = Parametres(mode="get", categorie="dlg_ouvertures", nom="afficher_tous_groupes", valeur=False)
     print(reponse, type(reponse))
-    
-    

--- a/tests/test_remaining_shared_defaults_contract.py
+++ b/tests/test_remaining_shared_defaults_contract.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+import ast
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _charger_fonction(chemin, nom, contexte=None):
+    path = ROOT / "noethys" / chemin
+    arbre = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    fonctions = [
+        noeud
+        for noeud in ast.walk(arbre)
+        if isinstance(noeud, ast.FunctionDef) and noeud.name == nom
+    ]
+    if len(fonctions) != 1:
+        raise AssertionError("Fonction %s introuvable ou ambiguë dans %s" % (nom, path))
+
+    module = ast.Module(body=[fonctions[0]], type_ignores=[])
+    ast.fix_missing_locations(module)
+    espace = {} if contexte is None else dict(contexte)
+    exec(compile(module, str(path), "exec"), espace)
+    return espace[nom]
+
+
+class _ConfigVide:
+    def SetItemsConfig(self, parametres):
+        self.parametres = parametres
+
+
+class _BaseEnEchec:
+    echec = 1
+
+
+class RemainingSharedDefaultsTests(unittest.TestCase):
+    def test_melange_dictionnaires_isole_les_appels_sans_destination(self):
+        fonction = _charger_fonction("Dlg/DLG_Saisie_transport.py", "MelangeDictionnaires")
+
+        premier = fonction(d2={"a": 1})
+        second = fonction(d2={"b": 2})
+
+        self.assertEqual(premier, {"a": 1})
+        self.assertEqual(second, {"b": 2})
+        self.assertIsNot(premier, second)
+
+    def test_melange_dictionnaires_continue_de_modifier_la_destination_fournie(self):
+        fonction = _charger_fonction("Dlg/DLG_Saisie_transport.py", "MelangeDictionnaires")
+        destination = {"a": 1}
+
+        resultat = fonction(destination, {"b": 2})
+
+        self.assertIs(resultat, destination)
+        self.assertEqual(destination, {"a": 1, "b": 2})
+
+    def test_set_parametres_ne_retourne_pas_un_dictionnaire_partage(self):
+        faux_wx = types.SimpleNamespace(GetApp=lambda: (_ for _ in ()).throw(RuntimeError()))
+        fonction = _charger_fonction(
+            "Utils/UTILS_Config.py",
+            "SetParametres",
+            {"wx": faux_wx, "FichierConfig": _ConfigVide},
+        )
+
+        premier = fonction()
+        premier["contamination"] = True
+        second = fonction()
+
+        self.assertEqual(second, {})
+        self.assertIsNot(premier, second)
+
+    def test_parametres_categorie_isole_le_repli_si_la_base_est_indisponible(self):
+        gestion_db = types.SimpleNamespace(DB=lambda nomFichier="": _BaseEnEchec())
+        fonction = _charger_fonction(
+            "Utils/UTILS_Parametres.py",
+            "ParametresCategorie",
+            {"GestionDB": gestion_db},
+        )
+
+        premier = fonction()
+        premier["contamination"] = True
+        second = fonction()
+
+        self.assertEqual(second, {})
+        self.assertIsNot(premier, second)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Défauts\n\nTrois paramètres mutables restaient réellement observables entre appels :\n\n- MelangeDictionnaires accumulait les clés lorsque la destination était omise ;\n- UTILS_Config.SetParametres retournait directement son dictionnaire par défaut ;\n- UTILS_Parametres.ParametresCategorie faisait de même lorsque la base était indisponible.\n\nUn appelant pouvait donc modifier la valeur reçue et contaminer un appel ultérieur.\n\n## Correction\n\nRemplacement des dictionnaires par défaut par None, puis création d’un dictionnaire local par appel. Le comportement avec un dictionnaire explicitement fourni est conservé.\n\n## Périmètre Vanilla+\n\nRobustesse Python uniquement, sans fonction métier. Les trois motifs sont attestés dans l’historique Noethys (HISTORIQUE_UPSTREAM).\n\n## Vérifications\n\n- 4 tests comportementaux ciblés ;\n- compilation des trois modules ;\n- disparition des trois signaux sémantiques ciblés (mutable_default_mutated / mutable_default_escape).