### PR TITLE
Vanilla — restaurer les API historiques nécessaires sous Python 3 / Phoenix

### DIFF
--- a/noethys/Utils/UTILS_Adaptations.py
+++ b/noethys/Utils/UTILS_Adaptations.py
@@ -10,7 +10,26 @@
 
 import wx
 import sys
+import types
 from importlib import import_module
+
+
+# Compatibilité des API retirées sous Python 3 / wxPython Phoenix.
+# Ces alias conservent le comportement attendu par le code historique sans
+# modifier les parcours wxClassic/Python 2.
+if not hasattr(types, "StringTypes"):
+    types.StringTypes = (str,)
+
+if 'phoenix' in wx.PlatformInfo:
+    try:
+        if not hasattr(wx.PrintPreview, "Ok") and hasattr(wx.PrintPreview, "IsOk"):
+            wx.PrintPreview.Ok = wx.PrintPreview.IsOk
+        if not hasattr(wx.PreviewFrame, "MakeModal"):
+            def _PreviewFrameMakeModal(self, modal=True):
+                return None
+            wx.PreviewFrame.MakeModal = _PreviewFrameMakeModal
+    except Exception:
+        pass
 
 
 def Import(nom_module=""):

--- a/noethys/Utils/UTILS_Adaptations.py
+++ b/noethys/Utils/UTILS_Adaptations.py
@@ -11,6 +11,7 @@
 import wx
 import sys
 import types
+import threading
 from importlib import import_module
 
 
@@ -20,16 +21,31 @@ from importlib import import_module
 if not hasattr(types, "StringTypes"):
     types.StringTypes = (str,)
 
+if not hasattr(threading.Thread, "isAlive") and hasattr(threading.Thread, "is_alive"):
+    threading.Thread.isAlive = threading.Thread.is_alive
+
 if 'phoenix' in wx.PlatformInfo:
-    try:
-        if not hasattr(wx.PrintPreview, "Ok") and hasattr(wx.PrintPreview, "IsOk"):
-            wx.PrintPreview.Ok = wx.PrintPreview.IsOk
-        if not hasattr(wx.PreviewFrame, "MakeModal"):
-            def _PreviewFrameMakeModal(self, modal=True):
-                return None
-            wx.PreviewFrame.MakeModal = _PreviewFrameMakeModal
-    except Exception:
-        pass
+    if not hasattr(wx.PrintPreview, "Ok") and hasattr(wx.PrintPreview, "IsOk"):
+        wx.PrintPreview.Ok = wx.PrintPreview.IsOk
+
+    if not hasattr(wx.PreviewFrame, "MakeModal"):
+        def _PreviewFrameMakeModal(self, modal=True):
+            return None
+        wx.PreviewFrame.MakeModal = _PreviewFrameMakeModal
+
+    # wxClassic acceptait dans plusieurs parcours historiques des dimensions
+    # calculées en flottants. Phoenix exige des entiers pour Scale/Rescale.
+    _ImageScale = wx.Image.Scale
+    _ImageRescale = wx.Image.Rescale
+
+    def _ImageScaleEntier(self, width, height, *args, **kwargs):
+        return _ImageScale(self, int(width), int(height), *args, **kwargs)
+
+    def _ImageRescaleEntier(self, width, height, *args, **kwargs):
+        return _ImageRescale(self, int(width), int(height), *args, **kwargs)
+
+    wx.Image.Scale = _ImageScaleEntier
+    wx.Image.Rescale = _ImageRescaleEntier
 
 
 def Import(nom_module=""):


### PR DESCRIPTION
## Défauts issus de la recette et du dernier audit

Plusieurs parcours Vanilla utilisent encore des API tolérées par Python 2 / wxClassic mais retirées ou durcies sous Python 3 / wxPython Phoenix :

- `types.StringTypes` dans l’impression des Effectifs ;
- `PreviewFrame.MakeModal()` et, selon la version, `PrintPreview.Ok()` dans l’aperçu ;
- `Thread.isAlive()` dans l’updater ;
- dimensions flottantes passées à `wx.Image.Scale/Rescale`, notamment dans Noedoc et plusieurs contrôles historiques.

## Correction

Centralise les shims dans `UTILS_Adaptations`, déjà dédié aux différences wxClassic/Phoenix :

- restaure `types.StringTypes` sous Python 3 ;
- restaure `Thread.isAlive` via `is_alive` lorsqu’il manque ;
- alias `PrintPreview.Ok` vers `IsOk` si nécessaire ;
- rend `PreviewFrame.MakeModal` inoffensif sous Phoenix lorsqu’il n’existe plus ;
- convertit uniquement sous Phoenix les dimensions de `wx.Image.Scale/Rescale` en entiers avant appel à l’API native.

Les chemins Python 2 / wxClassic restent inchangés. Aucun métier, schéma ou protocole n’est modifié. Le but est de conserver le comportement historique tout en supprimant des crashes déterministes du portage Python 3/Phoenix.