### PR TITLE
Vanilla — éviter le crash sur un format PES inconnu

### DIFF
--- a/noethys/Ol/OL_Lots_pes.py
+++ b/noethys/Ol/OL_Lots_pes.py
@@ -286,6 +286,7 @@ class ListView(FastObjectListView):
             else:
                 dlg.Destroy()
                 return False, False
+        classe = None
         if format == "pes":
             classe = DLG_Saisie_lot_tresor_public_pes.Dialog
         if format == "magnus":
@@ -294,6 +295,8 @@ class ListView(FastObjectListView):
             classe = DLG_Saisie_lot_tresor_public_jvs.Dialog
         if format == "corail":
             classe = DLG_Saisie_lot_tresor_public_corail.Dialog
+        if classe is None:
+            return False, False
         return (format, classe)
 
 # -------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Défaut historique

`OL_Lots_pes.ListView.Get_classe()` n'initialise `classe` que pour les quatre formats historiques connus (`pes`, `magnus`, `jvs`, `corail`). Si une donnée contient un code inconnu, la fonction peut atteindre `return (format, classe)` avec `classe` non définie.

## Patch Vanilla

- initialise `classe` à `None` ;
- retourne `(False, False)` pour un format non pris en charge ;
- conserve strictement les quatre mappings historiques ;
- aucune modification de schéma, de format PES, de stack ou d'interface.

## Provenance et validation

**HISTORIQUE_UPSTREAM — confirmé.** Le blob du fichier Vanilla avant correction est identique au fichier upstream concerné (`f138f69db00a9c3f5b1e838acb727df34288f2b5`).

Le même patch exact a été validé sur Upgrade dans #116 : CI `32868657916` verte et contrats couvrant les quatre formats connus et le repli inconnu.

Relates #120 et #116.