### PR TITLE
Windows — préserver la configuration et produire un installateur

### DIFF
--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -1,18 +1,26 @@
 name: Package Windows
 
-# Workflow réutilisable uniquement. La porte d'entrée humaine et automatique
-# est désormais ci.yml afin d'éviter les demandes concurrentes dans Actions.
+# Workflow réutilisable pour la qualification complète. Les PR qui touchent
+# directement au packaging ou à la migration de configuration déclenchent aussi
+# ce job : ce sont précisément les changements pour lesquels un vrai artefact
+# Windows est nécessaire avant fusion.
 on:
   workflow_call:
+  pull_request:
+    paths:
+      - 'noethys/Utils/UTILS_Fichiers.py'
+      - 'packaging/**'
+      - 'tests/test_noe_041_portable_paths.py'
+      - '.github/workflows/windows-package.yml'
 
 permissions:
   contents: read
 
 jobs:
   package:
-    name: Construire et exécuter Noethys portable
+    name: Construire et tester Noethys portable + installateur
     runs-on: windows-latest
-    timeout-minutes: 45
+    timeout-minutes: 55
 
     steps:
       - uses: actions/checkout@v7
@@ -46,7 +54,7 @@ jobs:
       - name: Valider les ressources PyInstaller essentielles
         run: python scripts/smoke_packaged_resources.py
 
-      - name: Construire le dossier portable
+      - name: Construire le dossier PyInstaller
         run: pyinstaller --noconfirm --clean packaging/noethys.spec
 
       - name: Vérifier l'exécutable et le layout historique
@@ -66,25 +74,149 @@ jobs:
           }
           Get-ChildItem "dist/Noethys" -Recurse | Measure-Object | Format-List
 
+      - name: Écrire les informations de build communes
+        shell: pwsh
+        run: |
+          $pythonVersion = (python --version 2>&1)
+          @(
+            "Noethys Windows"
+            "Commit: $env:GITHUB_SHA"
+            "Python: $pythonVersion"
+            "Workflow run: $env:GITHUB_RUN_ID"
+            "Python 3 source fixes: applied before PyInstaller"
+            "Build UTC: $([DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ'))"
+          ) | Set-Content -Path "dist/Noethys/BUILD-INFO.txt" -Encoding UTF8
+
+      - name: Préparer le dossier installable sans mode Portable
+        shell: pwsh
+        run: |
+          Remove-Item "dist/Noethys-installable" -Recurse -Force -ErrorAction SilentlyContinue
+          Copy-Item "dist/Noethys" "dist/Noethys-installable" -Recurse
+          if (Test-Path "dist/Noethys-installable/Portable") {
+            throw "Le dossier installable ne doit jamais contenir le marqueur Portable"
+          }
+
+      - name: Installer Inno Setup si nécessaire
+        shell: pwsh
+        run: |
+          $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
+          if (-not (Test-Path $iscc)) {
+            choco install innosetup -y --no-progress
+          }
+          if (-not (Test-Path $iscc)) {
+            throw "ISCC.exe introuvable après installation d'Inno Setup"
+          }
+
+      - name: Construire l'installateur Windows
+        shell: pwsh
+        run: |
+          $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
+          $version = "1.3.4.2-upgrade.$env:GITHUB_RUN_NUMBER"
+          & $iscc "/DMyAppVersion=$version" "packaging/noethys-installer.iss"
+          if ($LASTEXITCODE -ne 0) {
+            throw "Inno Setup a échoué avec le code $LASTEXITCODE"
+          }
+          if (-not (Test-Path "installer-output/Noethys-Upgrade-Setup.exe")) {
+            throw "Installateur Noethys-Upgrade-Setup.exe absent"
+          }
+
+      - name: Tester une mise à niveau sans perdre la configuration
+        shell: pwsh
+        run: |
+          $setup = (Resolve-Path "installer-output/Noethys-Upgrade-Setup.exe").Path
+          $installRoot = Join-Path $env:RUNNER_TEMP "noethys-installed"
+          $profileRoot = Join-Path $env:RUNNER_TEMP "noethys-installed-profile"
+          $workRoot = Join-Path $env:RUNNER_TEMP "noethys-foreign-cwd"
+          Remove-Item $installRoot -Recurse -Force -ErrorAction SilentlyContinue
+          Remove-Item $profileRoot -Recurse -Force -ErrorAction SilentlyContinue
+          Remove-Item $workRoot -Recurse -Force -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Path $installRoot -Force | Out-Null
+          New-Item -ItemType Directory -Path $profileRoot -Force | Out-Null
+          New-Item -ItemType Directory -Path $workRoot -Force | Out-Null
+
+          $roaming = Join-Path $profileRoot "Roaming"
+          $local = Join-Path $profileRoot "Local"
+          $configDir = Join-Path $roaming "noethys"
+          New-Item -ItemType Directory -Path $configDir -Force | Out-Null
+          New-Item -ItemType Directory -Path $local -Force | Out-Null
+          $config = Join-Path $configDir "Config.json"
+          $trap = Join-Path $workRoot "Config.json"
+          '{"nomFichier":"SENTINEL_EXISTANT","derniersFichiers":[],"interface_mysql":"mysqldb","pool_mysql":5}' | Set-Content -Path $config -Encoding UTF8
+          '{"nomFichier":"NE_DOIT_JAMAIS_ETRE_MIGRE"}' | Set-Content -Path $trap -Encoding UTF8
+          $configHashBefore = (Get-FileHash $config -Algorithm SHA256).Hash
+          $trapHashBefore = (Get-FileHash $trap -Algorithm SHA256).Hash
+
+          $installer = Start-Process -FilePath $setup -ArgumentList @(
+            '/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', "/DIR=$installRoot"
+          ) -PassThru -Wait
+          if ($installer.ExitCode -ne 0) {
+            throw "Installation silencieuse en échec (code $($installer.ExitCode))"
+          }
+
+          $exe = Join-Path $installRoot "Noethys.exe"
+          if (-not (Test-Path $exe)) {
+            throw "Noethys.exe absent après installation"
+          }
+          if (Test-Path (Join-Path $installRoot "Portable")) {
+            throw "L'installateur a créé un mode Portable : la configuration existante serait ignorée"
+          }
+
+          $savedPath = $env:PATH
+          $savedPythonHome = $env:PYTHONHOME
+          $savedPythonPath = $env:PYTHONPATH
+          $savedAppData = $env:APPDATA
+          $savedLocalAppData = $env:LOCALAPPDATA
+          try {
+            $env:NOETHYS_INSTALL_CONFIG_SMOKE = "1"
+            $env:NOETHYS_EXPECT_CONFIG_PATH = $config
+            $env:PYTHONHOME = ""
+            $env:PYTHONPATH = ""
+            $env:APPDATA = $roaming
+            $env:LOCALAPPDATA = $local
+            $env:PATH = "$env:SystemRoot\System32;$env:SystemRoot"
+
+            $process = Start-Process -FilePath $exe -WorkingDirectory $workRoot -PassThru
+            if (-not $process.WaitForExit(30000)) {
+              $process.Kill()
+              throw "Le smoke de configuration installée n'a pas quitté sous 30 secondes"
+            }
+
+            $errorMarker = Join-Path $installRoot "INSTALL-CONFIG-SMOKE-ERROR.txt"
+            $okMarker = Join-Path $installRoot "INSTALL-CONFIG-SMOKE-OK.txt"
+            if ($process.ExitCode -ne 0) {
+              if (Test-Path $errorMarker) { Get-Content $errorMarker | Write-Error }
+              throw "Smoke de configuration installée en échec (code $($process.ExitCode))"
+            }
+            if (-not (Test-Path $okMarker)) {
+              throw "Le smoke installable a quitté sans produire son marqueur de validation"
+            }
+            Get-Content $okMarker
+          }
+          finally {
+            Remove-Item Env:NOETHYS_INSTALL_CONFIG_SMOKE -ErrorAction SilentlyContinue
+            Remove-Item Env:NOETHYS_EXPECT_CONFIG_PATH -ErrorAction SilentlyContinue
+            $env:PATH = $savedPath
+            $env:PYTHONHOME = $savedPythonHome
+            $env:PYTHONPATH = $savedPythonPath
+            $env:APPDATA = $savedAppData
+            $env:LOCALAPPDATA = $savedLocalAppData
+          }
+
+          $configHashAfter = (Get-FileHash $config -Algorithm SHA256).Hash
+          $trapHashAfter = (Get-FileHash $trap -Algorithm SHA256).Hash
+          if ($configHashAfter -ne $configHashBefore) {
+            throw "Config.json existant a été modifié par l'installation ou le démarrage"
+          }
+          if ($trapHashAfter -ne $trapHashBefore) {
+            throw "Un Config.json du répertoire courant a été déplacé ou modifié"
+          }
+
       - name: Activer l'isolation portable
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Path "dist/Noethys/Portable" -Force | Out-Null
           Copy-Item "packaging/portable/README.txt" "dist/Noethys/Portable/README.txt"
-
-      - name: Écrire les informations de build
-        shell: pwsh
-        run: |
-          $pythonVersion = (python --version 2>&1)
-          @(
-            "Noethys portable Windows"
-            "Commit: $env:GITHUB_SHA"
-            "Python: $pythonVersion"
-            "Workflow run: $env:GITHUB_RUN_ID"
-            "Portable mode: enabled (Portable/)"
-            "Python 3 source fixes: applied before PyInstaller"
-            "Build UTC: $([DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ'))"
-          ) | Set-Content -Path "dist/Noethys/BUILD-INFO.txt" -Encoding UTF8
+          Add-Content -Path "dist/Noethys/BUILD-INFO.txt" -Value "Portable mode: enabled (Portable/)"
 
       - name: Créer l'archive portable
         shell: pwsh
@@ -156,6 +288,13 @@ jobs:
             $env:APPDATA = $savedAppData
             $env:LOCALAPPDATA = $savedLocalAppData
           }
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: Noethys-Windows-installer
+          path: installer-output/Noethys-Upgrade-Setup.exe
+          if-no-files-found: error
+          retention-days: 14
 
       - uses: actions/upload-artifact@v7
         with:

--- a/noethys/Utils/UTILS_Fichiers.py
+++ b/noethys/Utils/UTILS_Fichiers.py
@@ -107,23 +107,54 @@ def GetRepUtilisateur(fichier=""):
         os.mkdir(chemin)
     return os.path.join(chemin, fichier)
 
+
+def _MigreFichierLocal(source, destination):
+    """Migre un fichier historique sans jamais écraser le fichier utilisateur actif."""
+    if not os.path.isfile(source):
+        return False
+
+    source_absolue = os.path.abspath(source)
+    destination_absolue = os.path.abspath(destination)
+    if source_absolue == destination_absolue:
+        return False
+
+    # Une configuration déjà présente dans le profil utilisateur est
+    # autoritaire. Une mise à jour ne doit jamais la remplacer par une copie
+    # ancienne trouvée près de l'exécutable ou dans un ancien répertoire Data.
+    if os.path.exists(destination):
+        print(["migration ignoree, destination deja presente :", source, " > ", destination])
+        return False
+
+    print(["deplacement fichier config :", source, " > ", destination])
+    shutil.move(source, destination)
+    return True
+
+
 def DeplaceFichiers():
     """ Vérifie si des fichiers du répertoire Data ou du répertoire Utilisateur sont à déplacer vers le répertoire Utilisateur>AppData>Roaming """
 
-    # Déplace les fichiers de config et le journal
-    for nom in ("journal.log", "Config.json", "Customize.ini") :
-        for rep in ("", Chemins.GetMainPath("Data"), os.path.join(os.path.expanduser("~"), "noethys")) :
-            fichier = os.path.join(rep, nom)
-            if os.path.isfile(fichier) :
-                print(["deplacement fichier config :", fichier, " > ", GetRepUtilisateur(nom)])
-                shutil.move(fichier, GetRepUtilisateur(nom))
+    # Déplace les fichiers de config et le journal. L'ancien code utilisait
+    # rep="", donc le répertoire courant du processus : un raccourci Windows ou
+    # un installateur pouvait alors faire migrer un Config.json sans rapport
+    # avec Noethys. Les sources historiques sont désormais toutes explicites et
+    # ancrées sur le répertoire de l'application.
+    repertoires_historiques = (
+        Chemins.GetMainPath(""),
+        Chemins.GetMainPath("Data"),
+        os.path.join(os.path.expanduser("~"), "noethys"),
+    )
+    for nom in ("journal.log", "Config.json", "Config.json.bak", "Customize.ini") :
+        destination = GetRepUtilisateur(nom)
+        for rep in repertoires_historiques :
+            source = os.path.join(rep, nom)
+            _MigreFichierLocal(source, destination)
 
     # Déplace les fichiers xlang
     if os.path.isdir(Chemins.GetMainPath("Lang")) :
         for nomFichier in os.listdir(Chemins.GetMainPath("Lang")) :
             if nomFichier.endswith(".xlang") :
                 source = Chemins.GetMainPath(u"Lang/%s" % nomFichier)
-                print(["deplacement fichier xlang :", source, " > ", GetRepLang(nomFichier)])
+                print(["deplacement fichier config :", source, " > ", GetRepLang(nomFichier)])
                 shutil.move(source, GetRepLang(nomFichier))
 
     # Déplace les fichiers du répertoire Sync

--- a/packaging/noethys-installer.iss
+++ b/packaging/noethys-installer.iss
@@ -1,0 +1,42 @@
+; Installateur Windows de la ligne Upgrade Noethys.
+; Les données et la configuration utilisateur ne sont jamais embarquées ici :
+; elles restent gérées par UTILS_Fichiers dans le profil utilisateur.
+
+#ifndef MyAppVersion
+  #define MyAppVersion "1.3.4.2-upgrade"
+#endif
+
+[Setup]
+AppId=Noethys
+AppName=Noethys
+AppVersion={#MyAppVersion}
+AppPublisher=Noethys
+DefaultDirName={autopf}\Noethys
+DefaultGroupName=Noethys
+DisableProgramGroupPage=yes
+UsePreviousAppDir=yes
+PrivilegesRequired=admin
+OutputDir=..\installer-output
+OutputBaseFilename=Noethys-Upgrade-Setup
+SetupIconFile=..\noethys\Icone.ico
+UninstallDisplayIcon={app}\Noethys.exe
+Compression=lzma2
+SolidCompression=yes
+WizardStyle=modern
+CloseApplications=yes
+RestartApplications=no
+ChangesAssociations=no
+ChangesEnvironment=no
+
+[Files]
+Source: "..\dist\Noethys-installable\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{group}\Noethys"; Filename: "{app}\Noethys.exe"; WorkingDir: "{app}"
+Name: "{autodesktop}\Noethys"; Filename: "{app}\Noethys.exe"; WorkingDir: "{app}"; Tasks: desktopicon
+
+[Tasks]
+Name: "desktopicon"; Description: "Créer un raccourci sur le Bureau"; GroupDescription: "Raccourcis :"; Flags: unchecked
+
+[Run]
+Filename: "{app}\Noethys.exe"; Description: "Lancer Noethys"; Flags: nowait postinstall skipifsilent

--- a/packaging/runtime_frozen_smoke.py
+++ b/packaging/runtime_frozen_smoke.py
@@ -1,11 +1,14 @@
 # -*- coding: utf-8 -*-
-"""Smoke test du bundle PyInstaller avant l'exécution de Noethys.py.
+"""Smoke tests du bundle PyInstaller avant l'exécution de Noethys.py.
 
-Ce runtime hook ne fait strictement rien en usage normal. Quand
-``NOETHYS_FROZEN_SMOKE=1`` est défini, il valide que l'exécutable est réellement
-figé, que ses ressources essentielles sont présentes et que plusieurs piles
-runtime critiques sont importables depuis le bundle. Il quitte ensuite avant
-que Noethys n'ouvre une configuration ou une base utilisateur.
+Ce runtime hook ne fait strictement rien en usage normal.
+
+``NOETHYS_FROZEN_SMOKE=1`` valide le bundle portable sans ouvrir la
+configuration ni une base utilisateur.
+
+``NOETHYS_INSTALL_CONFIG_SMOKE=1`` valide le contrat de l'installable : la
+configuration doit rester dans le profil utilisateur, ne jamais dépendre du
+répertoire courant et ne pas être remplacée par la migration historique.
 
 Le hook utilise ``os._exit`` en mode smoke afin qu'un échec dans une application
 PyInstaller ``console=False`` ne puisse pas ouvrir une boîte de dialogue fatale
@@ -19,19 +22,83 @@ import sys
 from pathlib import Path
 
 
-def _finish(root: Path, code: int, message: str) -> None:
-    marker = root / ("FROZEN-SMOKE-OK.txt" if code == 0 else "FROZEN-SMOKE-ERROR.txt")
+def _finish(root: Path, code: int, message: str, marker_prefix: str = "FROZEN-SMOKE") -> None:
+    marker = root / ("%s-OK.txt" % marker_prefix if code == 0 else "%s-ERROR.txt" % marker_prefix)
     try:
         marker.write_text(message + "\n", encoding="utf-8")
     finally:
         os._exit(code)
 
 
+def _require_frozen(root: Path, marker_prefix: str) -> None:
+    if not getattr(sys, "frozen", False):
+        _finish(root, 2, "Le smoke exige un exécutable figé", marker_prefix)
+
+
+if os.environ.get("NOETHYS_INSTALL_CONFIG_SMOKE") == "1":
+    root = Path(sys.executable).resolve().parent
+    marker_prefix = "INSTALL-CONFIG-SMOKE"
+    _require_frozen(root, marker_prefix)
+
+    if (root / "Portable").exists():
+        _finish(
+            root,
+            5,
+            "L'installable contient un marqueur Portable et isolerait la configuration utilisateur",
+            marker_prefix,
+        )
+
+    expected_raw = os.environ.get("NOETHYS_EXPECT_CONFIG_PATH", "")
+    if not expected_raw:
+        _finish(root, 6, "NOETHYS_EXPECT_CONFIG_PATH est absent", marker_prefix)
+
+    expected = Path(expected_raw).resolve()
+    if not expected.is_file():
+        _finish(root, 7, "La configuration sentinelle attendue est absente: %s" % expected, marker_prefix)
+
+    before = expected.read_bytes()
+    try:
+        import Chemins
+        from Utils import UTILS_Fichiers
+
+        actual = Path(UTILS_Fichiers.GetRepUtilisateur("Config.json")).resolve()
+        if actual != expected:
+            _finish(
+                root,
+                8,
+                "Mauvais chemin de configuration: %s (attendu: %s)" % (actual, expected),
+                marker_prefix,
+            )
+
+        application_root = Path(Chemins.GetMainPath("")).resolve()
+        if application_root != root:
+            _finish(
+                root,
+                9,
+                "Le chemin applicatif figé n'est pas ancré sur Noethys.exe: %s" % application_root,
+                marker_prefix,
+            )
+
+        # Rejoue la migration réellement exécutée au démarrage. Avec une
+        # configuration déjà existante, elle doit être strictement sans effet.
+        UTILS_Fichiers.DeplaceFichiers()
+    except Exception as exc:
+        _finish(
+            root,
+            10,
+            "Smoke configuration installée en échec: %s: %s" % (type(exc).__name__, exc),
+            marker_prefix,
+        )
+
+    if not expected.is_file() or expected.read_bytes() != before:
+        _finish(root, 11, "La configuration utilisateur a été modifiée pendant la migration", marker_prefix)
+
+    _finish(root, 0, "Configuration installable Noethys préservée", marker_prefix)
+
+
 if os.environ.get("NOETHYS_FROZEN_SMOKE") == "1":
     root = Path(sys.executable).resolve().parent
-
-    if not getattr(sys, "frozen", False):
-        _finish(root, 2, "Le smoke NOETHYS_FROZEN_SMOKE exige un exécutable figé")
+    _require_frozen(root, "FROZEN-SMOKE")
 
     required = (
         root / "Static",

--- a/tests/test_noe_041_portable_paths.py
+++ b/tests/test_noe_041_portable_paths.py
@@ -1,16 +1,24 @@
 # -*- coding: utf-8 -*-
 import importlib.util
+import os
 import sys
 import tempfile
 import types
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
-def _load_utils_files(root):
+def _load_utils_files(root, config_root=None):
+    root = Path(root)
+    config_root = Path(config_root) if config_root is not None else root / "outside-user-config"
+    (root / "outside-site-data").mkdir(parents=True, exist_ok=True)
+    (root / "outside-user-data").mkdir(parents=True, exist_ok=True)
+    config_root.mkdir(parents=True, exist_ok=True)
+
     chemins = types.ModuleType("Chemins")
-    chemins.GetMainPath = lambda fichier="": str(Path(root) / fichier)
-    chemins.GetStaticPath = lambda fichier="": str(Path(root) / "Static" / fichier)
+    chemins.GetMainPath = lambda fichier="": str(root / fichier)
+    chemins.GetStaticPath = lambda fichier="": str(root / "Static" / fichier)
     sys.modules["Chemins"] = chemins
 
     utils_pkg = types.ModuleType("Utils")
@@ -23,9 +31,9 @@ def _load_utils_files(root):
     utils_pkg.UTILS_Customize = customize
 
     appdirs = types.ModuleType("appdirs")
-    appdirs.site_data_dir = lambda **kwargs: str(Path(root) / "outside-site-data")
-    appdirs.user_data_dir = lambda **kwargs: str(Path(root) / "outside-user-data")
-    appdirs.user_config_dir = lambda **kwargs: str(Path(root) / "outside-user-config")
+    appdirs.site_data_dir = lambda **kwargs: str(root / "outside-site-data")
+    appdirs.user_data_dir = lambda **kwargs: str(root / "outside-user-data")
+    appdirs.user_config_dir = lambda **kwargs: str(config_root)
     sys.modules["appdirs"] = appdirs
 
     six = types.ModuleType("six")
@@ -80,6 +88,94 @@ class PortablePathsTests(unittest.TestCase):
             data = Path(module.GetRepData("demo.dat"))
             self.assertNotIn("outside-", str(config))
             self.assertNotIn("outside-", str(data))
+
+
+class InstallableConfigPathsTests(unittest.TestCase):
+    def test_config_path_is_independent_from_process_working_directory(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            profile = root / "profile-roaming"
+            module = _load_utils_files(root, config_root=profile)
+            cwd_a = root / "cwd-a"
+            cwd_b = root / "cwd-b"
+            cwd_a.mkdir()
+            cwd_b.mkdir()
+
+            previous = Path.cwd()
+            try:
+                os.chdir(str(cwd_a))
+                path_a = Path(module.GetRepUtilisateur("Config.json"))
+                os.chdir(str(cwd_b))
+                path_b = Path(module.GetRepUtilisateur("Config.json"))
+            finally:
+                os.chdir(str(previous))
+
+            expected = profile / "noethys" / "Config.json"
+            self.assertEqual(path_a, expected)
+            self.assertEqual(path_b, expected)
+
+    def test_migration_does_not_read_config_from_current_working_directory(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            profile = root / "profile-roaming"
+            module = _load_utils_files(root, config_root=profile)
+            cwd = root / "foreign-working-directory"
+            cwd.mkdir()
+            foreign_config = cwd / "Config.json"
+            foreign_config.write_text('{"source":"foreign"}', encoding="utf-8")
+            home = root / "home"
+            home.mkdir()
+
+            previous = Path.cwd()
+            try:
+                os.chdir(str(cwd))
+                with mock.patch.dict(os.environ, {"HOME": str(home)}, clear=False):
+                    module.DeplaceFichiers()
+            finally:
+                os.chdir(str(previous))
+
+            self.assertEqual(foreign_config.read_text(encoding="utf-8"), '{"source":"foreign"}')
+            self.assertFalse((profile / "noethys" / "Config.json").exists())
+
+    def test_migration_never_overwrites_existing_user_config(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            profile = root / "profile-roaming"
+            module = _load_utils_files(root, config_root=profile)
+            legacy_config = root / "Config.json"
+            legacy_config.write_text('{"source":"legacy"}', encoding="utf-8")
+            active_config = Path(module.GetRepUtilisateur("Config.json"))
+            active_config.write_text('{"source":"active"}', encoding="utf-8")
+            home = root / "home"
+            home.mkdir()
+
+            with mock.patch.dict(os.environ, {"HOME": str(home)}, clear=False):
+                module.DeplaceFichiers()
+
+            self.assertEqual(active_config.read_text(encoding="utf-8"), '{"source":"active"}')
+            self.assertEqual(legacy_config.read_text(encoding="utf-8"), '{"source":"legacy"}')
+
+    def test_migration_moves_application_config_and_backup_when_destination_is_empty(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            profile = root / "profile-roaming"
+            module = _load_utils_files(root, config_root=profile)
+            legacy_config = root / "Config.json"
+            legacy_backup = root / "Config.json.bak"
+            legacy_config.write_text('{"source":"legacy"}', encoding="utf-8")
+            legacy_backup.write_text('{"source":"backup"}', encoding="utf-8")
+            home = root / "home"
+            home.mkdir()
+
+            with mock.patch.dict(os.environ, {"HOME": str(home)}, clear=False):
+                module.DeplaceFichiers()
+
+            active_config = profile / "noethys" / "Config.json"
+            active_backup = profile / "noethys" / "Config.json.bak"
+            self.assertEqual(active_config.read_text(encoding="utf-8"), '{"source":"legacy"}')
+            self.assertEqual(active_backup.read_text(encoding="utf-8"), '{"source":"backup"}')
+            self.assertFalse(legacy_config.exists())
+            self.assertFalse(legacy_backup.exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Objectif

Fournir un véritable installateur Windows Upgrade sans transformer une mise à jour en faux premier démarrage ni toucher à la configuration existante.

## Bug historique corrigé

`UTILS_Fichiers.DeplaceFichiers()` utilisait `rep=""`, donc le répertoire courant du processus, comme source potentielle de `Config.json`. Selon le raccourci ou le contexte de lancement, un fichier sans rapport avec Noethys pouvait ainsi être migré vers le profil utilisateur. La migration pouvait également tenter de remplacer une configuration déjà présente.

## Correctifs

- les sources historiques sont désormais ancrées explicitement sur le répertoire applicatif, `Data` et l'ancien `~/noethys` ;
- le répertoire courant n'est plus jamais une source de migration ;
- une configuration déjà présente dans le profil utilisateur est autoritaire et n'est jamais écrasée ;
- `Config.json.bak` est migré avec `Config.json` lorsqu'une migration historique est réellement nécessaire ;
- tests de non-régression sur changement de CWD, conservation d'une config existante et migration legacy.

## Installateur Windows

- ajoute un installateur Inno Setup `Noethys-Upgrade-Setup.exe` ;
- l'installable est construit à partir d'un bundle PyInstaller **sans dossier `Portable`** ;
- `AppId=Noethys` et `UsePreviousAppDir=yes` permettent à Inno Setup de réutiliser l'emplacement d'une installation précédente compatible ;
- aucune configuration ni donnée utilisateur n'est embarquée ou supprimée par l'installateur.

## Qualification binaire

Le workflow Windows installe silencieusement le nouvel installateur dans un répertoire propre, crée une configuration sentinelle dans un faux `%APPDATA%`, lance `Noethys.exe` depuis un autre répertoire contenant un faux `Config.json`, puis vérifie que :

- l'exécutable installé résout exactement la configuration du profil utilisateur ;
- la migration de démarrage ne la modifie pas ;
- le faux `Config.json` du répertoire courant reste intact ;
- l'installation ne contient aucun marqueur `Portable` ;
- le portable historique continue d'être construit et smoke-testé séparément.

Cette PR déclenche volontairement la fabrication Windows parce qu'elle touche directement au packaging et à la migration de configuration.