### PR TITLE
Vanilla — tolérer l’indisponibilité du service d’enregistrement

### DIFF
--- a/noethys/Dlg/DLG_Enregistrement.py
+++ b/noethys/Dlg/DLG_Enregistrement.py
@@ -263,11 +263,9 @@ class Dialog(wx.Dialog):
             h = urlopen(url, timeout=5)
             html = h.read()
             h.close()
-        except Exception as err:
-            self.AfficheEtatValidite(texte=u"Vérification impossible. Vérifiez votre connexion internet !", image="attention")
+        except Exception:
+            self.AfficheEtatValidite(texte=_(u"Vérification impossible : service d'enregistrement indisponible."), image="attention")
             del dlgAttente
-            print("pb dans verification code enregistrement.")
-            traceback.print_exc(file=sys.stdout)
             return False
 
         if six.PY3:


### PR DESCRIPTION
## Défaut observé

Le service historique `testcode.php` renvoie actuellement une erreur HTTP 500. L’ouverture/vérification de l’enregistrement produit alors un traceback complet alors qu’il s’agit d’une indisponibilité distante.

## Correction

- conserve intégralement la vérification historique lorsque le service répond ;
- en cas d’indisponibilité, affiche simplement que le service d’enregistrement est indisponible ;
- ne bloque pas la fermeture et conserve les identifiant/code déjà saisis ;
- supprime uniquement le traceback bruyant de cette indisponibilité distante.

Aucun contournement du mécanisme d’enregistrement, aucun changement de schéma.