### PR TITLE
Vanilla — préparer la release 1.3.4.2-r1

### DIFF
--- a/.github/workflows/vanilla-release.yml
+++ b/.github/workflows/vanilla-release.yml
@@ -1,0 +1,142 @@
+name: Publish Vanilla release
+
+on:
+  push:
+    branches:
+      - maintenance/vanilla
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.head_commit.message, '[release vanilla-1.3.4.2-r1]')
+    name: Construire et publier Vanilla+ 1.3.4.2-r1
+    runs-on: windows-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.10'
+          cache: pip
+
+      - name: Préparer les dépendances historiques compatibles Python 3
+        shell: pwsh
+        run: |
+          Get-Content requirements.txt |
+            Where-Object { $_.Trim() -ne 'pyttsx' } |
+            Set-Content requirements-vanilla-ci.txt -Encoding UTF8
+          python -m pip install --upgrade pip wheel
+          python -m pip install -r requirements-vanilla-ci.txt
+          python -m pip install pyttsx3 wxPython==4.2.5 'pyinstaller>=6,<7'
+
+      - name: Compiler les sources Vanilla
+        run: python -m compileall -q noethys
+
+      - name: Vérifier wxPython sous Windows
+        shell: pwsh
+        run: |
+          python -c "import wx; app=wx.App(False); print(wx.version()); app.Destroy()"
+
+      - name: Construire le dossier portable
+        run: pyinstaller --noconfirm --clean packaging/vanilla-noethys.spec
+
+      - name: Vérifier le contenu du paquet
+        shell: pwsh
+        run: |
+          if (-not (Test-Path 'dist/Noethys/Noethys.exe')) {
+            throw 'Noethys.exe absent du résultat PyInstaller'
+          }
+          foreach ($resource in @('Static', 'Versions.txt', 'Licence.txt', 'Icone.ico')) {
+            $path = Join-Path 'dist/Noethys' $resource
+            if (-not (Test-Path $path)) {
+              throw "Ressource attendue absente : $resource"
+            }
+          }
+          if (Test-Path 'dist/Noethys/_internal') {
+            throw 'Layout PyInstaller _internal détecté : incompatible avec les chemins historiques de Noethys'
+          }
+
+      - name: Smoke de démarrage de l'exécutable
+        shell: pwsh
+        run: |
+          $profileRoot = Join-Path $env:RUNNER_TEMP 'noethys-vanilla-profile'
+          New-Item -ItemType Directory -Path $profileRoot -Force | Out-Null
+          $env:APPDATA = Join-Path $profileRoot 'Roaming'
+          $env:LOCALAPPDATA = Join-Path $profileRoot 'Local'
+          New-Item -ItemType Directory -Path $env:APPDATA -Force | Out-Null
+          New-Item -ItemType Directory -Path $env:LOCALAPPDATA -Force | Out-Null
+
+          $process = Start-Process -FilePath 'dist/Noethys/Noethys.exe' -PassThru
+          Start-Sleep -Seconds 12
+          if ($process.HasExited) {
+            if ($process.ExitCode -ne 0) {
+              throw "Noethys.exe a quitté prématurément avec le code $($process.ExitCode)"
+            }
+          }
+          else {
+            Stop-Process -Id $process.Id -Force
+            Write-Host 'Noethys.exe est resté actif pendant le smoke de démarrage.'
+          }
+
+      - name: Écrire les informations de build
+        shell: pwsh
+        run: |
+          @(
+            'Noethys Vanilla+ 1.3.4.2-r1 - Windows portable'
+            "Commit: $env:GITHUB_SHA"
+            "Python: $(python --version 2>&1)"
+            "Workflow run: $env:GITHUB_RUN_ID"
+            'Base: Noethys upstream 1.3.4.2 + correctifs de maintenance Vanilla+'
+            'UI: interface historique, aucune refonte Upgrade/Repens'
+            "Build UTC: $([DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ'))"
+          ) | Set-Content -Path 'dist/Noethys/BUILD-INFO.txt' -Encoding UTF8
+
+      - name: Créer l'archive de release
+        shell: pwsh
+        run: Compress-Archive -Path 'dist/Noethys/*' -DestinationPath 'Noethys-Vanilla-1.3.4.2-r1-Windows-portable.zip'
+
+      - name: Préparer les notes de version
+        shell: pwsh
+        run: |
+          @'
+          # Noethys Vanilla+ 1.3.4.2-r1
+
+          Première release maintenue de la branche Vanilla de Noethys, basée sur la version historique 1.3.4.2.
+
+          Cette release conserve l'interface et le modèle de données historiques : aucune migration de schéma n'est introduite.
+
+          Principaux correctifs de maintenance :
+          - robustesse de plusieurs erreurs historiques rencontrées en exploitation ;
+          - sécurisation de l'accès aux factures d'une famille lorsque le compte payeur est absent ;
+          - tolérance à l'indisponibilité du service historique d'enregistrement ;
+          - correctifs de compatibilité d'impression et d'aperçu dans le runtime de build maintenu ;
+          - correction du bouton CAF/CDAP sous wxPhoenix ;
+          - journalisation locale des crashs et accès au suivi GitHub ;
+          - destinataire des rapports de bugs configurable par base et partagé entre les utilisateurs, avec repli sur l'adresse historique noethys@gmail.com ;
+          - libération explicite de la base SQLite temporaire utilisée par Connecthys afin d'éviter les verrous de fichiers sous Windows.
+
+          Le paquet joint est une version Windows portable. Une sauvegarde vérifiée de la base reste recommandée avant la première mise en production d'une nouvelle release.
+          '@ | Set-Content -Path 'RELEASE-NOTES.md' -Encoding UTF8
+
+      - name: Publier la release GitHub
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $tag = 'vanilla-1.3.4.2-r1'
+          $asset = 'Noethys-Vanilla-1.3.4.2-r1-Windows-portable.zip'
+          gh release view $tag *> $null
+          if ($LASTEXITCODE -eq 0) {
+            gh release upload $tag $asset --clobber
+            gh release edit $tag --title 'Noethys Vanilla+ 1.3.4.2-r1' --notes-file 'RELEASE-NOTES.md'
+          }
+          else {
+            gh release create $tag $asset --target $env:GITHUB_SHA --title 'Noethys Vanilla+ 1.3.4.2-r1' --notes-file 'RELEASE-NOTES.md' --latest
+          }

--- a/noethys/Dlg/DLG_Preferences.py
+++ b/noethys/Dlg/DLG_Preferences.py
@@ -24,6 +24,7 @@ from Utils import UTILS_Interface
 from Utils import UTILS_Fichiers
 from Utils import UTILS_Parametres
 from Utils import UTILS_Json
+from Utils import UTILS_Rapport_bugs
 
 
 
@@ -465,8 +466,11 @@ class Rapport_bugs(wx.Panel):
     def __init__(self, parent):
         wx.Panel.__init__(self, parent, id=-1, style=wx.TAB_TRAVERSAL)
 
-        self.staticbox_staticbox = wx.StaticBox(self, -1, _(u"Rapports de bugs"))
+        self.staticbox_staticbox = wx.StaticBox(self, -1, _(u"Maintenance et rapports de bugs"))
         self.check = wx.CheckBox(self, -1, _(u"Affichage du rapport de bugs lorsqu'une erreur est rencontrée"))
+        self.label_destinataire = wx.StaticText(self, -1, _(u"Adresse de réception :"))
+        self.ctrl_destinataire = wx.TextCtrl(self, -1, u"")
+        self.label_destinataire_aide = wx.StaticText(self, -1, _(u"Laisser vide pour utiliser l'adresse historique noethys@gmail.com."))
 
         self.__set_properties()
         self.__do_layout()
@@ -475,24 +479,46 @@ class Rapport_bugs(wx.Panel):
 
     def __set_properties(self):
         self.check.SetToolTip(wx.ToolTip(_(u"Affichage du rapport de bugs lorsqu'une erreur est rencontrée")))
+        self.ctrl_destinataire.SetToolTip(wx.ToolTip(_(u"Adresse de maintenance partagée par tous les utilisateurs de la base ouverte.")))
+        self.label_destinataire_aide.SetFont(wx.Font(7, wx.SWISS, wx.NORMAL, wx.NORMAL))
 
     def __do_layout(self):
         staticbox = wx.StaticBoxSizer(self.staticbox_staticbox, wx.VERTICAL)
-        grid_sizer_base = wx.FlexGridSizer(rows=2, cols=5, vgap=10, hgap=10)
+        grid_sizer_base = wx.FlexGridSizer(rows=2, cols=2, vgap=5, hgap=10)
         grid_sizer_base.Add(self.check, 0, wx.ALIGN_CENTER_VERTICAL, 0)
+        grid_sizer_base.Add((0, 0), 0, 0, 0)
+        grid_sizer_base.Add(self.label_destinataire, 0, wx.ALIGN_RIGHT|wx.ALIGN_CENTER_VERTICAL, 0)
+        grid_sizer_base.Add(self.ctrl_destinataire, 1, wx.EXPAND, 0)
+        grid_sizer_base.AddGrowableCol(1)
         staticbox.Add(grid_sizer_base, 1, wx.ALL|wx.EXPAND, 5)
+        staticbox.Add(self.label_destinataire_aide, 0, wx.LEFT|wx.RIGHT|wx.BOTTOM, 5)
         self.SetSizer(staticbox)
         staticbox.Fit(self)
     
     def Importation(self):
         valeur = UTILS_Config.GetParametre("rapports_bugs", True)
         self.check.SetValue(valeur)
+        try:
+            destinataire = UTILS_Parametres.Parametres(mode="get", categorie=UTILS_Rapport_bugs.CATEGORIE_PARAMETRES, nom=UTILS_Rapport_bugs.PARAM_DESTINATAIRE, valeur=u"")
+            if destinataire is None:
+                destinataire = u""
+        except Exception:
+            destinataire = u""
+        self.ctrl_destinataire.SetValue(destinataire)
     
     def Validation(self):
+        destinataire = self.ctrl_destinataire.GetValue().strip()
+        if len(destinataire) > 0 and "@" not in destinataire:
+            dlg = wx.MessageDialog(self, _(u"Veuillez saisir une adresse de réception valide ou laisser le champ vide pour utiliser noethys@gmail.com."), _(u"Adresse invalide"), wx.OK | wx.ICON_EXCLAMATION)
+            dlg.ShowModal()
+            dlg.Destroy()
+            self.ctrl_destinataire.SetFocus()
+            return False
         return True
     
     def Sauvegarde(self):
         UTILS_Config.SetParametre("rapports_bugs", self.check.GetValue())
+        UTILS_Rapport_bugs.SetDestinataireRapports(self.ctrl_destinataire.GetValue())
 
 # ---------------------------------------------------------------------------------------------------------------------------
 
@@ -940,5 +966,4 @@ if __name__ == u"__main__":
     app.SetTopWindow(dialog_1)
     dialog_1.ShowModal()
     app.MainLoop()
-
 

--- a/noethys/Utils/UTILS_Rapport_bugs.py
+++ b/noethys/Utils/UTILS_Rapport_bugs.py
@@ -25,10 +25,37 @@ import wx.lib.dialogs
 from Utils import UTILS_Config
 from Utils import UTILS_Customize
 from Utils import UTILS_Fichiers
+from Utils import UTILS_Parametres
 
 URL_SUIVI_BUGS = "https://github.com/fr4nck/Noethys/issues"
+CATEGORIE_PARAMETRES = "maintenance"
 PARAM_DESTINATAIRE = "adresse_rapport_bugs"
-DESTINATAIRE_DEFAUT = "multimedia@pelemele.org"
+DESTINATAIRE_DEFAUT = "noethys@gmail.com"
+
+
+def GetDestinataireRapports():
+    """Retourne le destinataire partagé par la base, avec repli sur l'adresse historique de Noethys."""
+    try:
+        adresse = UTILS_Parametres.Parametres(mode="get", categorie=CATEGORIE_PARAMETRES, nom=PARAM_DESTINATAIRE, valeur=u"")
+        if adresse is not None:
+            adresse = adresse.strip()
+            if len(adresse) > 0:
+                return adresse
+    except Exception:
+        pass
+    return DESTINATAIRE_DEFAUT
+
+
+def SetDestinataireRapports(adresse=u""):
+    """Mémorise le destinataire dans la base ouverte. Un échec ne doit jamais perturber le rapport de crash."""
+    try:
+        if adresse is None:
+            adresse = u""
+        adresse = adresse.strip()
+        UTILS_Parametres.Parametres(mode="set", categorie=CATEGORIE_PARAMETRES, nom=PARAM_DESTINATAIRE, valeur=adresse)
+        return True
+    except Exception:
+        return False
 
 
 def _GetRepLogs():
@@ -201,7 +228,7 @@ class DLG_Rapport(wx.Dialog):
             destinataire = ""
         destinataire = destinataire.strip()
         if len(destinataire) == 0:
-            destinataire = UTILS_Config.GetParametre(PARAM_DESTINATAIRE, DESTINATAIRE_DEFAUT) or DESTINATAIRE_DEFAUT
+            destinataire = GetDestinataireRapports()
         if len(destinataire) == 0 or "@" not in destinataire:
             dlg = wx.MessageDialog(self, _(u"Veuillez renseigner une adresse de réception valide pour le rapport d'erreur."), _(u"Envoi impossible"), wx.OK | wx.ICON_EXCLAMATION)
             dlg.ShowModal()
@@ -275,7 +302,7 @@ class DLG_Envoi(wx.Dialog):
         self.label_ligne_1 = wx.StaticText(self, wx.ID_ANY, _(u"Le rapport est prêt à être envoyé..."))
         self.label_ligne_2 = wx.StaticText(self, wx.ID_ANY, _(u"Choisissez l'adresse de réception, puis ajoutez si besoin un commentaire avant l'envoi."))
         self.label_destinataire = wx.StaticText(self, wx.ID_ANY, _(u"Adresse de réception :"))
-        self.ctrl_destinataire = wx.TextCtrl(self, wx.ID_ANY, UTILS_Config.GetParametre(PARAM_DESTINATAIRE, DESTINATAIRE_DEFAUT) or DESTINATAIRE_DEFAUT)
+        self.ctrl_destinataire = wx.TextCtrl(self, wx.ID_ANY, GetDestinataireRapports())
         self.ctrl_commentaires = wx.TextCtrl(self, wx.ID_ANY, "", style=wx.TE_MULTILINE)
         self.check_journal = wx.CheckBox(self, -1, _(u"Joindre les journaux d'erreurs (Recommandé)"))
 
@@ -293,7 +320,7 @@ class DLG_Envoi(wx.Dialog):
     def __set_properties(self):
         self.SetTitle(_(u"Envoyer le rapport d'erreur"))
         self.label_ligne_1.SetFont(wx.Font(9, wx.DEFAULT, wx.NORMAL, wx.BOLD, 0, ""))
-        self.ctrl_destinataire.SetToolTip(wx.ToolTip(_(u"Adresse Email qui recevra les futurs crashreports. Elle sera mémorisée sur ce poste.")))
+        self.ctrl_destinataire.SetToolTip(wx.ToolTip(_(u"Adresse Email de maintenance partagée par tous les utilisateurs de la base ouverte. Laissez vide pour utiliser noethys@gmail.com.")))
         self.ctrl_commentaires.SetToolTip(wx.ToolTip(_(u"Vous pouvez saisir des commentaires ici")))
         self.check_journal.SetToolTip(wx.ToolTip(_(u"Pour faciliter la résolution du bug, joignez les journaux locaux")))
         self.SetMinSize((600, 400))
@@ -328,19 +355,21 @@ class DLG_Envoi(wx.Dialog):
         commentaires = self.ctrl_commentaires.GetValue()
         if len(commentaires) == 0:
             commentaires = _(u"Aucun")
-        message = _(u"Destinataire : %s\n\nRapport : \n\n%s\nCommentaires : \n\n%s") % (self.GetDestinataire(), self.texteRapport, commentaires)
+        destinataire = self.GetDestinataire() or DESTINATAIRE_DEFAUT
+        message = _(u"Destinataire : %s\n\nRapport : \n\n%s\nCommentaires : \n\n%s") % (destinataire, self.texteRapport, commentaires)
         dlg = wx.lib.dialogs.ScrolledMessageDialog(self, message, _(u"Visualisation du contenu du message"))
         dlg.ShowModal()
         dlg.Destroy()
 
     def OnBoutonEnvoyer(self, event):
-        destinataire = self.GetDestinataire()
-        if len(destinataire) == 0 or "@" not in destinataire:
+        destinataire_saisi = self.GetDestinataire()
+        destinataire = destinataire_saisi or DESTINATAIRE_DEFAUT
+        if "@" not in destinataire:
             dlg = wx.MessageDialog(self, _(u"Veuillez saisir une adresse de réception valide."), _(u"Adresse invalide"), wx.OK | wx.ICON_EXCLAMATION)
             dlg.ShowModal()
             dlg.Destroy()
             return
-        UTILS_Config.SetParametre(PARAM_DESTINATAIRE, destinataire)
+        SetDestinataireRapports(destinataire_saisi)
         self.EndModal(wx.ID_OK)
 
     def OnBoutonAnnuler(self, event):


### PR DESCRIPTION
Prépare la première release maintenue Vanilla+ sans modifier le schéma ni le protocole de données.

- remplace le destinataire PMSL codé en dur par le destinataire historique de Noethys (`noethys@gmail.com`) en repli ;
- mémorise l'adresse de maintenance dans la table historique `parametres`, donc par base et partagée entre les postes qui utilisent cette base ;
- ajoute ce réglage dans Paramétrage > Préférences > Maintenance et rapports de bugs ;
- conserve le crashreport défensif : un échec d'accès à la base retombe sur l'adresse historique et ne masque pas l'exception initiale.

Le build Windows portable existant doit valider compilation, PyInstaller, ressources et smoke de démarrage avant fusion.