### PR TITLE
Vanilla+ — ajouter un repli aux types d’arrondi inconnus

### DIFF
--- a/noethys/Utils/UTILS_Dates.py
+++ b/noethys/Utils/UTILS_Dates.py
@@ -240,9 +240,7 @@ def CalculerArrondi(arrondi_type="duree", arrondi_delta=15, heure_debut=None, he
     :return: datetime.time
     """
     duree_reelle = SoustractionHeures(heure_fin, heure_debut)
-
-    if arrondi_type == None :
-        duree_arrondie = duree_reelle
+    duree_arrondie = duree_reelle
 
     if arrondi_type == "tranche_horaire" :
         heure_debut_temp = ArrondirTime(heure=heure_debut, delta_minutes=arrondi_delta, sens="inf")

--- a/tests/test_utils_dates_duration_contract.py
+++ b/tests/test_utils_dates_duration_contract.py
@@ -25,6 +25,24 @@ def _charger_heure_str_en_delta():
     return espace["HeureStrEnDelta"]
 
 
+def _charger_calculer_arrondi():
+    arbre = ast.parse(FICHIER.read_text(encoding="utf-8"), filename=str(FICHIER))
+    fonction = next(
+        noeud
+        for noeud in arbre.body
+        if isinstance(noeud, ast.FunctionDef) and noeud.name == "CalculerArrondi"
+    )
+    module = ast.Module(body=[fonction], type_ignores=[])
+    ast.fix_missing_locations(module)
+    espace = {
+        "SoustractionHeures": lambda heure_fin, heure_debut: datetime.timedelta(minutes=90),
+        "ArrondirTime": lambda **kwargs: kwargs["heure"],
+        "ArrondirDelta": lambda **kwargs: kwargs["duree"],
+    }
+    exec(compile(module, str(FICHIER), "exec"), espace)
+    return espace["CalculerArrondi"]
+
+
 class UtilsDatesDurationTests(unittest.TestCase):
     def test_les_formats_historiques_restent_acceptes(self):
         convertir = _charger_heure_str_en_delta()
@@ -47,6 +65,28 @@ class UtilsDatesDurationTests(unittest.TestCase):
             for signal in audit_branch_assignment_gaps.scan_file(FICHIER)
             if signal["function"] == "HeureStrEnDelta"
             and signal["name"] in {"heures", "minutes"}
+        ]
+
+        self.assertEqual(signaux, [])
+
+    def test_un_type_arrondi_inconnu_conserve_la_duree_reelle(self):
+        calculer = _charger_calculer_arrondi()
+
+        resultat = calculer(
+            arrondi_type="type_inconnu",
+            arrondi_delta=5,
+            heure_debut=datetime.time(8, 0),
+            heure_fin=datetime.time(9, 30),
+        )
+
+        self.assertEqual(resultat, datetime.timedelta(minutes=90))
+
+    def test_l_audit_ne_signale_plus_duree_arrondie_non_definie(self):
+        signaux = [
+            signal
+            for signal in audit_branch_assignment_gaps.scan_file(FICHIER)
+            if signal["function"] == "CalculerArrondi"
+            and signal["name"] == "duree_arrondie"
         ]
 
         self.assertEqual(signaux, [])


### PR DESCRIPTION
## Défaut\n\nUTILS_Dates.CalculerArrondi n’affectait duree_arrondie que pour None, 	ranche_horaire ou duree. Une valeur inconnue ou corrompue provoquait donc UnboundLocalError au retour.\n\n## Correction\n\nInitialise le résultat avec la durée réelle avant d’appliquer les deux arrondis connus. Le repli inconnu devient ainsi « aucun arrondi », sans modifier les chemins valides.\n\n## Périmètre Vanilla+\n\nBugfix Python historique, sans nouvelle fonction métier. Le motif est attesté upstream depuis 2015 (HISTORIQUE_UPSTREAM).\n\n## Vérifications\n\n- reproduction comportementale du type inconnu ;\n- 5 tests ciblés du module de durées ;\n- compilation ;\n- disparition du signal duree_arrondie dans l’audit de branches.