### PR TITLE
Docs — figer la séparation Vanilla / Upgrade

### DIFF
--- a/docs/governance/DECISIONS.md
+++ b/docs/governance/DECISIONS.md
@@ -1,0 +1,47 @@
+# Journal des décisions de gouvernance
+
+Ce fichier conserve les décisions qui changent le périmètre des branches ou la manière de développer Noethys. Il doit être mis à jour lorsqu'une décision durable est prise afin qu'elle ne reste pas uniquement dans une conversation.
+
+## 25 août 2026 — séparation stricte Vanilla / Upgrade
+
+### Décision
+
+Le terme **Vanilla** désigne désormais exclusivement la version historique issue du projet original Noethys, maintenue sans migration Python 3, sans wxPython Phoenix, sans nouvel UX et sans nouvelle fonction métier.
+
+Une branche permanente est créée :
+
+`maintenance/vanilla`
+
+Point de départ :
+
+`630ef4373dbc05dae1cbc597b9baccb1178e64e4`
+
+Le `master` actuel conserve le chantier de modernisation et doit être désigné comme **Upgrade**.
+
+### Motif
+
+L'exploitation quotidienne ne doit pas dépendre de l'achèvement du portage Python 3, de Phoenix ou de la refonte UI. La version historique fonctionne déjà en production ; l'objectif immédiat est donc de la maintenir et d'y apporter des correctifs ciblés sans modifier son identité technique ou graphique.
+
+### Conséquences
+
+- les correctifs de bugs historiques doivent pouvoir être backportés vers `maintenance/vanilla` ;
+- les changements Python 3 / Phoenix / UI restent dans Upgrade ;
+- aucune fusion globale de `master` vers Vanilla ;
+- compatibilité avec les bases existantes et le Connecthys actuellement exploité considérée comme contrainte prioritaire de Vanilla ;
+- les travaux Vanilla doivent être testables indépendamment de l'avancement d'Upgrade ;
+- les termes « Vanilla+ » ou « Vanilla modernisée » ne doivent plus être utilisés pour désigner `master`, car ils créent une ambiguïté de produit.
+
+### Priorité
+
+Le prochain jalon opérationnel est une première Vanilla maintenue et testable dans l'environnement d'exploitation actuel, avant toute dépendance à la finalisation du chantier Upgrade.
+
+## Modèle pour les prochaines décisions
+
+Ajouter une entrée avec :
+
+- date ;
+- décision ;
+- motif ;
+- branches ou composants concernés ;
+- compatibilité / migration éventuelle ;
+- conséquence sur la roadmap et les issues.

--- a/docs/governance/PROJECT_STRATEGY.md
+++ b/docs/governance/PROJECT_STRATEGY.md
@@ -1,0 +1,118 @@
+# Stratégie de branches — Vanilla et Upgrade
+
+> Décision de gouvernance du 25 août 2026. Ce document prime sur les anciennes formulations qui appelaient « Vanilla+ » la branche Python 3 / wxPython Phoenix.
+
+## 1. Deux lignes de produit distinctes
+
+Le dépôt `fr4nck/Noethys` porte désormais deux objectifs qui ne doivent plus être mélangés.
+
+### Vanilla — maintenance de la version originale
+
+La branche canonique est :
+
+`maintenance/vanilla`
+
+Elle part du snapshot upstream `Noethys/Noethys` au commit :
+
+`630ef4373dbc05dae1cbc597b9baccb1178e64e4`
+
+Vanilla désigne la version historique distribuée par le projet Noethys original. Son but n'est pas de moderniser le logiciel, mais de maintenir une version exploitable et familière pour les utilisateurs actuels.
+
+Sont autorisés sur Vanilla :
+
+- correction d'un bug démontré ;
+- correction de robustesse ou de sécurité strictement compatible ;
+- correctif de compatibilité nécessaire au fonctionnement de la version historique ;
+- tests et outils d'audit n'imposant pas une migration du runtime applicatif ;
+- documentation d'installation, de sauvegarde, de recette et de maintenance ;
+- packaging ou scripts d'exploitation qui ne modifient pas le comportement métier historique.
+
+Sont exclus de Vanilla sauf décision explicite ultérieure :
+
+- migration Python 3 ;
+- migration wxPython Phoenix ;
+- nouveau moteur de thème ou nouvelle UX ;
+- refonte graphique ;
+- nouvelles fonctions métier ;
+- changement de schéma de base de données ;
+- refactoring massif sans bug démontré ;
+- dépendance nouvelle imposée uniquement pour moderniser la stack.
+
+### Upgrade — modernisation du fork
+
+La branche `master` reste la ligne Upgrade. Elle peut porter :
+
+- Python 3 ;
+- wxPython Phoenix ;
+- modernisation UI/UX ;
+- nouveaux modules et fonctions métier ;
+- nouveaux outils de packaging et de CI ;
+- évolutions d'architecture explicitement décidées.
+
+Upgrade ne doit jamais bloquer la disponibilité ou la maintenance de Vanilla.
+
+## 2. Compatibilité Connecthys
+
+La compatibilité avec le Connecthys actuellement exploité constitue un invariant prioritaire de Vanilla.
+
+Aucun correctif Vanilla ne doit modifier volontairement :
+
+- les contrats de synchronisation ;
+- les structures ou identifiants de données attendus par Connecthys ;
+- le comportement de synchronisation historique ;
+- les formats échangés ;
+- le schéma de base nécessaire à l'instance Connecthys existante,
+
+sans décision dédiée et validation de compatibilité.
+
+Lorsqu'un correctif touche une zone liée à Connecthys, il doit être qualifié comme tel et testé sur une copie ou un environnement de recette avant utilisation en production.
+
+## 3. Règle de routage avant tout développement
+
+Avant chaque modification, répondre à la question suivante :
+
+> Cette modification corrige-t-elle le comportement de la version historique sans la moderniser ?
+
+- **Oui** → cibler `maintenance/vanilla`.
+- **Non, elle dépend de Python 3, Phoenix, du nouvel UX ou d'une évolution fonctionnelle** → cibler `master` / Upgrade.
+
+En cas de doute, ne pas commencer le code avant d'avoir classé le changement.
+
+## 4. Politique de transfert des correctifs
+
+Les deux branches ne sont pas fusionnées l'une dans l'autre en bloc.
+
+- Un bug historique corrigé dans Upgrade doit être backporté vers Vanilla sous forme de patch minimal lorsque le défaut existe aussi dans le snapshot historique.
+- Un correctif Vanilla pertinent pour Upgrade doit être porté vers `master` séparément.
+- Ne jamais fusionner `master` dans `maintenance/vanilla`.
+- Ne jamais importer dans Vanilla une dépendance Python 3/Phoenix/Repens uniquement parce que le correctif a été trouvé dans Upgrade.
+
+Le but est de partager les corrections, pas les chantiers de modernisation.
+
+## 5. Données et exploitation
+
+Vanilla doit rester compatible avec les bases existantes sans migration implicite.
+
+Pour toute correction touchant SQL, synchronisation, sauvegarde ou configuration :
+
+1. tester d'abord sur une copie de base ;
+2. vérifier l'absence de migration silencieuse ;
+3. vérifier le retour arrière ;
+4. ne jamais qualifier directement un nouveau build sur l'unique base de production.
+
+## 6. Priorité opérationnelle
+
+La priorité immédiate est de disposer rapidement d'une Vanilla maintenue, installable et utilisable dans les conditions d'exploitation actuelles.
+
+La modernisation Upgrade continue séparément, mais elle ne conditionne pas ce jalon.
+
+## 7. Source de vérité
+
+Pour éviter une nouvelle divergence entre conversations et développement :
+
+1. cette politique de branche ;
+2. les issues GitHub correspondantes ;
+3. le code et les tests de la branche ciblée ;
+4. les autres documents techniques du dépôt.
+
+Toute décision future qui modifie la frontière Vanilla / Upgrade doit être consignée dans `docs/governance/DECISIONS.md` avant ou avec le changement de code.

--- a/docs/governance/ROADMAP.md
+++ b/docs/governance/ROADMAP.md
@@ -1,0 +1,76 @@
+# Roadmap de gouvernance — Vanilla puis Upgrade
+
+> Feuille de route de haut niveau. La roadmap technique détaillée d'Upgrade reste dans `docs/ROADMAP.md`.
+
+## Piste A — Vanilla maintenance
+
+Branche : `maintenance/vanilla`
+
+### Objectif immédiat
+
+Obtenir une version historique Noethys maintenue, utilisable sans attendre les migrations Python 3 / wxPython Phoenix ni la nouvelle interface.
+
+### Étapes
+
+1. figer le snapshot upstream de référence ;
+2. inventorier les bugs historiques confirmés et les classer ;
+3. sélectionner uniquement les correctifs compatibles avec la stack historique ;
+4. backporter les correctifs déjà démontrés dans Upgrade lorsqu'ils sont réellement applicables ;
+5. ajouter des tests/audits compatibles sans transformer le runtime de l'application ;
+6. vérifier installation, ouverture, sauvegarde/restauration et parcours critiques ;
+7. vérifier la compatibilité avec le Connecthys actuellement exploité ;
+8. effectuer la recette sur une copie d'une base réelle ;
+9. publier une première release de maintenance Vanilla.
+
+### Critères de sortie
+
+- aucun bug bloquant connu dans le périmètre ciblé ;
+- aucun changement Python 3 / Phoenix / UX embarqué ;
+- aucune migration implicite de base ;
+- compatibilité Connecthys vérifiée sur les parcours concernés ;
+- démarrage et usage quotidien validés sous Windows ;
+- procédure d'installation et de retour arrière documentée.
+
+## Piste B — Upgrade
+
+Branche : `master`
+
+Upgrade poursuit séparément :
+
+- Python 3 ;
+- wxPython Phoenix ;
+- CI et packaging modernes ;
+- UI/UX modernisée ;
+- améliorations métier et architecture.
+
+Upgrade peut continuer en parallèle mais ne doit pas retarder le jalon Vanilla.
+
+## Flux entre les deux pistes
+
+### Upgrade → Vanilla
+
+Backporter uniquement les correctifs qui :
+
+- correspondent à un bug présent dans la version historique ;
+- peuvent être isolés de Python 3 / Phoenix / Repens ;
+- ne changent pas le schéma ni le contrat Connecthys ;
+- disposent d'une justification et d'une recette claire.
+
+### Vanilla → Upgrade
+
+Porter vers `master` les correctifs historiques encore pertinents afin d'éviter qu'un bug corrigé dans Vanilla reste présent dans Upgrade.
+
+## Priorité de travail
+
+Tant que la première release de maintenance Vanilla n'est pas qualifiée, lorsqu'un choix de priorité est nécessaire entre un correctif Vanilla utile à l'exploitation et une évolution non urgente d'Upgrade, le correctif Vanilla passe en premier.
+
+## Interdiction de mélange
+
+Un lot ne doit pas contenir simultanément :
+
+- un bugfix Vanilla ;
+- une migration Python 3/Phoenix ;
+- une refonte UX ;
+- une nouvelle fonction métier non liée.
+
+Les lots restent petits, ciblés, testables et transférables entre branches lorsque pertinent.


### PR DESCRIPTION
## Objet

Formaliser la décision du 25 août 2026 afin qu'elle ne reste plus dans les conversations.

## Changements

- ajoute `docs/governance/PROJECT_STRATEGY.md` ;
- ajoute `docs/governance/DECISIONS.md` ;
- ajoute `docs/governance/ROADMAP.md` ;
- définit Vanilla comme maintenance de la version historique sans Python 3, Phoenix ni nouvel UX ;
- définit `master` comme ligne Upgrade ;
- fige la compatibilité avec le Connecthys actuellement exploité comme invariant de Vanilla ;
- documente le flux de backports entre les deux lignes.

La branche permanente `maintenance/vanilla` a été créée depuis le snapshot upstream `630ef4373dbc05dae1cbc597b9baccb1178e64e4` et l'issue #120 devient le cockpit de la ligne Vanilla.

Aucun code applicatif n'est modifié dans cette PR.