### PR TITLE
Vanilla — clôturer le lot bugfix avant rentrée

### DIFF
--- a/.github/workflows/vanilla-r2.yml
+++ b/.github/workflows/vanilla-r2.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'noethys/Utils/UTILS_Fichiers.py'
       - 'noethys/Utils/UTILS_Rapport_bugs.py'
+      - 'tests/test_vanilla_crash_recipient.py'
       - 'packaging/vanilla-installer.iss'
       - 'packaging/vanilla-noethys.spec'
       - '.github/workflows/vanilla-r2.yml'
@@ -47,6 +48,9 @@ jobs:
 
       - name: Compiler les sources
         run: python -m compileall -q noethys
+
+      - name: Tester la migration du destinataire de crashreports
+        run: python -m unittest tests.test_vanilla_crash_recipient
 
       - name: Vérifier wxPython sous Windows
         shell: pwsh

--- a/.github/workflows/vanilla-r2.yml
+++ b/.github/workflows/vanilla-r2.yml
@@ -1,0 +1,191 @@
+name: Vanilla r2 - portable et installateur
+
+on:
+  pull_request:
+    paths:
+      - 'noethys/Utils/UTILS_Fichiers.py'
+      - 'noethys/Utils/UTILS_Rapport_bugs.py'
+      - 'packaging/vanilla-installer.iss'
+      - 'packaging/vanilla-noethys.spec'
+      - '.github/workflows/vanilla-r2.yml'
+      - 'requirements.txt'
+  push:
+    branches:
+      - maintenance/vanilla
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  qualify:
+    if: >-
+      github.event_name == 'pull_request' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.head_commit.message, '[release vanilla-1.3.4.2-r2]')
+    name: Qualifier Vanilla 1.3.4.2-r2
+    runs-on: windows-latest
+    timeout-minutes: 55
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.10'
+          cache: pip
+
+      - name: Préparer les dépendances Vanilla
+        shell: pwsh
+        run: |
+          Get-Content requirements.txt |
+            Where-Object { $_.Trim() -ne 'pyttsx' } |
+            Set-Content requirements-vanilla-ci.txt -Encoding UTF8
+          python -m pip install --upgrade pip wheel
+          python -m pip install -r requirements-vanilla-ci.txt
+          python -m pip install pyttsx3 wxPython==4.2.5 'pyinstaller>=6,<7'
+
+      - name: Compiler les sources
+        run: python -m compileall -q noethys
+
+      - name: Vérifier wxPython sous Windows
+        shell: pwsh
+        run: python -c "import wx; app=wx.App(False); print(wx.version()); app.Destroy()"
+
+      - name: Construire Noethys
+        run: pyinstaller --noconfirm --clean packaging/vanilla-noethys.spec
+
+      - name: Vérifier le payload
+        shell: pwsh
+        run: |
+          if (-not (Test-Path 'dist/Noethys/Noethys.exe')) { throw 'Noethys.exe absent' }
+          foreach ($resource in @('Static', 'Versions.txt', 'Licence.txt', 'Icone.ico')) {
+            if (-not (Test-Path (Join-Path 'dist/Noethys' $resource))) { throw "Ressource absente : $resource" }
+          }
+          if (Test-Path 'dist/Noethys/_internal') { throw 'Layout PyInstaller _internal incompatible' }
+
+          @(
+            'Noethys Vanilla 1.3.4.2-r2 - Windows'
+            "Commit: $env:GITHUB_SHA"
+            "Python: $(python --version 2>&1)"
+            "Workflow run: $env:GITHUB_RUN_ID"
+            'UI: interface historique, aucune refonte Upgrade/Repens'
+            "Build UTC: $([DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ'))"
+          ) | Set-Content -Path 'dist/Noethys/BUILD-INFO.txt' -Encoding UTF8
+
+      - name: Préparer le payload installable
+        shell: pwsh
+        run: |
+          Remove-Item 'dist/Noethys-installable' -Recurse -Force -ErrorAction SilentlyContinue
+          Copy-Item 'dist/Noethys' 'dist/Noethys-installable' -Recurse
+          Remove-Item 'dist/Noethys-installable/Portable' -Recurse -Force -ErrorAction SilentlyContinue
+          if (Test-Path 'dist/Noethys-installable/Portable') { throw 'Le Setup ne doit jamais contenir Portable/' }
+
+      - name: Construire le Setup Windows
+        shell: pwsh
+        run: |
+          choco install innosetup --no-progress -y
+          $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
+          if (-not (Test-Path $iscc)) { throw 'ISCC.exe introuvable' }
+          & $iscc '/DMyAppVersion=1.3.4.2-r2' 'packaging\vanilla-installer.iss'
+          if ($LASTEXITCODE -ne 0) { throw "Inno Setup a échoué : $LASTEXITCODE" }
+          if (-not (Test-Path 'installer-output/Noethys-Vanilla-Setup.exe')) { throw 'Setup absent' }
+
+      - name: Tester installation et conservation de la configuration
+        shell: pwsh
+        run: |
+          $setup = (Resolve-Path 'installer-output/Noethys-Vanilla-Setup.exe').Path
+          $installRoot = Join-Path $env:RUNNER_TEMP 'noethys-vanilla-installed'
+          $profileRoot = Join-Path $env:RUNNER_TEMP 'noethys-vanilla-profile'
+          $workRoot = Join-Path $env:RUNNER_TEMP 'foreign-cwd'
+          Remove-Item $installRoot,$profileRoot,$workRoot -Recurse -Force -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Path $installRoot,$profileRoot,$workRoot -Force | Out-Null
+
+          $roaming = Join-Path $profileRoot 'Roaming'
+          $local = Join-Path $profileRoot 'Local'
+          $configDir = Join-Path $roaming 'noethys'
+          New-Item -ItemType Directory -Path $configDir,$local -Force | Out-Null
+          $config = Join-Path $configDir 'Config.json'
+          $foreign = Join-Path $workRoot 'Config.json'
+          '{"nomFichier":"","derniersFichiers":[],"interface_mysql":"mysqldb","pool_mysql":5}' | Set-Content $config -Encoding UTF8
+          '{"nomFichier":"NE_DOIT_PAS_ETRE_MIGRE"}' | Set-Content $foreign -Encoding UTF8
+          $configBefore = (Get-FileHash $config -Algorithm SHA256).Hash
+          $foreignBefore = (Get-FileHash $foreign -Algorithm SHA256).Hash
+
+          $p = Start-Process $setup -ArgumentList @('/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART',"/DIR=$installRoot") -PassThru -Wait
+          if ($p.ExitCode -ne 0) { throw "Installation silencieuse en échec : $($p.ExitCode)" }
+          $exe = Join-Path $installRoot 'Noethys.exe'
+          if (-not (Test-Path $exe)) { throw 'Noethys.exe absent après installation' }
+          if (Test-Path (Join-Path $installRoot 'Portable')) { throw 'Mode Portable présent dans le Setup' }
+
+          $savedAppData = $env:APPDATA
+          $savedLocalAppData = $env:LOCALAPPDATA
+          try {
+            $env:APPDATA = $roaming
+            $env:LOCALAPPDATA = $local
+            $app = Start-Process $exe -WorkingDirectory $workRoot -PassThru
+            Start-Sleep -Seconds 10
+            if ($app.HasExited) {
+              if ($app.ExitCode -ne 0) { throw "Noethys a quitté avec le code $($app.ExitCode)" }
+            } else {
+              Stop-Process -Id $app.Id -Force
+            }
+          }
+          finally {
+            $env:APPDATA = $savedAppData
+            $env:LOCALAPPDATA = $savedLocalAppData
+          }
+
+          if ((Get-FileHash $config -Algorithm SHA256).Hash -ne $configBefore) { throw 'Config.json utilisateur a été modifié' }
+          if ((Get-FileHash $foreign -Algorithm SHA256).Hash -ne $foreignBefore) { throw 'Config.json du CWD a été déplacé ou modifié' }
+
+      - name: Créer le portable
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path 'dist/Noethys/Portable' -Force | Out-Null
+          if (Test-Path 'packaging/portable/README.txt') {
+            Copy-Item 'packaging/portable/README.txt' 'dist/Noethys/Portable/README.txt'
+          }
+          Add-Content 'dist/Noethys/BUILD-INFO.txt' 'Portable mode: enabled (Portable/)'
+          Compress-Archive -Path 'dist/Noethys/*' -DestinationPath 'Noethys-Vanilla-1.3.4.2-r2-Windows-portable.zip'
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: Noethys-Vanilla-r2-Windows
+          path: |
+            installer-output/Noethys-Vanilla-Setup.exe
+            Noethys-Vanilla-1.3.4.2-r2-Windows-portable.zip
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Publier la release r2
+        if: github.event_name == 'push' && contains(github.event.head_commit.message, '[release vanilla-1.3.4.2-r2]')
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          @'
+          # Noethys Vanilla 1.3.4.2-r2
+
+          Release de clôture du lot Vanilla bugfix avant rentrée.
+
+          - corrections historiques et robustesse cumulées de la branche maintenance/vanilla ;
+          - configuration existante préservée lors des mises à jour ;
+          - migration des anciens fichiers de configuration bornée aux répertoires Noethys ;
+          - destinataire de crashreport historique/local préservé et écriture partagée vérifiée ;
+          - vrai installateur Windows Inno Setup réutilisant l'identité historique Noethys ;
+          - portable conservé pour recette et dépannage ;
+          - aucune migration de schéma de base ;
+          - aucune refonte UI Upgrade/Repens.
+          '@ | Set-Content RELEASE-NOTES-r2.md -Encoding UTF8
+
+          $tag = 'vanilla-1.3.4.2-r2'
+          $setup = 'installer-output/Noethys-Vanilla-Setup.exe'
+          $portable = 'Noethys-Vanilla-1.3.4.2-r2-Windows-portable.zip'
+          gh release view $tag *> $null
+          if ($LASTEXITCODE -eq 0) {
+            gh release upload $tag $setup $portable --clobber
+            gh release edit $tag --title 'Noethys Vanilla 1.3.4.2-r2' --notes-file RELEASE-NOTES-r2.md
+          } else {
+            gh release create $tag $setup $portable --target $env:GITHUB_SHA --title 'Noethys Vanilla 1.3.4.2-r2' --notes-file RELEASE-NOTES-r2.md --latest
+          }

--- a/noethys/Utils/UTILS_Fichiers.py
+++ b/noethys/Utils/UTILS_Fichiers.py
@@ -3,7 +3,7 @@
 #------------------------------------------------------------------------
 # Application :    Noethys, gestion multi-activités
 # Site internet :  www.noethys.com
-# Auteur:           Ivan LUCAS
+# Auteur:          Ivan LUCAS
 # Copyright:       (c) 2010-16 Ivan LUCAS
 # Licence:         Licence GNU GPL
 #------------------------------------------------------------------------
@@ -99,16 +99,58 @@ def GetRepUtilisateur(fichier=""):
     # Ajoute le dirname si besoin
     return os.path.join(chemin, fichier)
 
+
+def _MigreFichierLocal(source, destination):
+    """Migre un fichier historique sans jamais écraser le fichier utilisateur actif."""
+    if not os.path.isfile(source):
+        return False
+
+    source_absolue = os.path.abspath(source)
+    destination_absolue = os.path.abspath(destination)
+    if source_absolue == destination_absolue:
+        return False
+
+    if os.path.exists(destination):
+        print(["migration ignoree, destination deja presente :", source, " > ", destination])
+        return False
+
+    print(["deplacement fichier config :", source, " > ", destination])
+    shutil.move(source, destination)
+    return True
+
+
 def DeplaceFichiers():
     """ Vérifie si des fichiers du répertoire Data ou du répertoire Utilisateur sont à déplacer vers le répertoire Utilisateur>AppData>Roaming """
 
-    # Déplace les fichiers de config et le journal
-    for nom in ("journal.log", "Config.json", "Customize.ini") :
-        for rep in ("", Chemins.GetMainPath("Data"), os.path.join(os.path.expanduser("~"), "noethys")) :
-            fichier = os.path.join(rep, nom)
-            if os.path.isfile(fichier) :
-                print(["deplacement fichier config :", fichier, " > ", GetRepUtilisateur(nom)])
-                shutil.move(fichier, GetRepUtilisateur(nom))
+    # Les sources historiques doivent être ancrées sur Noethys. L'ancien rep=""
+    # dépendait du répertoire courant du processus et pouvait déplacer un fichier
+    # sans rapport avec Noethys lorsqu'un raccourci ou un installateur changeait le CWD.
+    repertoires_historiques = (
+        Chemins.GetMainPath(""),
+        Chemins.GetMainPath("Data"),
+        os.path.join(os.path.expanduser("~"), "noethys"),
+    )
+
+    # Journal et personnalisation peuvent être migrés indépendamment.
+    for nom in ("journal.log", "Customize.ini"):
+        destination = GetRepUtilisateur(nom)
+        for rep in repertoires_historiques:
+            source = os.path.join(rep, nom)
+            if _MigreFichierLocal(source, destination):
+                break
+
+    # Config.json est autoritaire dès qu'il existe dans le profil utilisateur.
+    # Son .bak n'est migré que si la configuration correspondante vient elle-même
+    # d'être migrée, afin de ne jamais associer un vieux backup à une config active.
+    destination_config = GetRepUtilisateur("Config.json")
+    destination_backup = GetRepUtilisateur("Config.json.bak")
+    if not os.path.exists(destination_config):
+        for rep in repertoires_historiques:
+            source_config = os.path.join(rep, "Config.json")
+            if _MigreFichierLocal(source_config, destination_config):
+                source_backup = os.path.join(rep, "Config.json.bak")
+                _MigreFichierLocal(source_backup, destination_backup)
+                break
 
     # Déplace les fichiers xlang
     if os.path.isdir(Chemins.GetMainPath("Lang")) :

--- a/noethys/Utils/UTILS_Rapport_bugs.py
+++ b/noethys/Utils/UTILS_Rapport_bugs.py
@@ -25,7 +25,6 @@ import wx.lib.dialogs
 from Utils import UTILS_Config
 from Utils import UTILS_Customize
 from Utils import UTILS_Fichiers
-from Utils import UTILS_Parametres
 
 URL_SUIVI_BUGS = "https://github.com/fr4nck/Noethys/issues"
 CATEGORIE_PARAMETRES = "maintenance"
@@ -33,29 +32,122 @@ PARAM_DESTINATAIRE = "adresse_rapport_bugs"
 DESTINATAIRE_DEFAUT = "noethys@gmail.com"
 
 
-def GetDestinataireRapports():
-    """Retourne le destinataire partagé par la base, avec repli sur l'adresse historique de Noethys."""
+def _NettoieAdresse(adresse):
+    if adresse is None:
+        return u""
     try:
-        adresse = UTILS_Parametres.Parametres(mode="get", categorie=CATEGORIE_PARAMETRES, nom=PARAM_DESTINATAIRE, valeur=u"")
-        if adresse is not None:
-            adresse = adresse.strip()
-            if len(adresse) > 0:
-                return adresse
+        return adresse.strip()
     except Exception:
-        pass
+        return u""
+
+
+def _GetDestinataireLocal():
+    """Lit l'ancien réglage local sans jamais perturber le rapport de crash."""
+    try:
+        return _NettoieAdresse(UTILS_Config.GetParametre(PARAM_DESTINATAIRE, u""))
+    except Exception:
+        return u""
+
+
+def _LireDestinataireBase():
+    """Retourne (adresse, existe, accessible) depuis la base ouverte."""
+    DB = None
+    try:
+        DB = GestionDB.DB()
+        if getattr(DB, "echec", 0) == 1:
+            return u"", False, False
+        req = u'''SELECT parametre FROM parametres WHERE categorie="%s" AND nom="%s";''' % (CATEGORIE_PARAMETRES, PARAM_DESTINATAIRE)
+        DB.ExecuterReq(req)
+        listeDonnees = DB.ResultatReq()
+        if listeDonnees is None:
+            return u"", False, False
+        if len(listeDonnees) == 0:
+            return u"", False, True
+        return _NettoieAdresse(listeDonnees[0][0]), True, True
+    except Exception:
+        return u"", False, False
+    finally:
+        try:
+            if DB is not None:
+                DB.Close()
+        except Exception:
+            pass
+
+
+def GetDestinataireRapports():
+    """Retourne le destinataire partagé, en conservant un ancien réglage local existant."""
+    adresse, existe, accessible = _LireDestinataireBase()
+    if existe and len(adresse) > 0:
+        return adresse
+
+    # La version précédente mémorisait cette adresse dans Config.json. Tant que
+    # la base n'a pas encore reçu son réglage partagé, cette valeur est prioritaire
+    # sur l'adresse historique afin de ne jamais rerouter un rapport existant.
+    adresse_locale = _GetDestinataireLocal()
+    if len(adresse_locale) > 0:
+        if accessible and not existe:
+            SetDestinataireRapports(adresse_locale, silencieux=True)
+        return adresse_locale
+
     return DESTINATAIRE_DEFAUT
 
 
-def SetDestinataireRapports(adresse=u""):
-    """Mémorise le destinataire dans la base ouverte. Un échec ne doit jamais perturber le rapport de crash."""
+def _AlerteEchecDestinataire():
     try:
-        if adresse is None:
-            adresse = u""
-        adresse = adresse.strip()
-        UTILS_Parametres.Parametres(mode="set", categorie=CATEGORIE_PARAMETRES, nom=PARAM_DESTINATAIRE, valeur=adresse)
-        return True
+        dlg = wx.MessageDialog(None,
+            _(u"L'adresse de maintenance n'a pas pu être enregistrée dans la base ouverte. Le réglage précédent est conservé."),
+            _(u"Enregistrement impossible"), wx.OK | wx.ICON_EXCLAMATION)
+        dlg.ShowModal()
+        dlg.Destroy()
     except Exception:
-        return False
+        pass
+
+
+def SetDestinataireRapports(adresse=u"", silencieux=False):
+    """Mémorise puis relit le destinataire afin de ne jamais annoncer un faux succès."""
+    adresse = _NettoieAdresse(adresse)
+    DB = None
+    succes = False
+    try:
+        DB = GestionDB.DB()
+        if getattr(DB, "echec", 0) == 1:
+            raise RuntimeError("base indisponible")
+
+        req = u'''SELECT IDparametre FROM parametres WHERE categorie="%s" AND nom="%s";''' % (CATEGORIE_PARAMETRES, PARAM_DESTINATAIRE)
+        DB.ExecuterReq(req)
+        listeDonnees = DB.ResultatReq()
+        if listeDonnees is None:
+            raise RuntimeError("lecture parametre impossible")
+
+        if len(listeDonnees) == 0:
+            IDparametre = DB.ReqInsert("parametres", [
+                ("categorie", CATEGORIE_PARAMETRES),
+                ("nom", PARAM_DESTINATAIRE),
+                ("parametre", adresse),
+            ])
+            if IDparametre in (None, False):
+                raise RuntimeError("insertion parametre impossible")
+        else:
+            resultat = DB.ReqMAJ("parametres", [("parametre", adresse)], "IDparametre", listeDonnees[0][0])
+            if resultat is False:
+                raise RuntimeError("mise a jour parametre impossible")
+        succes = getattr(DB, "echec", 0) != 1
+    except Exception:
+        succes = False
+    finally:
+        try:
+            if DB is not None:
+                DB.Close()
+        except Exception:
+            pass
+
+    if succes:
+        adresse_lue, existe, accessible = _LireDestinataireBase()
+        succes = accessible and existe and adresse_lue == adresse
+
+    if not succes and not silencieux:
+        _AlerteEchecDestinataire()
+    return succes
 
 
 def _GetRepLogs():
@@ -369,7 +461,8 @@ class DLG_Envoi(wx.Dialog):
             dlg.ShowModal()
             dlg.Destroy()
             return
-        SetDestinataireRapports(destinataire_saisi)
+        # Le rapport de crash doit rester utilisable même si la base est momentanément indisponible.
+        SetDestinataireRapports(destinataire_saisi, silencieux=True)
         self.EndModal(wx.ID_OK)
 
     def OnBoutonAnnuler(self, event):

--- a/noethys/Utils/UTILS_Rapport_bugs.py
+++ b/noethys/Utils/UTILS_Rapport_bugs.py
@@ -75,17 +75,22 @@ def _LireDestinataireBase():
 
 
 def GetDestinataireRapports():
-    """Retourne le destinataire partagé, en conservant un ancien réglage local existant."""
+    """Retourne le destinataire partagé, avec migration unique de l'ancien réglage local."""
     adresse, existe, accessible = _LireDestinataireBase()
-    if existe and len(adresse) > 0:
-        return adresse
 
-    # La version précédente mémorisait cette adresse dans Config.json. Tant que
-    # la base n'a pas encore reçu son réglage partagé, cette valeur est prioritaire
-    # sur l'adresse historique afin de ne jamais rerouter un rapport existant.
+    # Dès qu'une ligne partagée existe, elle est autoritaire. Une valeur vide
+    # signifie explicitement « revenir au destinataire historique » et ne doit
+    # jamais ressusciter un ancien réglage local de Config.json.
+    if existe:
+        if len(adresse) > 0:
+            return adresse
+        return DESTINATAIRE_DEFAUT
+
+    # La version précédente mémorisait cette adresse dans Config.json. Elle ne
+    # sert qu'à amorcer la base tant que la ligne partagée n'existe pas encore.
     adresse_locale = _GetDestinataireLocal()
     if len(adresse_locale) > 0:
-        if accessible and not existe:
+        if accessible:
             SetDestinataireRapports(adresse_locale, silencieux=True)
         return adresse_locale
 

--- a/packaging/vanilla-installer.iss
+++ b/packaging/vanilla-installer.iss
@@ -1,0 +1,44 @@
+; Installateur Windows de la ligne Vanilla maintenue.
+; Réutilise l'identité historique Inno Setup afin qu'une mise à jour remplace
+; proprement l'installation existante au lieu de créer un second désinstalleur.
+
+#ifndef MyAppVersion
+  #define MyAppVersion "1.3.4.2-r2"
+#endif
+
+[Setup]
+AppId=Noethys
+AppName=Noethys
+AppVersion={#MyAppVersion}
+AppPublisher=Noethys
+DefaultDirName={autopf}\Noethys
+DefaultGroupName=Noethys
+DisableProgramGroupPage=yes
+UsePreviousAppDir=yes
+PrivilegesRequired=admin
+ArchitecturesAllowed=x64compatible
+OutputDir=..\installer-output
+OutputBaseFilename=Noethys-Vanilla-Setup
+SetupIconFile=..\noethys\Icone.ico
+UninstallDisplayIcon={app}\Noethys.exe
+Compression=lzma2
+SolidCompression=yes
+WizardStyle=modern
+CloseApplications=yes
+RestartApplications=no
+ChangesAssociations=no
+ChangesEnvironment=no
+SetupLogging=yes
+
+[Files]
+Source: "..\dist\Noethys-installable\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{group}\Noethys"; Filename: "{app}\Noethys.exe"; WorkingDir: "{app}"
+Name: "{autodesktop}\Noethys"; Filename: "{app}\Noethys.exe"; WorkingDir: "{app}"; Tasks: desktopicon
+
+[Tasks]
+Name: "desktopicon"; Description: "Créer un raccourci sur le Bureau"; GroupDescription: "Raccourcis :"; Flags: unchecked
+
+[Run]
+Filename: "{app}\Noethys.exe"; Description: "Lancer Noethys"; Flags: nowait postinstall skipifsilent

--- a/tests/test_vanilla_crash_recipient.py
+++ b/tests/test_vanilla_crash_recipient.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+import ast
+import unittest
+from pathlib import Path
+
+
+SOURCE = Path(__file__).resolve().parents[1] / "noethys" / "Utils" / "UTILS_Rapport_bugs.py"
+
+
+def _load_get_destinataire():
+    tree = ast.parse(SOURCE.read_text(encoding="utf-8"), filename=str(SOURCE))
+    function = next(
+        node for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "GetDestinataireRapports"
+    )
+    module = ast.Module(body=[function], type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = {"DESTINATAIRE_DEFAUT": "noethys@gmail.com"}
+    exec(compile(module, str(SOURCE), "exec"), namespace)
+    return namespace
+
+
+class CrashRecipientMigrationTests(unittest.TestCase):
+    def test_explicit_empty_shared_value_restores_historical_default(self):
+        namespace = _load_get_destinataire()
+        namespace["_LireDestinataireBase"] = lambda: ("", True, True)
+        namespace["_GetDestinataireLocal"] = lambda: self.fail("Le réglage local ne doit plus être relu")
+        namespace["SetDestinataireRapports"] = lambda *args, **kwargs: self.fail("Aucune migration ne doit être tentée")
+
+        self.assertEqual(namespace["GetDestinataireRapports"](), "noethys@gmail.com")
+
+    def test_existing_shared_value_is_authoritative(self):
+        namespace = _load_get_destinataire()
+        namespace["_LireDestinataireBase"] = lambda: ("maintenance@example.org", True, True)
+        namespace["_GetDestinataireLocal"] = lambda: self.fail("Le réglage local ne doit pas être relu")
+        namespace["SetDestinataireRapports"] = lambda *args, **kwargs: self.fail("Aucune migration ne doit être tentée")
+
+        self.assertEqual(namespace["GetDestinataireRapports"](), "maintenance@example.org")
+
+    def test_legacy_local_value_seeds_database_only_when_row_is_absent(self):
+        namespace = _load_get_destinataire()
+        calls = []
+        namespace["_LireDestinataireBase"] = lambda: ("", False, True)
+        namespace["_GetDestinataireLocal"] = lambda: "legacy@example.org"
+        namespace["SetDestinataireRapports"] = lambda adresse, silencieux=False: calls.append((adresse, silencieux)) or True
+
+        self.assertEqual(namespace["GetDestinataireRapports"](), "legacy@example.org")
+        self.assertEqual(calls, [("legacy@example.org", True)])
+
+    def test_unavailable_database_keeps_legacy_local_value_without_writing(self):
+        namespace = _load_get_destinataire()
+        calls = []
+        namespace["_LireDestinataireBase"] = lambda: ("", False, False)
+        namespace["_GetDestinataireLocal"] = lambda: "legacy@example.org"
+        namespace["SetDestinataireRapports"] = lambda *args, **kwargs: calls.append((args, kwargs)) or True
+
+        self.assertEqual(namespace["GetDestinataireRapports"](), "legacy@example.org")
+        self.assertEqual(calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Objectif
Clore la phase Vanilla bugfix avec un paquet installable Windows réellement utilisable en mise à jour, sans perdre la configuration existante.

## Correctifs de clôture
- borne la migration des fichiers locaux aux répertoires Noethys connus ;
- n'écrase jamais une configuration déjà présente dans le profil utilisateur ;
- ne migre `Config.json.bak` qu'avec son `Config.json` correspondant ;
- préserve un ancien destinataire de crashreport stocké dans `Config.json` et le migre vers le réglage partagé lorsqu'une base est disponible ;
- vérifie la persistance du destinataire au lieu d'annoncer un faux succès ;
- ajoute un vrai Setup Windows Inno Setup avec l'identité historique `AppId=Noethys` afin de mettre à niveau l'installation existante sans second désinstalleur ;
- conserve en parallèle le ZIP portable.

## Qualification
Le workflow `Vanilla r2` construit PyInstaller, compile le Setup, effectue une installation silencieuse dans un environnement propre, lance l'exécutable avec un profil de configuration sentinelle et vérifie que ni la configuration utilisateur ni un `Config.json` placé dans un répertoire courant étranger ne sont modifiés.

Aucun changement de schéma, aucune nouvelle fonction métier, aucune UI Upgrade/Repens.