### PR TITLE
Vanilla — corriger trois noms non définis

### DIFF
--- a/noethys/Ctrl/CTRL_Calendrier_ouvertures.py
+++ b/noethys/Ctrl/CTRL_Calendrier_ouvertures.py
@@ -16,6 +16,7 @@ import wx
 from Ctrl import CTRL_Bouton_image
 import wx.lib.agw.hypertreelist as HTL
 import datetime
+import calendar
 import GestionDB
 
 

--- a/noethys/Dlg/DLG_Banques.py
+++ b/noethys/Dlg/DLG_Banques.py
@@ -122,7 +122,7 @@ class Dialog(wx.Dialog):
         
     def OnBouton_ok(self, event):
         IDbanque = self.GetIDbanque()
-        if IDmedecin == None :
+        if IDbanque == None :
             dlg = wx.MessageDialog(self, _(u"Vous n'avez sélectionné aucun établissement bancaire dans la liste"), _(u"Erreur de saisie"), wx.OK | wx.ICON_EXCLAMATION)
             dlg.ShowModal()
             dlg.Destroy()

--- a/noethys/Dlg/DLG_Commandes.py
+++ b/noethys/Dlg/DLG_Commandes.py
@@ -3,7 +3,7 @@
 #------------------------------------------------------------------------
 # Application :    Noethys, gestion multi-activités
 # Site internet :  www.noethys.com
-# Auteur:          Ivan LUCAS
+# Auteur:           Ivan LUCAS
 # Copyright:       (c) 2010-18 Ivan LUCAS
 # Licence:         Licence GNU GPL
 #------------------------------------------------------------------------
@@ -49,7 +49,8 @@ class CTRL_Modele(wx.Choice):
                 selection_defaut = index
             index += 1
 
-        self.SetItems(listeItems)
+        self.listeItems = listeItems
+        self.SetItems(self.listeItems)
         if len(self.dictDonnees) > 0:
             self.Enable(True)
             if selection_defaut != None :
@@ -58,7 +59,7 @@ class CTRL_Modele(wx.Choice):
             self.Enable(False)
 
     def GetListeDonnees(self):
-        return listeItems
+        return self.listeItems
 
     def SetID(self, ID=0):
         for index, values in self.dictDonnees.items():


### PR DESCRIPTION
## Objectif

Corriger trois défauts historiques directement démontrables sur `maintenance/vanilla`, sans toucher à l'UX, au schéma ni à la logique métier générale.

## Correctifs

- `DLG_Banques.py` : teste `IDbanque` au lieu de la variable inexistante `IDmedecin` lors de la validation d'une banque ;
- `CTRL_Calendrier_ouvertures.py` : importe `calendar` pour `GetListeDates()` ;
- `DLG_Commandes.py` : conserve `listeItems` sur l'instance afin que `GetListeDonnees()` ne retourne plus un nom local inexistant.

Le défaut `CalculeAge` dans `CTRL_Remplissage.py` reste suivi dans #130 et sera traité séparément afin de garder des patches minimaux.

Fixes partiellement #130.
Relates #120.