### PR TITLE
Vanilla — fiabiliser les titulaires des familles rattachées

### DIFF
--- a/noethys/Utils/UTILS_Titulaires.py
+++ b/noethys/Utils/UTILS_Titulaires.py
@@ -270,9 +270,14 @@ def GetFamillesRattachees(IDindividu=None):
     listeRattachements = db.ResultatReq()
     dictFamilles = {}
     for IDrattachement, IDfamille, IDcategorie, titulaire, IDcompte_payeur in listeRattachements :
-        if IDcategorie == 1 : nomCategorie = _(u"représentant")
-        if IDcategorie == 2 : nomCategorie = _(u"enfant")
-        if IDcategorie == 3 : nomCategorie = _(u"contact")
+        if IDcategorie == 1 :
+            nomCategorie = _(u"représentant")
+        elif IDcategorie == 2 :
+            nomCategorie = _(u"enfant")
+        elif IDcategorie == 3 :
+            nomCategorie = _(u"contact")
+        else :
+            nomCategorie = _(u"catégorie inconnue")
         dictFamilles[IDfamille] = {"nomsTitulaires" : u"", "listeNomsTitulaires" : [], "IDcategorie" : IDcategorie, "nomCategorie" : nomCategorie, "IDcompte_payeur" : IDcompte_payeur }
     # Recherche des noms des titulaires
     if len(dictFamilles) == 0 : condition = "()"
@@ -295,9 +300,9 @@ def GetFamillesRattachees(IDindividu=None):
             dictFamilles[IDfamille]["nomsTitulaires"] = _(u"%s et %s") % (dictFamilles[IDfamille]["listeNomsTitulaires"][0], dictFamilles[IDfamille]["listeNomsTitulaires"][1])
         if nbreTitulaires > 2 :
             texteNoms = ""
-            for nomTitulaire in dictFamilles[IDfamille]["listeNomsTitulaires"][:-1] :
+            for nomTitulaire in dictFamilles[IDfamille]["listeNomsTitulaires"][:-2] :
                 texteNoms += u"%s, " % nomTitulaire
-            texteNoms = _(u"%s et %s") % (dictFamilles[IDfamille]["listeNomsTitulaires"][-2], dictFamilles[IDfamille]["listeNomsTitulaires"][-1])
+            texteNoms += _(u"%s et %s") % (dictFamilles[IDfamille]["listeNomsTitulaires"][-2], dictFamilles[IDfamille]["listeNomsTitulaires"][-1])
             dictFamilles[IDfamille]["nomsTitulaires"] = texteNoms
     return dictFamilles
 


### PR DESCRIPTION
## Défauts historiques

Deux défauts sont présents dans `UTILS_Titulaires.GetFamillesRattachees()` du snapshot Vanilla :

1. avec trois titulaires ou plus, le texte accumulé est écrasé juste avant le retour et seuls les deux derniers noms restent affichés ;
2. pour une catégorie de rattachement différente de 1/2/3, `nomCategorie` peut être lu sans avoir été défini, avec `UnboundLocalError`.

## Patch Vanilla

- conserve les catégories historiques `représentant`, `enfant`, `contact` ;
- ajoute uniquement un repli `catégorie inconnue` pour les données non reconnues ;
- construit le libellé de trois titulaires ou plus avec les premiers noms puis les deux derniers ;
- aucun changement de schéma, de format échangé, de Python/wx ou d'interface.

## Provenance et validation

**HISTORIQUE_UPSTREAM — confirmé.** Le fichier du snapshot Vanilla est identique au fichier upstream concerné (blob `c7937cc203344d2ba80eef08c9a05c4863e6fe9b`).

Le même patch minimal a été exercé sur la ligne Upgrade dans la PR #123 avec deux contrats ciblés ; la CI de cette PR est verte. Le dépôt Vanilla ne possède actuellement ni workflow GitHub Actions ni répertoire de tests : ce PR ne les introduit pas afin de garder ce premier backport strictement applicatif et compatible avec la stack historique.

Closes une partie de #120. Relates #123.