### PR TITLE
Vanilla: isoler les fichiers temporaires par processus

### DIFF
--- a/noethys/Utils/UTILS_Fichiers.py
+++ b/noethys/Utils/UTILS_Fichiers.py
@@ -62,25 +62,22 @@ def GetRepData(fichier=""):
 
 
 def GetRepTemp(fichier=""):
-    chemin = GetRepUtilisateur("Temp")
+    chemin = GetRepUtilisateur(os.path.join("Temp", str(os.getpid())))
+    if not os.path.isdir(chemin):
+        os.makedirs(chemin)
     return os.path.join(chemin, fichier)
-
 def GetRepUpdates(fichier=""):
     chemin = GetRepUtilisateur("Updates")
     return os.path.join(chemin, fichier)
-
 def GetRepLang(fichier=""):
     chemin = GetRepUtilisateur("Lang")
     return os.path.join(chemin, fichier)
-
 def GetRepSync(fichier=""):
     chemin = GetRepUtilisateur("Sync")
     return os.path.join(chemin, fichier)
-
 def GetRepExtensions(fichier=""):
     chemin = GetRepUtilisateur("Extensions")
     return os.path.join(chemin, fichier)
-
 def GetRepUtilisateur(fichier=""):
     """ Recherche le répertoire Utilisateur pour stockage des fichiers de config et provisoires """
     chemin = None


### PR DESCRIPTION
Backport minimal pour la lignée Vanilla Clean.

Le backlog upstream identifie le risque de collision/suppression des fichiers PDF temporaires entre plusieurs instances de Noethys. `GetRepTemp()` utilisait jusqu'ici un répertoire `Temp` commun à toutes les instances.

Ce patch conserve l'API existante mais place les temporaires dans `Temp/<pid>/`, ce qui empêche deux processus Noethys simultanés d'écrire/supprimer les mêmes fichiers.

Périmètre volontairement limité : aucun changement de schéma, aucune UI Repens, aucune nouvelle fonctionnalité.