### PR TITLE
Upgrade — interrompre les boucles de reflow du texte responsive

### DIFF
--- a/noethys/Ctrl/CTRL_TexteRepens.py
+++ b/noethys/Ctrl/CTRL_TexteRepens.py
@@ -44,6 +44,7 @@ class CTRL(wx.StaticText):
         self.role_fond = role_fond
         self.wrap_actif = bool(wrap)
         self._reflow_pending = False
+        self._last_wrap_width = None
         self.AppliquerStyle()
         if self.wrap_actif:
             self.Bind(wx.EVT_SIZE, self.OnSize)
@@ -62,6 +63,7 @@ class CTRL(wx.StaticText):
         self.role = _role(role)
         self.AppliquerStyle()
         self.InvalidateBestSize()
+        self._last_wrap_width = None
         if self.wrap_actif:
             wx.CallAfter(self.Reflow)
 
@@ -72,6 +74,7 @@ class CTRL(wx.StaticText):
     def SetLabel(self, label):
         wx.StaticText.SetLabel(self, label or u"")
         self.InvalidateBestSize()
+        self._last_wrap_width = None
         if self.wrap_actif:
             wx.CallAfter(self.Reflow)
 
@@ -81,8 +84,11 @@ class CTRL(wx.StaticText):
             return
         try:
             largeur = self.GetClientSize().GetWidth()
-            if largeur > Style.px(80):
-                self.Wrap(max(Style.px(80), largeur))
+            largeur_min = Style.px(80)
+            if largeur <= largeur_min or largeur == self._last_wrap_width:
+                return
+            self._last_wrap_width = largeur
+            self.Wrap(largeur)
         except Exception:
             return
         try:

--- a/tests/test_repens_typography_scale_contract.py
+++ b/tests/test_repens_typography_scale_contract.py
@@ -50,6 +50,15 @@ def test_ctrl_texte_expose_un_helper_pour_chaque_niveau():
     assert "Style.normaliser_role_typographie" in texte
 
 
+def test_reflow_ignore_une_largeur_deja_traitee():
+    texte = TEXTES.read_text(encoding="utf-8")
+
+    assert "self._last_wrap_width = None" in texte
+    assert "largeur == self._last_wrap_width" in texte
+    assert "self._last_wrap_width = largeur" in texte
+    assert "self.Wrap(largeur)" in texte
+
+
 def test_gabarits_utilisent_la_hierarchie_semantique():
     bandeau = BANDEAU.read_text(encoding="utf-8")
     fenetre = FENETRE.read_text(encoding="utf-8")


### PR DESCRIPTION
## Défaut reproduit
Sous Windows 10, Python 3.10 et wxPython 4.2.5, la fenêtre Ouvrir un fichier devient non répondante. Une capture faulthandler montre une boucle EVT_SIZE -> Reflow -> Layout -> EVT_SIZE dans CTRL_TexteRepens.

## Correction
- mémoriser la dernière largeur effectivement traitée
- ne pas relancer Wrap et Layout lorsque la largeur est inchangée
- invalider ce cache lorsque le libellé ou le rôle typographique change

## Routage
Correction Upgrade uniquement : dépend de Repens, Python 3 et wxPython Phoenix. Aucun backport Vanilla.

## Vérifications
- 5 tests typographie/scaling verts
- fenêtre réelle construite en 1,04 s
- cycle modal automatique terminé en 1,02 s
- compilation ciblée et git diff --check