### PR TITLE
Audit Vanilla+ — réduire les faux positifs d’affectation

### DIFF
--- a/scripts/audit_branch_assignment_gaps.py
+++ b/scripts/audit_branch_assignment_gaps.py
@@ -105,6 +105,18 @@ def direct_definitions(statement):
     return set()
 
 
+def direct_definitions_in_sequence(statements):
+    """Noms définis par des instructions inconditionnelles du bloc courant.
+
+    On ne descend volontairement pas dans les ``if``/boucles/``try`` imbriqués :
+    leur exécution ne garantit pas qu'un nom existe à la sortie du bloc.
+    """
+    result = set()
+    for statement in statements:
+        result.update(direct_definitions(statement))
+    return result
+
+
 def block_terminates(statements):
     if not statements:
         return False
@@ -172,6 +184,14 @@ def scan_sequence(statements, predefined, relpath, function_name, findings):
 
             scan_sequence(statement.body, defined, relpath, function_name, findings)
             scan_sequence(statement.orelse, defined, relpath, function_name, findings)
+
+            # Si les deux branches affectent directement un nom, celui-ci est
+            # garanti pour les instructions suivantes. Sans cette propagation,
+            # un second ``if`` qui réaffecte ce nom était signalé à tort.
+            if statement.orelse:
+                body_defined = direct_definitions_in_sequence(statement.body)
+                else_defined = direct_definitions_in_sequence(statement.orelse)
+                defined.update(body_defined & else_defined)
 
         elif isinstance(statement, (ast.For, ast.AsyncFor)):
             loop_defined = defined | target_names(statement.target)

--- a/tests/test_branch_assignment_gaps_audit.py
+++ b/tests/test_branch_assignment_gaps_audit.py
@@ -60,6 +60,35 @@ class BranchAssignmentGapTests(unittest.TestCase):
         ''')
         self.assertEqual(report["count"], 0)
 
+    def test_assignment_in_both_branches_is_propagated_to_following_if(self):
+        report = self.report_for('''
+            def f(flag, other):
+                if flag:
+                    value = 1
+                else:
+                    value = 2
+                if other:
+                    value = 3
+                return value
+        ''')
+        self.assertEqual(report["count"], 0)
+
+    def test_nested_conditional_assignment_is_not_treated_as_guaranteed(self):
+        report = self.report_for('''
+            def f(flag, nested, other):
+                if flag:
+                    if nested:
+                        value = 1
+                else:
+                    value = 2
+                if other:
+                    value = 3
+                return value
+        ''')
+        # Le premier if reste trop complexe pour être qualifié ici, mais il ne
+        # doit surtout pas faire considérer ``value`` comme garanti ensuite.
+        self.assertTrue(any(item["name"] == "value" for item in report["findings"]))
+
     def test_repository_inventory_is_exported(self):
         report = audit.build_report()
         output = Path("tmp/branch-assignment-audit.json")


### PR DESCRIPTION
## Problème

L’audit `branch_assignment_gap` ne mémorisait pas qu’un nom affecté directement dans les deux branches d’un `if/else` est garanti après ce bloc. Un second `if` réaffectant ce même nom pouvait alors être signalé à tort.

Exemple :

```python
if flag:
    value = 1
else:
    value = 2
if other:
    value = 3
return value
```

`value` est défini sur tous les chemins, mais l’inventaire le considérait encore comme potentiellement absent.

## Correction

- propage uniquement l’intersection des **affectations directes** des deux branches ;
- ne descend pas dans les conditions, boucles ou `try` imbriqués pour éviter de transformer une affectation conditionnelle en garantie ;
- conserve la détection des affectations réellement unilatérales ;
- ajoute deux tests : cas garanti et garde contre la propagation d’une affectation imbriquée.

## Périmètre Vanilla+

Aucun runtime Noethys n’est modifié. Cette amélioration rend l’audit plus exploitable pour la phase de gel Vanilla+ 1.0 et évite des corrections opportunistes sur des faux positifs.

Relates #99 et #97.