### PR TITLE
Audit Vanilla+ — reconnaître les affectations garanties des try

### DIFF
--- a/scripts/audit_branch_assignment_gaps.py
+++ b/scripts/audit_branch_assignment_gaps.py
@@ -219,6 +219,21 @@ def scan_sequence(statements, predefined, relpath, function_name, findings):
             scan_sequence(statement.orelse, defined, relpath, function_name, findings)
             scan_sequence(statement.finalbody, defined, relpath, function_name, findings)
 
+            # Si chaque chemin d'exception quitte le bloc courant, continuer
+            # après le ``try`` implique que son corps (et son ``else`` éventuel)
+            # s'est terminé normalement. Leurs affectations directes sont donc
+            # disponibles pour les contrôles suivants.
+            handlers_terminate = not statement.handlers or all(
+                block_terminates(handler.body) for handler in statement.handlers
+            )
+            if handlers_terminate:
+                defined.update(direct_definitions_in_sequence(statement.body))
+                defined.update(direct_definitions_in_sequence(statement.orelse))
+
+            # Un ``finally`` exécuté jusqu'au bout l'est sur tout chemin qui
+            # continue après le ``try``.
+            defined.update(direct_definitions_in_sequence(statement.finalbody))
+
         defined.update(direct_definitions(statement))
 
 

--- a/tests/test_branch_assignment_gaps_audit.py
+++ b/tests/test_branch_assignment_gaps_audit.py
@@ -89,6 +89,45 @@ class BranchAssignmentGapTests(unittest.TestCase):
         # doit surtout pas faire considérer ``value`` comme garanti ensuite.
         self.assertTrue(any(item["name"] == "value" for item in report["findings"]))
 
+    def test_try_assignment_with_terminating_handler_is_propagated(self):
+        report = self.report_for('''
+            def f(flag):
+                try:
+                    value = operation()
+                except Exception:
+                    return None
+                if flag:
+                    value = 2
+                return value
+        ''')
+        self.assertEqual(report["count"], 0)
+
+    def test_try_assignment_with_non_terminating_handler_is_not_guaranteed(self):
+        report = self.report_for('''
+            def f(flag):
+                try:
+                    value = operation()
+                except Exception:
+                    pass
+                if flag:
+                    value = 2
+                return value
+        ''')
+        self.assertTrue(any(item["name"] == "value" for item in report["findings"]))
+
+    def test_finally_assignment_is_guaranteed_on_continuing_paths(self):
+        report = self.report_for('''
+            def f(flag):
+                try:
+                    operation()
+                finally:
+                    value = 1
+                if flag:
+                    value = 2
+                return value
+        ''')
+        self.assertEqual(report["count"], 0)
+
     def test_repository_inventory_is_exported(self):
         report = audit.build_report()
         output = Path("tmp/branch-assignment-audit.json")


### PR DESCRIPTION
## Problème

L’audit `branch_assignment_gap` ne propageait aucune définition issue d’un `try`. Il pouvait donc signaler à tort un nom pourtant garanti lorsqu’un `except` quitte immédiatement la fonction.

Cas typique déjà rencontré dans Noethys :

```python
try:
    html = urlopen(...).read()
except Exception:
    return False
if six.PY3:
    html = html.decode("utf8")
```

Sur tout chemin qui atteint le second `if`, `html` est nécessairement défini.

## Correction

- propage les affectations directes du corps du `try` lorsque tous les handlers terminent (`return`, `raise`, etc.) ;
- propage également les affectations directes d’un `finally`, exécuté sur tout chemin qui continue ;
- ne propage rien depuis un `try` dont un handler peut continuer sans avoir défini le nom ;
- ajoute trois contrats ciblés.

## Périmètre Vanilla+

Aucun code métier/runtime n’est modifié. Le but est d’abaisser le bruit de l’inventaire avant de qualifier les prochains bugs de Vanilla+ 1.0.

Relates #99 et #97.