### PR TITLE
Vanilla — isoler le dictionnaire par défaut de SetParametres

### DIFF
--- a/noethys/Utils/UTILS_Config.py
+++ b/noethys/Utils/UTILS_Config.py
@@ -207,8 +207,10 @@ def GetParametres(dictParametres={}):
 
 
 
-def SetParametres(dictParametres={}):
+def SetParametres(dictParametres=None):
     """ dictParametres = {nom : valeur, nom: valeur...} """
+    if dictParametres is None:
+        dictParametres = {}
     try :
         topWindow = wx.GetApp().GetTopWindow()
         nomWindow = topWindow.GetName()


### PR DESCRIPTION
## Défaut historique

`UTILS_Config.SetParametres()` utilisait `dictParametres={}` et retournait directement cet objet. Deux appels sans argument partageaient donc le même dictionnaire : un appelant pouvait modifier le résultat du premier appel et contaminer silencieusement le suivant.

## Patch Vanilla

- remplace le dictionnaire mutable par défaut par `None` ;
- crée un dictionnaire local neuf lorsque l’argument est omis ;
- conserve le comportement lorsqu’un dictionnaire explicite est fourni ;
- aucun changement de schéma, de stack, d’interface ou de logique métier.

## Provenance et validation

**HISTORIQUE_UPSTREAM — confirmé.** Le motif est présent dans le snapshot Vanilla.

Le patch est exactement celui déjà validé sur Upgrade dans #108, où un contrat comportemental vérifie que deux appels sans argument ne partagent plus le même objet.

Relates #120 et #108.