### PR TITLE
Vanilla — corriger le redimensionnement du logo organisateur sous wxPython Phoenix

### DIFF
--- a/noethys/Utils/UTILS_Organisateur.py
+++ b/noethys/Utils/UTILS_Organisateur.py
@@ -32,13 +32,16 @@ def RecadreImg(img=None, tailleImage=(40, 40)):
     largeur, hauteur = img.GetSize()
     if max(largeur, hauteur) > tailleMaxi :
         if largeur > hauteur :
-            hauteur = hauteur * tailleMaxi / largeur
-            largeur = tailleMaxi
+            hauteur = int(hauteur * tailleMaxi / largeur)
+            largeur = int(tailleMaxi)
         else:
-            largeur = largeur * tailleMaxi / hauteur
-            hauteur = tailleMaxi
+            largeur = int(largeur * tailleMaxi / hauteur)
+            hauteur = int(tailleMaxi)
+    else:
+        largeur = int(largeur)
+        hauteur = int(hauteur)
     img.Rescale(width=largeur, height=hauteur, quality=wx.IMAGE_QUALITY_HIGH)
-    position = (((tailleImage[0]/2.0) - (largeur/2.0)), ((tailleImage[1]/2.0) - (hauteur/2.0)))
+    position = (int((tailleImage[0] - largeur) / 2), int((tailleImage[1] - hauteur) / 2))
     img.Resize(tailleImage, position, 255, 255, 255)
     return img
 


### PR DESCRIPTION
## Objet

Correctif bloquant découvert en recette pré-production pendant une synchronisation portail.

## Défaut

`UTILS_Organisateur.RecadreImg()` calcule largeur/hauteur avec `/`. Sous Python 3, ces valeurs deviennent des `float`, mais `wx.Image.Rescale()` exige des entiers. Le parcours plante donc avec :

`TypeError: Image.Rescale(): argument 'width' has unexpected type 'float'`

Le calcul de position de `Resize()` utilisait également des flottants et est converti en entiers dans le même patch afin d'éviter le crash suivant.

## Correction

- dimensions explicitement converties en `int` ;
- position de centrage explicitement convertie en `int` ;
- aucune modification du protocole Connecthys ni des données envoyées.

## Portée

- 1 fichier applicatif ;
- aucun schéma ;
- aucune UI Repens ;
- compatibilité Python 3 / wxPython Phoenix uniquement.

Closes #198.