### PR TITLE
Vanilla — filtrer correctement les événements iCalendar

### DIFF
--- a/noethys/Utils/UTILS_Icalendar.py
+++ b/noethys/Utils/UTILS_Icalendar.py
@@ -75,7 +75,8 @@ class Calendrier():
 
         for nomOriginal, nomFinal in listeCorrespondances :
             for dictEvent in listeEvents :
-                if nomOriginal in dictEvent["description"] :
+                description = dictEvent.get("description") or u""
+                if nomOriginal in description :
                     if dictEvent["date_debut"] != None and dictEvent["date_fin"] != None :
                         annee = dictEvent["date_debut"].year
                         date_debut = dictEvent["date_debut"]
@@ -85,14 +86,16 @@ class Calendrier():
         # Recherche les grandes vacances
         dictTemp = {}
         for dictEvent in listeEvents :
-            if u"élèves" or u"été" in dictEvent["description"] :
-                annee = dictEvent["date_debut"].year
+            description = dictEvent.get("description") or u""
+            date_debut = dictEvent.get("date_debut")
+            if (u"élèves" in description or u"été" in description) and date_debut != None :
+                annee = date_debut.year
                 if (annee in dictTemp) == False :
                     dictTemp[annee] = {"date_debut" : None, "date_fin" : None}
-                if u"été" in dictEvent["description"] :
-                    dictTemp[annee]["date_debut"] = dictEvent["date_debut"] + datetime.timedelta(days=1)
-                if u"élèves" in dictEvent["description"] :
-                    dictTemp[annee]["date_fin"] = dictEvent["date_debut"] - datetime.timedelta(days=1)
+                if u"été" in description :
+                    dictTemp[annee]["date_debut"] = date_debut + datetime.timedelta(days=1)
+                if u"élèves" in description :
+                    dictTemp[annee]["date_fin"] = date_debut - datetime.timedelta(days=1)
 
         for annee, dictDates in dictTemp.items() :
             if dictDates["date_debut"] != None and dictDates["date_fin"] != None :


### PR DESCRIPTION
## Défaut historique

Dans `UTILS_Icalendar.Calendrier.GetVacances()`, la condition :

```python
if u"élèves" or u"été" in dictEvent["description"]:
```

est toujours vraie puisque `u"élèves"` est une chaîne non vide. Tout événement du calendrier pouvait donc être interprété comme candidat aux grandes vacances, avec en plus un risque sur les événements sans description ou sans date de début.

## Patch Vanilla

- teste réellement la présence de `élèves` ou `été` dans la description ;
- ignore proprement une description absente ;
- ignore un candidat aux grandes vacances sans date de début ;
- conserve le calcul historique des bornes d'été ;
- aucun changement de stack, de schéma ou d'interface.

## Provenance et validation

**HISTORIQUE_UPSTREAM — confirmé.** Le motif est présent dans le snapshot Vanilla.

Le correctif équivalent a déjà été validé sur Upgrade par #114 : CI `32854144923` verte et contrats couvrant événement sans rapport, événement incomplet et extraction normale des grandes vacances.

Relates #120 et #114.