### PR TITLE
Vanilla — éviter le crash Factures sur une famille absente

### DIFF
--- a/noethys/Dlg/DLG_Famille_factures.py
+++ b/noethys/Dlg/DLG_Famille_factures.py
@@ -259,6 +259,8 @@ class Panel(wx.Panel):
             DB.ExecuterReq(req)
             listeDonnees = DB.ResultatReq()
             DB.Close()
+            if len(listeDonnees) == 0:
+                return
             self.IDcompte_payeur = listeDonnees[0][0]
             self.ctrl_listview.SetIDcompte_payeur(self.IDcompte_payeur)
         # MAJ des contrôles


### PR DESCRIPTION
## Défaut reproduit

La version historique peut lever `IndexError: list index out of range` dans `DLG_Famille_factures.Panel.MAJ()` lorsque la requête de récupération du compte payeur ne renvoie aucune famille.

## Correction

- vérifie que la requête a retourné une ligne avant l’accès à `listeDonnees[0][0]` ;
- quitte proprement la mise à jour du panneau si la famille n’existe plus ;
- aucun changement de schéma, de calcul de facturation ou de comportement nominal.

Correctif Vanilla historique minimal.