### PR TITLE
fix: filtrer les événements iCalendar pertinents

### DIFF
--- a/noethys/Utils/UTILS_Icalendar.py
+++ b/noethys/Utils/UTILS_Icalendar.py
@@ -71,11 +71,12 @@ class Calendrier():
             (_(u"printemps"), _(u"Pâques")),
             (_(u"Toussaint"), _(u"Toussaint")),
             (_(u"Noël"), _(u"Noël")),
-            ]
+        ]
 
         for nomOriginal, nomFinal in listeCorrespondances :
             for dictEvent in listeEvents :
-                if nomOriginal in dictEvent["description"] :
+                description = dictEvent.get("description") or u""
+                if nomOriginal in description :
                     if dictEvent["date_debut"] != None and dictEvent["date_fin"] != None :
                         annee = dictEvent["date_debut"].year
                         date_debut = dictEvent["date_debut"]
@@ -85,14 +86,16 @@ class Calendrier():
         # Recherche les grandes vacances
         dictTemp = {}
         for dictEvent in listeEvents :
-            if u"élèves" or u"été" in dictEvent["description"] :
-                annee = dictEvent["date_debut"].year
+            description = dictEvent.get("description") or u""
+            date_debut = dictEvent.get("date_debut")
+            if (u"élèves" in description or u"été" in description) and date_debut != None :
+                annee = date_debut.year
                 if (annee in dictTemp) == False :
                     dictTemp[annee] = {"date_debut" : None, "date_fin" : None}
-                if u"été" in dictEvent["description"] :
-                    dictTemp[annee]["date_debut"] = dictEvent["date_debut"] + datetime.timedelta(days=1)
-                if u"élèves" in dictEvent["description"] :
-                    dictTemp[annee]["date_fin"] = dictEvent["date_debut"] - datetime.timedelta(days=1)
+                if u"été" in description :
+                    dictTemp[annee]["date_debut"] = date_debut + datetime.timedelta(days=1)
+                if u"élèves" in description :
+                    dictTemp[annee]["date_fin"] = date_debut - datetime.timedelta(days=1)
 
         for annee, dictDates in dictTemp.items() :
             if dictDates["date_debut"] != None and dictDates["date_fin"] != None :
@@ -118,4 +121,3 @@ if __name__ == "__main__":
 ##        print event
     for x in cal.GetVacances() :
         print(x)
-        

--- a/tests/test_utils_icalendar_contract.py
+++ b/tests/test_utils_icalendar_contract.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+import ast
+import datetime
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FICHIER = ROOT / "noethys" / "Utils" / "UTILS_Icalendar.py"
+
+
+def _charger_get_vacances():
+    arbre = ast.parse(FICHIER.read_text(encoding="utf-8"), filename=str(FICHIER))
+    classe = next(
+        noeud
+        for noeud in arbre.body
+        if isinstance(noeud, ast.ClassDef) and noeud.name == "Calendrier"
+    )
+    fonction = next(
+        noeud
+        for noeud in classe.body
+        if isinstance(noeud, ast.FunctionDef) and noeud.name == "GetVacances"
+    )
+    module = ast.Module(body=[fonction], type_ignores=[])
+    ast.fix_missing_locations(module)
+    espace = {
+        "_": lambda texte: texte,
+        "datetime": datetime,
+        "six": types.SimpleNamespace(PY2=False),
+    }
+    exec(compile(module, str(FICHIER), "exec"), espace)
+    return espace["GetVacances"]
+
+
+class FauxCalendrier:
+    def __init__(self, evenements):
+        self.evenements = evenements
+
+    def GetEvents(self):
+        return self.evenements
+
+
+class UtilsIcalendarTests(unittest.TestCase):
+    def test_un_evenement_sans_rapport_est_ignore(self):
+        get_vacances = _charger_get_vacances()
+        calendrier = FauxCalendrier([
+            {
+                "description": "Réunion pédagogique",
+                "date_debut": None,
+                "date_fin": None,
+            },
+        ])
+
+        self.assertEqual(get_vacances(calendrier), [])
+
+    def test_un_evenement_incomplet_est_ignore(self):
+        get_vacances = _charger_get_vacances()
+        calendrier = FauxCalendrier([
+            {"description": None, "date_debut": None, "date_fin": None},
+            {"description": "Vacances d'été", "date_debut": None, "date_fin": None},
+        ])
+
+        self.assertEqual(get_vacances(calendrier), [])
+
+    def test_les_bornes_des_grandes_vacances_restent_extraites(self):
+        get_vacances = _charger_get_vacances()
+        calendrier = FauxCalendrier([
+            {
+                "description": "Vacances d'été",
+                "date_debut": datetime.date(2026, 7, 4),
+                "date_fin": datetime.date(2026, 7, 5),
+            },
+            {
+                "description": "Rentrée des élèves",
+                "date_debut": datetime.date(2026, 9, 1),
+                "date_fin": datetime.date(2026, 9, 2),
+            },
+        ])
+
+        self.assertEqual(
+            get_vacances(calendrier),
+            [{
+                "annee": 2026,
+                "nom": "Eté",
+                "date_debut": datetime.date(2026, 7, 5),
+                "date_fin": datetime.date(2026, 8, 31),
+            }],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Résumé : corrige une condition toujours vraie dans l'extraction des grandes vacances. Les événements sans rapport sont désormais ignorés au lieu d'être interprétés comme des bornes de vacances, tout en conservant l'extraction historique des dates d'été. Défaut issu de l'historique upstream. Doctrine Vanilla+ : bugfix pur, sans évolution métier. Tests : py -3.9 -m unittest tests.test_utils_icalendar_contract -v ; compilation ciblée ; git diff --check.