### PR TITLE
fix: fiabiliser les conversions utilitaires Python 3

### DIFF
--- a/noethys/Utils/UTILS_Dates.py
+++ b/noethys/Utils/UTILS_Dates.py
@@ -80,6 +80,8 @@ def HeuresEnDecimal(texteHeure="07:00"):
     """ Transforme une heure string ou datetime.time en entier de type 2075"""
     if texteHeure == None :
         return 0
+    heures = "0"
+    minutes = 0
     if type(texteHeure) == datetime.time :
         heures = str(texteHeure.hour)
         minutes = int(texteHeure.minute)

--- a/noethys/Utils/UTILS_Images.py
+++ b/noethys/Utils/UTILS_Images.py
@@ -76,7 +76,7 @@ def ConvertirToutesImagesPNG():
 def hex_to_rgb(value):
     value = value.lstrip('#')
     lv = len(value)
-    return tuple(int(value[i:i+lv/3], 16) for i in range(0, lv, lv/3))
+    return tuple(int(value[i:i+lv//3], 16) for i in range(0, lv, lv//3))
 
 def rgb_to_hex(value):
     return '#%02x%02x%02x' % (value[0], value[1], value[2])

--- a/tests/test_utils_dates_duration_contract.py
+++ b/tests/test_utils_dates_duration_contract.py
@@ -11,6 +11,20 @@ ROOT = Path(__file__).resolve().parents[1]
 FICHIER = ROOT / "noethys" / "Utils" / "UTILS_Dates.py"
 
 
+def _charger_heures_en_decimal():
+    arbre = ast.parse(FICHIER.read_text(encoding="utf-8"), filename=str(FICHIER))
+    fonction = next(
+        noeud
+        for noeud in arbre.body
+        if isinstance(noeud, ast.FunctionDef) and noeud.name == "HeuresEnDecimal"
+    )
+    module = ast.Module(body=[fonction], type_ignores=[])
+    ast.fix_missing_locations(module)
+    espace = {"datetime": datetime, "six": type("Six", (), {"text_type": str})}
+    exec(compile(module, str(FICHIER), "exec"), espace)
+    return espace["HeuresEnDecimal"]
+
+
 def _charger_heure_str_en_delta():
     arbre = ast.parse(FICHIER.read_text(encoding="utf-8"), filename=str(FICHIER))
     fonction = next(
@@ -44,6 +58,29 @@ def _charger_calculer_arrondi():
 
 
 class UtilsDatesDurationTests(unittest.TestCase):
+    def test_heures_en_decimal_conserve_les_formats_historiques(self):
+        convertir = _charger_heures_en_decimal()
+
+        self.assertEqual(convertir("07:00"), 700)
+        self.assertEqual(convertir("14:30"), 1450)
+        self.assertEqual(convertir(datetime.time(9, 15)), 925)
+
+    def test_heures_en_decimal_replie_un_type_inattendu_sur_zero(self):
+        convertir = _charger_heures_en_decimal()
+
+        self.assertEqual(convertir(None), 0)
+        self.assertEqual(convertir(object()), 0)
+
+    def test_l_audit_ne_signale_plus_heures_en_decimal(self):
+        signaux = [
+            signal
+            for signal in audit_branch_assignment_gaps.scan_file(FICHIER)
+            if signal["function"] == "HeuresEnDecimal"
+            and signal["name"] in {"heures", "minutes"}
+        ]
+
+        self.assertEqual(signaux, [])
+
     def test_les_formats_historiques_restent_acceptes(self):
         convertir = _charger_heure_str_en_delta()
 

--- a/tests/test_utils_images_conversion_contract.py
+++ b/tests/test_utils_images_conversion_contract.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+import ast
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FICHIER = ROOT / "noethys" / "Utils" / "UTILS_Images.py"
+
+
+def _charger_hex_to_rgb():
+    arbre = ast.parse(FICHIER.read_text(encoding="utf-8"), filename=str(FICHIER))
+    fonction = next(
+        noeud
+        for noeud in arbre.body
+        if isinstance(noeud, ast.FunctionDef) and noeud.name == "hex_to_rgb"
+    )
+    module = ast.Module(body=[fonction], type_ignores=[])
+    ast.fix_missing_locations(module)
+    espace = {}
+    exec(compile(module, str(FICHIER), "exec"), espace)
+    return espace["hex_to_rgb"]
+
+
+class UtilsImagesConversionTests(unittest.TestCase):
+    def test_hex_to_rgb_fonctionne_sous_python_3(self):
+        convertir = _charger_hex_to_rgb()
+
+        self.assertEqual(convertir("#336699"), (51, 102, 153))
+        self.assertEqual(convertir("FFFFFF"), (255, 255, 255))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Résumé : corrige le pas de range flottant de hex_to_rgb sous Python 3 et initialise le repli de HeuresEnDecimal pour les types inattendus. Tests ciblés couvrant les formats historiques, les replis et le signal d'audit. Doctrine Vanilla+ : compatibilité Python 3 et robustesse uniquement, sans évolution métier.