### PR TITLE
Vanilla — isoler le repli de ParametresCategorie

### DIFF
--- a/noethys/Utils/UTILS_Parametres.py
+++ b/noethys/Utils/UTILS_Parametres.py
@@ -19,10 +19,12 @@ else:
     TYPE_COULEUR = wx._gdi.Colour
 
 
-def ParametresCategorie(mode="get", categorie="", dictParametres={}, nomFichier=""):
+def ParametresCategorie(mode="get", categorie="", dictParametres=None, nomFichier=""):
     """ Pour mémoriser ou récupérer des paramètres dans la base de données """
     """ Renseigner categorie et dictParametres obligatoirement !!!  (pour avoir les valeurs par défaut et deviner les types de valeur) """
     """ dictParametres = {nom:valeur, nom:valeur, ....} """
+    if dictParametres is None:
+        dictParametres = {}
     # Recherche du parametre
     DB = GestionDB.DB(nomFichier=nomFichier)
     


### PR DESCRIPTION
## Défaut historique

`UTILS_Parametres.ParametresCategorie()` utilisait `dictParametres={}` et, lorsque la base était indisponible, retournait directement cet objet. Un appelant pouvait donc modifier ce repli et contaminer un appel ultérieur sans argument.

## Patch Vanilla

- remplace le dictionnaire mutable par défaut par `None` ;
- crée un dictionnaire local neuf lorsque l’argument est omis ;
- conserve le comportement pour un dictionnaire explicitement fourni ;
- aucun changement de schéma, de stack, d’interface ni de logique métier.

## Provenance et validation

**HISTORIQUE_UPSTREAM — confirmé.** Le motif est présent dans le snapshot Vanilla.

Le patch est exactement celui déjà validé sur Upgrade dans #108, avec un contrat comportemental simulant une base indisponible.

Relates #120 et #108.