### PR TITLE
Vanilla+ — sécuriser les reçus de dons aux œuvres

### DIFF
--- a/noethys/Dlg/DLG_Impression_don_oeuvres.py
+++ b/noethys/Dlg/DLG_Impression_don_oeuvres.py
@@ -94,11 +94,12 @@ class Choix_donateur(wx.Choice):
             nomTitulaires = _(u"%s et %s") % (listeTitulaires[0][1], listeTitulaires[1][1])
         if nbreTitulaires > 2 :
             nomTitulaires = ""
-            for IDindividu, nomTitulaire in listeTitulaires[:-2] :
+            for IDindividu, nomTitulaire in listeTitulaires[:-1] :
                 nomTitulaires += u"%s, " % nomTitulaire
             nomTitulaires += listeTitulaires[-1][1]
         self.listeNoms.append(nomTitulaires)
-        self.dictDonnees[0] = IDindividu
+        if nbreTitulaires > 0:
+            self.dictDonnees[0] = listeTitulaires[-1][0]
         
         index = 1
         for IDindividu, nomTitulaire in listeTitulaires :
@@ -713,7 +714,7 @@ class Impression():
         if dictDonnees["date_edition"] != u"" : 
             date_edition = _(u"Le %s") % dictDonnees["date_edition"]
         else:
-            dictDonnees["date_edition"] = u""
+            date_edition = u""
         
         txt110 = Paragraph(u"""
         <para align=right rightIndent=50>

--- a/tests/test_dons_oeuvres_fallback_contract.py
+++ b/tests/test_dons_oeuvres_fallback_contract.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FICHIER = ROOT / "noethys" / "Dlg" / "DLG_Impression_don_oeuvres.py"
+
+
+def _source_et_arbre():
+    source = FICHIER.read_text(encoding="utf-8")
+    return source, ast.parse(source)
+
+
+def _methode(arbre, classe, methode):
+    for noeud in arbre.body:
+        if isinstance(noeud, ast.ClassDef) and noeud.name == classe:
+            for membre in noeud.body:
+                if isinstance(membre, ast.FunctionDef) and membre.name == methode:
+                    return membre
+    raise AssertionError(f"{classe}.{methode} introuvable")
+
+
+def _est_cible_date_edition(cible):
+    return isinstance(cible, ast.Name) and cible.id == "date_edition"
+
+
+def test_aucun_titulaire_ne_reutilise_pas_un_idindividu_inexistant():
+    source, _ = _source_et_arbre()
+    assert "self.dictDonnees[0] = IDindividu" not in source
+    assert "if nbreTitulaires > 0:" in source
+    assert "self.dictDonnees[0] = listeTitulaires[-1][0]" in source
+
+
+def test_nom_collectif_conserve_tous_les_titulaires():
+    source, _ = _source_et_arbre()
+    assert "listeTitulaires[:-2]" not in source
+    assert "listeTitulaires[:-1]" in source
+
+
+def test_date_edition_est_definie_dans_les_deux_branches():
+    _, arbre = _source_et_arbre()
+    constructeur = _methode(arbre, "Impression", "__init__")
+
+    candidat = None
+    for noeud in ast.walk(constructeur):
+        if not isinstance(noeud, ast.If):
+            continue
+        test = ast.unparse(noeud.test)
+        if "dictDonnees['date_edition']" in test or 'dictDonnees["date_edition"]' in test:
+            candidat = noeud
+            break
+
+    assert candidat is not None
+    assert any(
+        isinstance(stmt, ast.Assign)
+        and any(_est_cible_date_edition(cible) for cible in stmt.targets)
+        for stmt in candidat.body
+    )
+    assert any(
+        isinstance(stmt, ast.Assign)
+        and any(_est_cible_date_edition(cible) for cible in stmt.targets)
+        for stmt in candidat.orelse
+    )
+
+
+def test_repli_date_edition_ne_modifie_pas_le_dictionnaire_appelant():
+    source, _ = _source_et_arbre()
+    assert 'dictDonnees["date_edition"] = u""' not in source


### PR DESCRIPTION
## Défauts corrigés

Trois défauts indépendants sont présents dans l’édition historique des reçus de dons :

1. **Aucun titulaire** : `Choix_donateur.SetListeDonnees()` réutilisait `IDindividu` après une boucle qui peut ne jamais s’exécuter. Une famille sans titulaire pouvait donc provoquer un `UnboundLocalError`.
2. **Trois titulaires ou plus** : la construction du libellé parcourait `listeTitulaires[:-2]` puis ajoutait uniquement le dernier élément, ce qui supprimait silencieusement l’avant-dernier titulaire du libellé collectif.
3. **Date d’édition vide** : `Impression.__init__()` utilisait la variable locale `date_edition` sans l’avoir définie dans le chemin où la date est vide, ce qui pouvait interrompre la génération du PDF.

## Correction

- ne crée le mapping du titulaire automatique que lorsqu’un titulaire existe ;
- utilise explicitement le dernier ID de `listeTitulaires` au lieu d’une variable de boucle résiduelle ;
- conserve tous les titulaires dans le libellé collectif (`[:-1]` + dernier élément) ;
- définit `date_edition` à chaîne vide dans le chemin vide, sans modifier le dictionnaire d’entrée ;
- ajoute quatre contrats statiques ciblés.

## Provenance

**HISTORIQUE_UPSTREAM — confirmé.** Les trois motifs sont présents dans `Noethys/Noethys`, fichier `noethys/Dlg/DLG_Impression_don_oeuvres.py`.

Cette qualification décrit uniquement la provenance du code dans l’historique du projet.

## Périmètre Vanilla+

Bugfix/robustesse uniquement. Aucun changement de schéma, aucune nouvelle fonction métier, aucun changement du format des reçus hors correction du nom collectif incomplet.

Relates #99 et #97.