### PR TITLE
fix: rendre le lanceur Windows indépendant de Get-FileHash

### DIFF
--- a/scripts/dev_windows.ps1
+++ b/scripts/dev_windows.ps1
@@ -39,6 +39,26 @@ function Get-NoethysBootstrapPython {
     throw 'Python 3.10 est introuvable. Installer Python 3.10 pour Windows puis relancer DEV-Noethys.cmd.'
 }
 
+function Get-NoethysFileSha256 {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $stream = [System.IO.File]::OpenRead($Path)
+    try {
+        $sha256 = [System.Security.Cryptography.SHA256]::Create()
+        try {
+            $hash = $sha256.ComputeHash($stream)
+        }
+        finally {
+            $sha256.Dispose()
+        }
+    }
+    finally {
+        $stream.Dispose()
+    }
+
+    return ([System.BitConverter]::ToString($hash)).Replace('-', '')
+}
+
 if (-not (Test-Path $Python)) {
     Write-Host 'Premiere utilisation : creation du venv Python 3.10...'
     $bootstrap = Get-NoethysBootstrapPython
@@ -47,8 +67,8 @@ if (-not (Test-Path $Python)) {
     if ($LASTEXITCODE -ne 0) { throw 'Impossible de creer le venv Python 3.10.' }
 }
 
-$hash1 = (Get-FileHash $ReqBuild -Algorithm SHA256).Hash
-$hash2 = (Get-FileHash $ReqRuntime -Algorithm SHA256).Hash
+$hash1 = Get-NoethysFileSha256 $ReqBuild
+$hash2 = Get-NoethysFileSha256 $ReqRuntime
 $requirementsHash = "$hash1-$hash2"
 $currentHash = ''
 if (Test-Path $ReqMarker) {

--- a/tests/test_windows_dev_launcher_contract.py
+++ b/tests/test_windows_dev_launcher_contract.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "dev_windows.ps1"
+
+
+class WindowsDevLauncherTests(unittest.TestCase):
+    def test_le_hash_ne_depend_pas_de_get_file_hash(self):
+        source = SCRIPT.read_text(encoding="utf-8")
+
+        self.assertNotIn("Get-FileHash", source)
+        self.assertIn("function Get-NoethysFileSha256", source)
+        self.assertIn("[System.Security.Cryptography.SHA256]::Create()", source)
+        self.assertIn("[System.IO.File]::OpenRead($Path)", source)
+
+    def test_les_ressources_de_hashage_sont_liberees(self):
+        source = SCRIPT.read_text(encoding="utf-8")
+
+        self.assertIn("$sha256.Dispose()", source)
+        self.assertIn("$stream.Dispose()", source)
+
+    def test_les_deux_fichiers_requirements_utilisent_le_repli(self):
+        source = SCRIPT.read_text(encoding="utf-8")
+
+        self.assertIn("$hash1 = Get-NoethysFileSha256 $ReqBuild", source)
+        self.assertIn("$hash2 = Get-NoethysFileSha256 $ReqRuntime", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Résumé : remplace la dépendance à l'applet PowerShell Get-FileHash par un calcul SHA-256 via les API .NET disponibles sur les environnements Windows historiques. Le lanceur DEV-Noethys.cmd peut ainsi poursuivre la création du venv et l'installation des dépendances. Tests : contrat du lanceur, libération des flux et analyse syntaxique PowerShell. Doctrine Vanilla+ : robustesse du parcours de recette Windows uniquement.