### PR TITLE
Upgrade — porter la correction des titulaires familiaux

### DIFF
--- a/noethys/Utils/UTILS_Titulaires.py
+++ b/noethys/Utils/UTILS_Titulaires.py
@@ -270,9 +270,14 @@ def GetFamillesRattachees(IDindividu=None):
     listeRattachements = db.ResultatReq()
     dictFamilles = {}
     for IDrattachement, IDfamille, IDcategorie, titulaire, IDcompte_payeur in listeRattachements :
-        if IDcategorie == 1 : nomCategorie = _(u"représentant")
-        if IDcategorie == 2 : nomCategorie = _(u"enfant")
-        if IDcategorie == 3 : nomCategorie = _(u"contact")
+        if IDcategorie == 1 :
+            nomCategorie = _(u"représentant")
+        elif IDcategorie == 2 :
+            nomCategorie = _(u"enfant")
+        elif IDcategorie == 3 :
+            nomCategorie = _(u"contact")
+        else :
+            nomCategorie = _(u"catégorie inconnue")
         dictFamilles[IDfamille] = {"nomsTitulaires" : u"", "listeNomsTitulaires" : [], "IDcategorie" : IDcategorie, "nomCategorie" : nomCategorie, "IDcompte_payeur" : IDcompte_payeur }
     # Recherche des noms des titulaires
     if len(dictFamilles) == 0 : condition = "()"
@@ -295,9 +300,9 @@ def GetFamillesRattachees(IDindividu=None):
             dictFamilles[IDfamille]["nomsTitulaires"] = _(u"%s et %s") % (dictFamilles[IDfamille]["listeNomsTitulaires"][0], dictFamilles[IDfamille]["listeNomsTitulaires"][1])
         if nbreTitulaires > 2 :
             texteNoms = ""
-            for nomTitulaire in dictFamilles[IDfamille]["listeNomsTitulaires"][:-1] :
+            for nomTitulaire in dictFamilles[IDfamille]["listeNomsTitulaires"][:-2] :
                 texteNoms += u"%s, " % nomTitulaire
-            texteNoms = _(u"%s et %s") % (dictFamilles[IDfamille]["listeNomsTitulaires"][-2], dictFamilles[IDfamille]["listeNomsTitulaires"][-1])
+            texteNoms += _(u"%s et %s") % (dictFamilles[IDfamille]["listeNomsTitulaires"][-2], dictFamilles[IDfamille]["listeNomsTitulaires"][-1])
             dictFamilles[IDfamille]["nomsTitulaires"] = texteNoms
     return dictFamilles
 

--- a/tests/test_titulaires_rattachements_contract.py
+++ b/tests/test_titulaires_rattachements_contract.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import ast
+import types
+import unittest
+from pathlib import Path
+
+
+SOURCE = Path("noethys/Utils/UTILS_Titulaires.py")
+
+
+def load_get_familles_rattachees(resultats):
+    tree = ast.parse(SOURCE.read_text(encoding="utf-8"))
+    fonction = next(
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "GetFamillesRattachees"
+    )
+    module = ast.Module(body=[fonction], type_ignores=[])
+    ast.fix_missing_locations(module)
+
+    class FakeDB:
+        def __init__(self):
+            self._resultats = iter(resultats)
+
+        def ExecuterReq(self, req):
+            return True
+
+        def ResultatReq(self):
+            return next(self._resultats)
+
+        def Close(self):
+            return None
+
+    namespace = {
+        "GestionDB": types.SimpleNamespace(DB=FakeDB),
+        "_": lambda texte: texte,
+    }
+    exec(compile(module, str(SOURCE), "exec"), namespace)
+    return namespace["GetFamillesRattachees"]
+
+
+class TitulairesRattachementsContractTests(unittest.TestCase):
+    def test_trois_titulaires_conservent_tous_les_noms(self):
+        fonction = load_get_familles_rattachees([
+            [(1, 10, 1, 1, 100)],
+            [
+                (1, 101, 10, 1, 1, "Alpha", "Ana"),
+                (2, 102, 10, 1, 1, "Beta", "Ben"),
+                (3, 103, 10, 1, 1, "Gamma", "Gus"),
+            ],
+        ])
+
+        resultat = fonction(IDindividu=999)
+
+        self.assertEqual(
+            resultat[10]["nomsTitulaires"],
+            "Alpha Ana, Beta Ben et Gamma Gus",
+        )
+
+    def test_categorie_inconnue_ne_provoque_pas_de_variable_locale_absente(self):
+        fonction = load_get_familles_rattachees([
+            [(1, 10, 99, 0, 100)],
+            [],
+        ])
+
+        resultat = fonction(IDindividu=999)
+
+        self.assertEqual(resultat[10]["IDcategorie"], 99)
+        self.assertEqual(resultat[10]["nomCategorie"], "catégorie inconnue")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Objet

Forward-port vers `master`/Upgrade du correctif Vanilla intégré par #124.

Deux défauts historiques de `UTILS_Titulaires.GetFamillesRattachees()` sont corrigés :

- avec trois titulaires ou plus, les premiers noms étaient perdus par écrasement du texte accumulé ;
- une catégorie de rattachement différente de 1/2/3 pouvait laisser `nomCategorie` indéfini.

## Validation

- même patch applicatif que #124 ;
- deux contrats exécutables ajoutés sur la ligne Upgrade ;
- CI #1889 verte ;
- provenance `HISTORIQUE_UPSTREAM` confirmée.

Aucun changement de schéma ni de comportement pour les catégories historiques valides.

Forward-port de #124. Relates #97.