### PR TITLE
Vanilla+ — livrer un vrai installateur Windows

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -1,0 +1,59 @@
+name: Package Windows Installer
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'packaging/windows/**'
+      - 'packaging/noethys.spec'
+      - '.github/workflows/windows-installer.yml'
+      - 'requirements*.txt'
+
+permissions:
+  contents: read
+
+jobs:
+  installer:
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.10'
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-build.txt
+      - name: Installer les dépendances de fabrication
+        run: python -m pip install --upgrade pip wheel && python -m pip install -r requirements-build.txt
+      - name: Appliquer les corrections runtime Python 3 validées
+        run: python scripts/apply_py3_runtime_source_fixes.py
+      - name: Construire Noethys
+        run: pyinstaller --noconfirm --clean packaging/noethys.spec
+      - name: Vérifier le payload
+        shell: pwsh
+        run: |
+          if (-not (Test-Path 'dist/Noethys/Noethys.exe')) { throw 'Noethys.exe absent' }
+          if (Test-Path 'dist/Noethys/Portable') { Remove-Item 'dist/Noethys/Portable' -Recurse -Force }
+      - name: Installer Inno Setup
+        shell: pwsh
+        run: choco install innosetup --no-progress -y
+      - name: Construire le Setup
+        shell: pwsh
+        run: |
+          $version = "0.0.$env:GITHUB_RUN_NUMBER"
+          & "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe" "/DMyAppVersion=$version" "packaging\windows\Noethys-VanillaPlus.iss"
+          if (-not (Test-Path 'dist-installer/Noethys-VanillaPlus-Setup.exe')) { throw 'Setup absent' }
+      - name: Vérifier que le Setup est un exécutable Windows
+        shell: pwsh
+        run: |
+          $f = Get-Item 'dist-installer/Noethys-VanillaPlus-Setup.exe'
+          if ($f.Length -lt 1MB) { throw 'Setup anormalement petit' }
+          Get-FileHash $f.FullName -Algorithm SHA256
+      - uses: actions/upload-artifact@v7
+        with:
+          name: Noethys-VanillaPlus-Setup
+          path: dist-installer/Noethys-VanillaPlus-Setup.exe
+          if-no-files-found: error
+          retention-days: 14

--- a/packaging/windows/Noethys-VanillaPlus.iss
+++ b/packaging/windows/Noethys-VanillaPlus.iss
@@ -1,0 +1,72 @@
+#define MyAppName "Noethys Vanilla+"
+#define MyAppExeName "Noethys.exe"
+#ifndef MyAppVersion
+  #define MyAppVersion "0.0.0-dev"
+#endif
+
+[Setup]
+AppId={{8D89C258-714E-4CB4-A0A8-0FCEBC6EEBA8}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+AppPublisher=PMSL
+DefaultDirName={code:GetInstallDir}
+DisableDirPage=auto
+UsePreviousAppDir=yes
+PrivilegesRequired=admin
+ArchitecturesAllowed=x64compatible
+OutputDir=..\..\dist-installer
+OutputBaseFilename=Noethys-VanillaPlus-Setup
+Compression=lzma2
+SolidCompression=yes
+WizardStyle=modern
+CloseApplications=yes
+RestartApplications=no
+Uninstallable=yes
+SetupLogging=yes
+
+[Files]
+Source: "..\..\dist\Noethys\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs; Excludes: "Portable\*"
+
+[Icons]
+Name: "{autoprograms}\Noethys"; Filename: "{app}\{#MyAppExeName}"; WorkingDir: "{app}"
+Name: "{autodesktop}\Noethys"; Filename: "{app}\{#MyAppExeName}"; WorkingDir: "{app}"; Tasks: desktopicon
+
+[Tasks]
+Name: "desktopicon"; Description: "Créer un raccourci sur le Bureau"; GroupDescription: "Raccourcis :"; Flags: unchecked
+
+[Run]
+Filename: "{app}\{#MyAppExeName}"; Description: "Lancer Noethys"; Flags: nowait postinstall skipifsilent
+
+[Code]
+function ExistingNoethysDir(): String;
+var
+  Candidate: String;
+begin
+  Result := '';
+  if RegQueryStringValue(HKLM32, 'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Noethys_is1', 'InstallLocation', Candidate) and DirExists(Candidate) then begin Result := Candidate; exit; end;
+  if RegQueryStringValue(HKLM64, 'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Noethys_is1', 'InstallLocation', Candidate) and DirExists(Candidate) then begin Result := Candidate; exit; end;
+  Candidate := ExpandConstant('{pf32}\Noethys');
+  if FileExists(AddBackslash(Candidate) + '{#MyAppExeName}') then begin Result := Candidate; exit; end;
+  Candidate := ExpandConstant('{pf}\Noethys');
+  if FileExists(AddBackslash(Candidate) + '{#MyAppExeName}') then Result := Candidate;
+end;
+
+function GetInstallDir(Param: String): String;
+var
+  Existing: String;
+begin
+  Existing := ExistingNoethysDir();
+  if Existing <> '' then Result := Existing else Result := ExpandConstant('{autopf}\Noethys');
+end;
+
+function InitializeSetup(): Boolean;
+var
+  Existing: String;
+begin
+  Result := True;
+  Existing := ExistingNoethysDir();
+  if Existing <> '' then
+    Log('Installation Noethys existante détectée : ' + Existing)
+  else
+    Log('Aucune installation Noethys existante détectée : installation standard.');
+end;


### PR DESCRIPTION
Remplace la cible de livraison portable pour PMSL par un vrai Setup Windows.

- construit le payload PyInstaller existant ;
- exclut explicitement le marqueur/dossier Portable ;
- détecte une installation Noethys existante et réutilise son répertoire ;
- remplace les fichiers applicatifs sans supprimer les fichiers de configuration/données non présents dans le payload ;
- crée/maintient les raccourcis Windows ;
- produit `Noethys-VanillaPlus-Setup.exe` via Inno Setup ;
- conserve le ZIP portable existant comme artefact séparé de test/debug.

Le workflow est déclenchable manuellement et sur les PR touchant le packaging installateur.