### PR TITLE
Vanilla — corriger l’ouverture de l’assistant CAF-CDAP sous Python 3

### DIFF
--- a/noethys/Dlg/DLG_Consultation_cafpro.py
+++ b/noethys/Dlg/DLG_Consultation_cafpro.py
@@ -3,7 +3,7 @@
 #------------------------------------------------------------------------
 # Application :    Noethys, gestion multi-activités
 # Site internet :  www.noethys.com
-# Auteur:          Ivan LUCAS
+# Auteur:           Ivan LUCAS
 # Copyright:       (c) 2010-18 Ivan LUCAS
 # Licence:         Licence GNU GPL
 #------------------------------------------------------------------------
@@ -191,14 +191,14 @@ class CTRL_Drop(wx.StaticBitmap):
 
         # Texte
         if texte != None :
-            xTexte = largeurImage / 2.0 - largeurTexte / 2.0
-            yTexte = hauteurImage / 2.0 - hauteurTexte / 2.0 - 1
+            xTexte = largeurImage // 2 - largeurTexte // 2
+            yTexte = hauteurImage // 2 - hauteurTexte // 2 - 1
             dc.DrawLabel(texte, wx.Rect(xTexte, yTexte, largeurTexte, hauteurTexte), wx.ALIGN_CENTER | wx.ALIGN_CENTER_VERTICAL)
 
 
         if texte != None :
-            xTexte = largeurImage / 2.0 - largeurTexte / 2.0
-            yTexte = hauteurImage / 2.0 - hauteurTexte / 2.0 - 1
+            xTexte = largeurImage // 2 - largeurTexte // 2
+            yTexte = hauteurImage // 2 - hauteurTexte // 2 - 1
             dc.DrawLabel(texte, wx.Rect(xTexte, yTexte, largeurTexte, hauteurTexte), wx.ALIGN_CENTER | wx.ALIGN_CENTER_VERTICAL)
 
         mdc.SelectObject(wx.NullBitmap)


### PR DESCRIPTION
## Objet

Corrige le crash observé lors du clic sur le bouton CAF-CDAP dans la fiche famille sous Python 3 / wxPython Phoenix.

## Diagnostic

`DLG_Consultation_cafpro.py` calcule les coordonnées de texte avec `/ 2.0`. Sous Python 2, le code historique produisait des coordonnées entières dans ce contexte ; sous Python 3, ces expressions deviennent des `float`. `wx.Rect(...)` sous Phoenix refuse alors ces valeurs et l’assistant plante avant même l’appel d’ouverture du navigateur.

Trace observée : `TypeError: Rect(): argument 1 has unexpected type 'float'` dans `CreationImageDrop()`.

## Correctif

- remplace les divisions flottantes par des divisions entières `//` pour conserver le positionnement historique ;
- aucun changement métier, aucun changement de base de données, aucune nouvelle dépendance.

Le message `Unknown database 'pelemele_photos'` vu dans le même journal est indépendant de ce crash et n’est pas traité dans cette PR.