### PR TITLE
Vanilla+ — éviter le crash sur un format PES inconnu

### DIFF
--- a/noethys/Ol/OL_Lots_pes.py
+++ b/noethys/Ol/OL_Lots_pes.py
@@ -286,6 +286,7 @@ class ListView(FastObjectListView):
             else:
                 dlg.Destroy()
                 return False, False
+        classe = None
         if format == "pes":
             classe = DLG_Saisie_lot_tresor_public_pes.Dialog
         if format == "magnus":
@@ -294,6 +295,8 @@ class ListView(FastObjectListView):
             classe = DLG_Saisie_lot_tresor_public_jvs.Dialog
         if format == "corail":
             classe = DLG_Saisie_lot_tresor_public_corail.Dialog
+        if classe is None:
+            return False, False
         return (format, classe)
 
 # -------------------------------------------------------------------------------------------------------------------------------------------

--- a/tests/test_lots_pes_format_fallback_contract.py
+++ b/tests/test_lots_pes_format_fallback_contract.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+from scripts import audit_branch_assignment_gaps
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FICHIER = ROOT / "noethys" / "Ol" / "OL_Lots_pes.py"
+
+
+def _charger_get_classe():
+    source = FICHIER.read_text(encoding="utf-8")
+    arbre = ast.parse(source)
+    fonction = None
+    for noeud in arbre.body:
+        if isinstance(noeud, ast.ClassDef) and noeud.name == "ListView":
+            for membre in noeud.body:
+                if isinstance(membre, ast.FunctionDef) and membre.name == "Get_classe":
+                    fonction = membre
+                    break
+    assert fonction is not None
+
+    marqueurs = {
+        "pes": object(),
+        "magnus": object(),
+        "jvs": object(),
+        "corail": object(),
+    }
+    espace = {
+        "DLG_Saisie_lot_tresor_public_pes": SimpleNamespace(Dialog=marqueurs["pes"]),
+        "DLG_Saisie_lot_tresor_public_magnus": SimpleNamespace(Dialog=marqueurs["magnus"]),
+        "DLG_Saisie_lot_tresor_public_jvs": SimpleNamespace(Dialog=marqueurs["jvs"]),
+        "DLG_Saisie_lot_tresor_public_corail": SimpleNamespace(Dialog=marqueurs["corail"]),
+    }
+    module = ast.Module(body=[fonction], type_ignores=[])
+    ast.fix_missing_locations(module)
+    exec(compile(module, str(FICHIER), "exec"), espace)
+    return espace["Get_classe"], marqueurs
+
+
+def test_get_classe_conserve_les_quatre_formats_connus():
+    get_classe, marqueurs = _charger_get_classe()
+    for code, classe in marqueurs.items():
+        assert get_classe(None, code) == (code, classe)
+
+
+def test_get_classe_refuse_proprement_un_format_inconnu():
+    get_classe, _ = _charger_get_classe()
+    assert get_classe(None, "format-inconnu") == (False, False)
+
+
+def test_get_classe_ne_presente_plus_de_variable_classe_non_initialisee():
+    findings = audit_branch_assignment_gaps.scan_file(FICHIER)
+    assert not any(
+        item["function"] == "Get_classe" and item["name"] == "classe"
+        for item in findings
+    )


### PR DESCRIPTION
## Défaut

`OL_Lots_pes.ListView.Get_classe()` n'initialisait `classe` que pour quatre codes connus (`pes`, `magnus`, `jvs`, `corail`). Si un lot stocké en base contient un code inconnu, l'écran peut l'afficher via le repli de `GetFormatByCode()`, mais l'ouverture/modification du lot termine ensuite sur une variable locale `classe` non définie.

## Correction

- initialise explicitement `classe` ;
- retourne `(False, False)` pour un format non pris en charge, comme lors de l'annulation du choix de format ;
- conserve strictement les quatre mappings historiques ;
- ajoute trois contrats ciblés, dont l'exécution isolée de `Get_classe()` sans importer wx.

## Provenance

**HISTORIQUE_UPSTREAM — confirmé.** Le même motif est présent dans `Noethys/Noethys` dans `noethys/Ol/OL_Lots_pes.py`.

## Périmètre Vanilla+

Bugfix de robustesse uniquement : aucune nouvelle fonction métier, aucun changement de schéma ni de format de données. Le correctif évite un crash sur une valeur de format inconnue/corrompue au lieu de tenter d'ouvrir un dialogue non déterminé.

## Validation attendue

- CI rapide ;
- test des quatre formats connus ;
- test du repli inconnu ;
- disparition du signal `branch_assignment_gap` pour `Get_classe/classe`.

Relates #99 et #97.