### PR TITLE
Vanilla — stabiliser le splash au démarrage

### DIFF
--- a/noethys/Noethys.py
+++ b/noethys/Noethys.py
@@ -4399,20 +4399,21 @@ class MyApp(wx.App):
         theme = CUSTOMIZE.GetValeur("interface", "theme", "Vert")
 
         # AdvancedSplashScreen
+        splash = None
         if CUSTOMIZE.GetValeur("utilisateur", "pass", "") == "" :
             nom_fichier_splash = "Logo_splash.png"
             if six.PY3 and theme == "Vert":
                 nom_fichier_splash = "Logo_splash_2019.png"
             bmp = wx.Bitmap(Chemins.GetStaticPath("Images/Interface/%s/%s" % (theme, nom_fichier_splash)), wx.BITMAP_TYPE_PNG)
-            frame = AS.AdvancedSplash(None, bitmap=bmp, timeout=3000, agwStyle=AS.AS_TIMEOUT | AS.AS_CENTER_ON_SCREEN)
+            splash = AS.AdvancedSplash(None, bitmap=bmp, timeout=3000, agwStyle=AS.AS_CENTER_ON_SCREEN)
             anneeActuelle = str(datetime.date.today().year)
-            frame.SetText(u"Copyright © 2010-%s Ivan LUCAS" % anneeActuelle[2:])
-            frame.SetTextFont(wx.Font(8, wx.SWISS, wx.NORMAL, wx.NORMAL, False))
-            frame.SetTextPosition((425, 212))
+            splash.SetText(u"Copyright © 2010-%s Ivan LUCAS" % anneeActuelle[2:])
+            splash.SetTextFont(wx.Font(8, wx.SWISS, wx.NORMAL, wx.NORMAL, False))
+            splash.SetTextPosition((425, 212))
             couleur_texte = "WHITE" #UTILS_Interface.GetValeur("couleur_claire", wx.Colour(255, 255, 255))
-            frame.SetTextColour(couleur_texte)
-            frame.Refresh()
-            frame.Update()
+            splash.SetTextColour(couleur_texte)
+            splash.Refresh()
+            splash.Update()
             if 'phoenix' not in wx.PlatformInfo:
                 wx.Yield()
 
@@ -4420,6 +4421,9 @@ class MyApp(wx.App):
         frame = MainFrame(None)
         self.SetTopWindow(frame)
         frame.Initialisation()
+        if splash is not None:
+            splash.Hide()
+            splash.Destroy()
         frame.Show()
 
         # Affiche une annonce si c'est un premier démarrage ou après une mise à jour


### PR DESCRIPTION
## Objet

Corrige le blocage/flicker UI observé au démarrage sous Windows avec Python 2.7 / wxPython 2.8.

## Diagnostic

Les journaux de reproduction montrent que la `MainFrame` est déjà créée et affichée alors que `AdvancedSplash` reste encore visible. Le splash est piloté par `AS_TIMEOUT` (3 s) et se détruit donc de façon asynchrone pendant que l'interface principale termine son initialisation, ce qui coïncide avec un stall de peinture au démarrage.

Le code réutilisait en outre le même nom local `frame` pour le splash puis pour la fenêtre principale, ce qui empêchait de gérer explicitement la durée de vie du splash.

## Correctif

- conserve une référence dédiée `splash` ;
- retire le teardown asynchrone `AS_TIMEOUT` ;
- garde le splash uniquement pendant `MainFrame.Initialisation()` ;
- masque puis détruit explicitement le splash avant `frame.Show()`.

Le splash continue donc à jouer son rôle d'écran de chargement, mais ne peut plus disparaître au milieu de l'activation/peinture de la fenêtre principale.

## Portée Vanilla+

- 1 fichier applicatif ;
- aucun changement métier ;
- aucun changement de schéma ;
- aucune refonte graphique ;
- aucune dépendance ;
- comportement compatible wxPython 2.8.

La validation finale du symptôme visuel reste une recette Windows réelle, la CI ne pouvant pas reproduire fidèlement le gestionnaire de fenêtres du poste utilisateur.