### PR TITLE
Vanilla+ — supprimer les pauses bloquantes des callbacks wx

### DIFF
--- a/noethys/Ctrl/CTRL_Portail_serveur.py
+++ b/noethys/Ctrl/CTRL_Portail_serveur.py
@@ -445,8 +445,7 @@ class Panel(wx.Panel):
 
     def OnClose(self, evt):
         self.serveur.Stop()
-        time.sleep(0.1)
-        self.Destroy()
+        wx.CallLater(100, self.Destroy)
 
     def OnDestroy(self, evt):
         self.serveur.Stop()

--- a/noethys/Dlg/DLG_Transfert_tables.py
+++ b/noethys/Dlg/DLG_Transfert_tables.py
@@ -18,7 +18,6 @@ import os
 from Ctrl import CTRL_Bandeau
 import GestionDB
 import wx.lib.filebrowsebutton as filebrowse
-import time
 
 
 class Dialog(wx.Dialog):
@@ -135,7 +134,6 @@ class Dialog(wx.Dialog):
         DB = GestionDB.DB() 
         for nomTable in listeTables :
             DB.Exportation_vers_base_defaut(nomTable=nomTable, nomFichierdefault=nomFichier)
-            time.sleep(1)
         DB.Close() 
         
         # Confirmation

--- a/noethys/Noethys.py
+++ b/noethys/Noethys.py
@@ -29,7 +29,6 @@ import codecs
 # except:
 #     pass
 
-from time import sleep 
 
 from Utils import UTILS_Linux
 if "linux" in sys.platform :
@@ -2853,7 +2852,6 @@ class MainFrame(wx.Frame):
         dlg.Destroy()
         if installation == True :
             self.Quitter(videRepertoiresTemp=False, sauvegardeAuto=False)
-            sleep(2)
             self.Destroy()
 
     def On_reglements_regler_facture(self, event):

--- a/tests/test_nonblocking_ui_callbacks_contract.py
+++ b/tests/test_nonblocking_ui_callbacks_contract.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+import ast
+import unittest
+from pathlib import Path
+
+from scripts import audit_semantic_traps
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CAS = (
+    ("Ctrl/CTRL_Portail_serveur.py", "OnClose"),
+    ("Dlg/DLG_Transfert_tables.py", "OnBoutonOk"),
+    ("Noethys.py", "On_outils_updater"),
+)
+
+
+def _fonction(path, nom):
+    arbre = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    fonctions = [
+        noeud
+        for noeud in ast.walk(arbre)
+        if isinstance(noeud, ast.FunctionDef) and noeud.name == nom
+    ]
+    if len(fonctions) != 1:
+        raise AssertionError("Fonction %s introuvable ou ambiguë dans %s" % (nom, path))
+    return fonctions[0]
+
+
+class NonBlockingUiCallbacksTests(unittest.TestCase):
+    def test_l_audit_ne_signale_plus_de_pause_dans_les_callbacks(self):
+        for chemin, nom_fonction in CAS:
+            path = ROOT / "noethys" / chemin
+            with self.subTest(path=chemin, fonction=nom_fonction):
+                signaux = [
+                    signal
+                    for signal in audit_semantic_traps.scan_file(path)
+                    if signal["kind"] == "blocking_sleep_ui_callback"
+                    and signal["function"] == nom_fonction
+                ]
+
+                self.assertEqual(signaux, [])
+
+    def test_la_fermeture_du_serveur_conserve_son_delai_sans_bloquer_wx(self):
+        path = ROOT / "noethys" / "Ctrl" / "CTRL_Portail_serveur.py"
+        fonction = _fonction(path, "OnClose")
+        appels = [
+            noeud
+            for noeud in ast.walk(fonction)
+            if isinstance(noeud, ast.Call)
+            and isinstance(noeud.func, ast.Attribute)
+            and isinstance(noeud.func.value, ast.Name)
+            and noeud.func.value.id == "wx"
+            and noeud.func.attr == "CallLater"
+        ]
+
+        self.assertEqual(len(appels), 1)
+        self.assertIsInstance(appels[0].args[0], ast.Constant)
+        self.assertEqual(appels[0].args[0].value, 100)
+        rappel = appels[0].args[1]
+        self.assertIsInstance(rappel, ast.Attribute)
+        self.assertIsInstance(rappel.value, ast.Name)
+        self.assertEqual(rappel.value.id, "self")
+        self.assertEqual(rappel.attr, "Destroy")
+
+    def test_le_transfert_reste_synchrone_sans_pause_artificielle(self):
+        path = ROOT / "noethys" / "Dlg" / "DLG_Transfert_tables.py"
+        fonction = _fonction(path, "OnBoutonOk")
+        exports = [
+            noeud
+            for noeud in ast.walk(fonction)
+            if isinstance(noeud, ast.Call)
+            and isinstance(noeud.func, ast.Attribute)
+            and noeud.func.attr == "Exportation_vers_base_defaut"
+        ]
+
+        self.assertEqual(len(exports), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Défauts\n\nTrois callbacks UI appelaient sleep sur le thread wx : fermeture du serveur portail, transfert de tables et fermeture après lancement de l’installeur. L’interface était gelée pendant ces délais, jusqu’à une seconde par table exportée.\n\n## Correction\n\n- conserve le délai de 100 ms du serveur portail avec wx.CallLater, sans bloquer la boucle d’événements ;\n- supprime la pause artificielle après chaque export SQLite, déjà synchrone et validé par commit() ;\n- supprime l’attente redondante après le retour du dialogue d’installation, qui avait déjà lancé l’installeur et attendu avant sa fermeture.\n\n## Périmètre Vanilla+\n\nRobustesse et compatibilité wx uniquement, sans fonction métier. Les trois motifs sont attestés dans l’historique Noethys (HISTORIQUE_UPSTREAM).\n\n## Vérifications\n\n- compilation des trois modules ;\n- 3 contrats ciblés ;\n- audit sémantique : locking_sleep_ui_callback passe de 3 à 0.