### PR TITLE
Vanilla — protéger la famille du compte payeur lors d’un règlement

### DIFF
--- a/noethys/Dlg/DLG_Saisie_reglement.py
+++ b/noethys/Dlg/DLG_Saisie_reglement.py
@@ -1455,7 +1455,11 @@ class Dialog(wx.Dialog):
         WHERE IDcompte_payeur=%d
         """ % self.IDcompte_payeur
         DB.ExecuterReq(req)
-        IDfamille = DB.ResultatReq()[0][0]
+        listeDonnees = DB.ResultatReq()
+        if not listeDonnees:
+            DB.Close()
+            return False
+        IDfamille = listeDonnees[0][0]
 
         # Récupère des frais de gestion
         donneesFrais = self.hyperlien_frais.GetDonnees() 


### PR DESCRIPTION
## Défaut observé
Noethys 1.3.3.9 plante dans DLG_Saisie_reglement.Sauvegarde avec IndexError lorsque la recherche de la famille associée au compte payeur ne renvoie aucune ligne.

## Correction
- mémoriser le résultat de la requête
- vérifier qu'il contient une ligne avant indexation
- fermer la connexion et annuler proprement la sauvegarde dans le cas incohérent

## Routage
Backport minimal vers maintenance/vanilla uniquement. Aucun Python 3, wxPython Phoenix, nouvel UX, métier ou schéma.

## Vérifications
Compilation ciblée et git diff --check.