### PR TITLE
Noe-062A — poser le référentiel tiers et contacts

### DIFF
--- a/noethys/Data/DATA_Structures.py
+++ b/noethys/Data/DATA_Structures.py
@@ -2,26 +2,28 @@
 # -*- coding: utf-8 -*-
 """Schéma cible pour les structures et relations métier de Noethys 1.3.5.x.
 
-Ce module est volontairement séparé de DATA_Tables.py tant que la migration
-n'est pas activée. Il permet de figer et tester le modèle sans modifier les
-bases existantes.
+Ce module reste volontairement séparé de ``DATA_Tables.py`` tant que la
+migration additive n'est pas activée sur les bases existantes. Il sert de
+contrat de données testable pour Noe-062.
 
 Principes :
 - aucun champ famille/individu existant n'est modifié ;
 - les identifiants administratifs restent optionnels ;
+- une structure possède un identifiant interne numérique et un UID stable
+  destiné aux échanges avec PMSL-Equipe / Dolibarr ;
 - une structure peut avoir plusieurs contacts, catégories et groupes libres ;
 - bénéficiaire et payeur sont dissociés ;
-- une prestation/MAD peut être reliée à une activité Noethys et à un
-  intervenant externe (notamment PMSL-Equipe) ;
 - les règles de facturation sont portées par la relation/prestation, pas par
   le type de structure.
 """
 
 DB_STRUCTURES = {
     "structures": [
-        ("IDstructure", "INTEGER PRIMARY KEY AUTOINCREMENT", u"ID de la structure"),
-        ("type_structure", "VARCHAR(50)", u"association, ecole, mairie, alsh, departement, institution, autre"),
+        ("IDstructure", "INTEGER PRIMARY KEY AUTOINCREMENT", u"ID local de la structure"),
+        ("uid", "VARCHAR(64)", u"Identifiant stable inter-applications"),
+        ("type_structure", "VARCHAR(50)", u"association, club_section, ecole, mairie_collectivite, alsh, departement_ase, financeur, autre"),
         ("nom", "VARCHAR(300)", u"Nom usuel de la structure"),
+        ("nom_court", "VARCHAR(150)", u"Nom court optionnel"),
         ("nom_officiel", "VARCHAR(300)", u"Dénomination officielle optionnelle"),
         ("IDstructure_parent", "INTEGER", u"Structure parente éventuelle"),
         ("rue", "VARCHAR(255)", u"Adresse"),
@@ -37,6 +39,7 @@ DB_STRUCTURES = {
         ("memo", "VARCHAR(2000)", u"Mémo"),
         ("actif", "INTEGER", u"Structure active 0/1"),
         ("date_creation", "DATE", u"Date de création de la fiche"),
+        ("date_modification", "DATE", u"Date de dernière modification"),
     ],
 
     "structures_contacts": [
@@ -130,3 +133,8 @@ DB_STRUCTURES = {
 def GetNomsTables():
     """Retourne les tables du module dans un ordre stable pour les tests/migrations."""
     return tuple(DB_STRUCTURES.keys())
+
+
+def GetChamps(nom_table):
+    """Retourne les noms de champs déclarés pour une table du module."""
+    return tuple(champ[0] for champ in DB_STRUCTURES[nom_table])

--- a/noethys/Utils/UTILS_Tiers.py
+++ b/noethys/Utils/UTILS_Tiers.py
@@ -75,6 +75,15 @@ CHAMPS_CONTACT = (
     "memo",
 )
 
+CHAMPS_TEXTE_STRUCTURE = (
+    "nom", "nom_court", "nom_officiel", "rue", "cp", "ville", "tel",
+    "mail", "site_web", "rna", "siren", "siret", "ape", "memo",
+)
+
+CHAMPS_TEXTE_CONTACT = (
+    "nom", "prenom", "fonction", "tel", "mobile", "mail", "memo",
+)
+
 
 def _texte(valeur):
     if valeur is None:
@@ -100,56 +109,94 @@ def GenererUIDStructure():
 
 
 def NormaliserStructure(donnees, date=None, creation=False):
-    """Valide et normalise un dictionnaire de structure avant écriture."""
-    donnees = dict(donnees or {})
-    type_structure = _texte(donnees.get("type_structure")) or "autre"
-    if type_structure not in TYPES_TIERS:
-        raise ValueError("type_structure inconnu: %s" % type_structure)
+    """Valide et normalise un dictionnaire de structure avant écriture.
 
-    nom = _texte(donnees.get("nom"))
-    if not nom:
-        raise ValueError("Le nom de la structure est obligatoire")
+    En modification, seuls les champs explicitement fournis sont renvoyés afin
+    qu'une mise à jour ciblée (par exemple ``actif=0``) ne vide jamais les
+    coordonnées ou identifiants administratifs existants.
+    """
+    donnees = dict(donnees or {})
+
+    if creation:
+        type_structure = _texte(donnees.get("type_structure")) or "autre"
+        nom = _texte(donnees.get("nom"))
+        if not nom:
+            raise ValueError("Le nom de la structure est obligatoire")
+    else:
+        type_structure = None
+        nom = None
+        if "type_structure" in donnees:
+            type_structure = _texte(donnees.get("type_structure"))
+            if not type_structure:
+                raise ValueError("type_structure ne peut pas être vide")
+        if "nom" in donnees:
+            nom = _texte(donnees.get("nom"))
+            if not nom:
+                raise ValueError("Le nom de la structure ne peut pas être vide")
+        if not donnees:
+            raise ValueError("Aucune donnée à modifier")
+
+    if type_structure is not None and type_structure not in TYPES_TIERS:
+        raise ValueError("type_structure inconnu: %s" % type_structure)
 
     resultat = {}
     for champ in CHAMPS_STRUCTURE:
         if champ in donnees:
             resultat[champ] = donnees[champ]
 
-    resultat["type_structure"] = type_structure
-    resultat["nom"] = nom
-    resultat["nom_court"] = _texte(donnees.get("nom_court"))
-    resultat["nom_officiel"] = _texte(donnees.get("nom_officiel"))
-    for champ in ("rue", "cp", "ville", "tel", "mail", "site_web", "rna", "siren", "siret", "ape", "memo"):
-        resultat[champ] = _texte(donnees.get(champ))
+    if creation or "type_structure" in donnees:
+        resultat["type_structure"] = type_structure
+    if creation or "nom" in donnees:
+        resultat["nom"] = nom
 
-    resultat["actif"] = 1 if donnees.get("actif", 1) not in (0, False, "0") else 0
+    for champ in CHAMPS_TEXTE_STRUCTURE:
+        if champ == "nom":
+            continue
+        if creation or champ in donnees:
+            resultat[champ] = _texte(donnees.get(champ))
+
+    if creation or "actif" in donnees:
+        resultat["actif"] = 1 if donnees.get("actif", 1) not in (0, False, "0") else 0
     resultat["date_modification"] = _date_iso(date)
 
     if creation:
         resultat["uid"] = _texte(donnees.get("uid")) or GenererUIDStructure()
         resultat["date_creation"] = _date_iso(donnees.get("date_creation") or date)
     else:
+        # L'UID et la date de création sont immuables par le CRUD standard.
         resultat.pop("uid", None)
         resultat.pop("date_creation", None)
 
     return resultat
 
 
-def NormaliserContact(donnees):
+def NormaliserContact(donnees, creation=True):
     donnees = dict(donnees or {})
-    if not donnees.get("IDstructure"):
+
+    if creation and not donnees.get("IDstructure"):
         raise ValueError("IDstructure est obligatoire pour un contact")
-    if not (_texte(donnees.get("nom")) or _texte(donnees.get("prenom")) or _texte(donnees.get("fonction"))):
-        raise ValueError("Un contact doit avoir au moins un nom, un prénom ou une fonction")
+    if "IDstructure" in donnees and not donnees.get("IDstructure"):
+        raise ValueError("IDstructure ne peut pas être vide")
+
+    if creation:
+        if not (_texte(donnees.get("nom")) or _texte(donnees.get("prenom")) or _texte(donnees.get("fonction"))):
+            raise ValueError("Un contact doit avoir au moins un nom, un prénom ou une fonction")
+    elif not donnees:
+        raise ValueError("Aucune donnée à modifier")
 
     resultat = {}
     for champ in CHAMPS_CONTACT:
         if champ in donnees:
             resultat[champ] = donnees[champ]
-    for champ in ("nom", "prenom", "fonction", "tel", "mobile", "mail", "memo"):
-        resultat[champ] = _texte(donnees.get(champ))
-    resultat["contact_principal"] = 1 if donnees.get("contact_principal", 0) not in (0, False, "0") else 0
-    resultat["actif"] = 1 if donnees.get("actif", 1) not in (0, False, "0") else 0
+
+    for champ in CHAMPS_TEXTE_CONTACT:
+        if creation or champ in donnees:
+            resultat[champ] = _texte(donnees.get(champ))
+
+    if creation or "contact_principal" in donnees:
+        resultat["contact_principal"] = 1 if donnees.get("contact_principal", 0) not in (0, False, "0") else 0
+    if creation or "actif" in donnees:
+        resultat["actif"] = 1 if donnees.get("actif", 1) not in (0, False, "0") else 0
     return resultat
 
 
@@ -179,7 +226,8 @@ class GestionnaireTiers(object):
         )
 
     def ArchiverStructure(self, IDstructure, date=None):
-        return self.ModifierStructure(IDstructure, {"nom": self.LireStructure(IDstructure)["nom"], "type_structure": self.LireStructure(IDstructure)["type_structure"], "actif": 0}, date=date)
+        """Archive sans supprimer ni réécrire les autres données du tiers."""
+        return self.ModifierStructure(IDstructure, {"actif": 0}, date=date)
 
     def LireStructure(self, IDstructure):
         req = "SELECT IDstructure, %s FROM structures WHERE IDstructure=%d;" % (
@@ -202,19 +250,22 @@ class GestionnaireTiers(object):
         return [dict(zip(champs, ligne)) for ligne in self.db.ResultatReq()]
 
     def CreerContact(self, donnees):
-        valeurs = NormaliserContact(donnees)
+        valeurs = NormaliserContact(donnees, creation=True)
         return self.db.ReqInsert("structures_contacts", _liste_pairs(valeurs, CHAMPS_CONTACT))
 
     def ModifierContact(self, IDcontact, donnees):
         if not IDcontact:
             raise ValueError("IDcontact obligatoire")
-        valeurs = NormaliserContact(donnees)
+        valeurs = NormaliserContact(donnees, creation=False)
         return self.db.ReqMAJ(
             "structures_contacts",
             _liste_pairs(valeurs, CHAMPS_CONTACT),
             "IDcontact",
             int(IDcontact),
         )
+
+    def ArchiverContact(self, IDcontact):
+        return self.ModifierContact(IDcontact, {"actif": 0})
 
     def ListerContacts(self, IDstructure, actifs_seulement=True):
         condition_actif = " AND actif=1" if actifs_seulement else ""

--- a/noethys/Utils/UTILS_Tiers.py
+++ b/noethys/Utils/UTILS_Tiers.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Couche métier minimale pour le référentiel des tiers (Noe-062A).
+
+Le module ne dépend pas de wxPython et accepte une instance de ``GestionDB.DB``
+(ou un double de test) injectée par l'appelant. Il ne crée aucune table : le
+schéma reste déclaré dans ``Data.DATA_Structures`` tant que la migration
+additive n'est pas explicitement activée.
+"""
+
+from __future__ import unicode_literals
+
+import datetime
+import uuid
+
+
+TYPES_TIERS = (
+    "association",
+    "club_section",
+    "ecole",
+    "mairie_collectivite",
+    "alsh",
+    "departement_ase",
+    "financeur",
+    "autre",
+)
+
+ROLES_CONTACT = (
+    "direction",
+    "president_bureau",
+    "tresorier",
+    "responsable_section",
+    "planning",
+    "facturation",
+    "convention",
+    "administratif",
+    "urgence",
+    "autre",
+)
+
+CHAMPS_STRUCTURE = (
+    "uid",
+    "type_structure",
+    "nom",
+    "nom_court",
+    "nom_officiel",
+    "IDstructure_parent",
+    "rue",
+    "cp",
+    "ville",
+    "tel",
+    "mail",
+    "site_web",
+    "rna",
+    "siren",
+    "siret",
+    "ape",
+    "memo",
+    "actif",
+    "date_creation",
+    "date_modification",
+)
+
+CHAMPS_CONTACT = (
+    "IDstructure",
+    "IDindividu",
+    "nom",
+    "prenom",
+    "fonction",
+    "tel",
+    "mobile",
+    "mail",
+    "contact_principal",
+    "actif",
+    "memo",
+)
+
+
+def _texte(valeur):
+    if valeur is None:
+        return u""
+    try:
+        return valeur.strip()
+    except Exception:
+        return valeur
+
+
+def _date_iso(date=None):
+    date = date or datetime.date.today()
+    if isinstance(date, datetime.datetime):
+        date = date.date()
+    if isinstance(date, datetime.date):
+        return date.isoformat()
+    return _texte(date)
+
+
+def GenererUIDStructure():
+    """Produit un identifiant stable et opaque destiné aux synchronisations."""
+    return "STR-%s" % uuid.uuid4().hex
+
+
+def NormaliserStructure(donnees, date=None, creation=False):
+    """Valide et normalise un dictionnaire de structure avant écriture."""
+    donnees = dict(donnees or {})
+    type_structure = _texte(donnees.get("type_structure")) or "autre"
+    if type_structure not in TYPES_TIERS:
+        raise ValueError("type_structure inconnu: %s" % type_structure)
+
+    nom = _texte(donnees.get("nom"))
+    if not nom:
+        raise ValueError("Le nom de la structure est obligatoire")
+
+    resultat = {}
+    for champ in CHAMPS_STRUCTURE:
+        if champ in donnees:
+            resultat[champ] = donnees[champ]
+
+    resultat["type_structure"] = type_structure
+    resultat["nom"] = nom
+    resultat["nom_court"] = _texte(donnees.get("nom_court"))
+    resultat["nom_officiel"] = _texte(donnees.get("nom_officiel"))
+    for champ in ("rue", "cp", "ville", "tel", "mail", "site_web", "rna", "siren", "siret", "ape", "memo"):
+        resultat[champ] = _texte(donnees.get(champ))
+
+    resultat["actif"] = 1 if donnees.get("actif", 1) not in (0, False, "0") else 0
+    resultat["date_modification"] = _date_iso(date)
+
+    if creation:
+        resultat["uid"] = _texte(donnees.get("uid")) or GenererUIDStructure()
+        resultat["date_creation"] = _date_iso(donnees.get("date_creation") or date)
+    else:
+        resultat.pop("uid", None)
+        resultat.pop("date_creation", None)
+
+    return resultat
+
+
+def NormaliserContact(donnees):
+    donnees = dict(donnees or {})
+    if not donnees.get("IDstructure"):
+        raise ValueError("IDstructure est obligatoire pour un contact")
+    if not (_texte(donnees.get("nom")) or _texte(donnees.get("prenom")) or _texte(donnees.get("fonction"))):
+        raise ValueError("Un contact doit avoir au moins un nom, un prénom ou une fonction")
+
+    resultat = {}
+    for champ in CHAMPS_CONTACT:
+        if champ in donnees:
+            resultat[champ] = donnees[champ]
+    for champ in ("nom", "prenom", "fonction", "tel", "mobile", "mail", "memo"):
+        resultat[champ] = _texte(donnees.get(champ))
+    resultat["contact_principal"] = 1 if donnees.get("contact_principal", 0) not in (0, False, "0") else 0
+    resultat["actif"] = 1 if donnees.get("actif", 1) not in (0, False, "0") else 0
+    return resultat
+
+
+def _liste_pairs(donnees, ordre):
+    return [(champ, donnees.get(champ)) for champ in ordre if champ in donnees]
+
+
+class GestionnaireTiers(object):
+    """CRUD minimal du référentiel, sans dépendance UI."""
+
+    def __init__(self, db):
+        self.db = db
+
+    def CreerStructure(self, donnees, date=None):
+        valeurs = NormaliserStructure(donnees, date=date, creation=True)
+        return self.db.ReqInsert("structures", _liste_pairs(valeurs, CHAMPS_STRUCTURE))
+
+    def ModifierStructure(self, IDstructure, donnees, date=None):
+        if not IDstructure:
+            raise ValueError("IDstructure obligatoire")
+        valeurs = NormaliserStructure(donnees, date=date, creation=False)
+        return self.db.ReqMAJ(
+            "structures",
+            _liste_pairs(valeurs, CHAMPS_STRUCTURE),
+            "IDstructure",
+            int(IDstructure),
+        )
+
+    def ArchiverStructure(self, IDstructure, date=None):
+        return self.ModifierStructure(IDstructure, {"nom": self.LireStructure(IDstructure)["nom"], "type_structure": self.LireStructure(IDstructure)["type_structure"], "actif": 0}, date=date)
+
+    def LireStructure(self, IDstructure):
+        req = "SELECT IDstructure, %s FROM structures WHERE IDstructure=%d;" % (
+            ", ".join(CHAMPS_STRUCTURE), int(IDstructure))
+        if self.db.ExecuterReq(req) != 1:
+            return None
+        lignes = self.db.ResultatReq()
+        if not lignes:
+            return None
+        champs = ("IDstructure",) + CHAMPS_STRUCTURE
+        return dict(zip(champs, lignes[0]))
+
+    def ListerStructures(self, actifs_seulement=True):
+        condition = " WHERE actif=1" if actifs_seulement else ""
+        req = "SELECT IDstructure, %s FROM structures%s ORDER BY nom;" % (
+            ", ".join(CHAMPS_STRUCTURE), condition)
+        if self.db.ExecuterReq(req) != 1:
+            return []
+        champs = ("IDstructure",) + CHAMPS_STRUCTURE
+        return [dict(zip(champs, ligne)) for ligne in self.db.ResultatReq()]
+
+    def CreerContact(self, donnees):
+        valeurs = NormaliserContact(donnees)
+        return self.db.ReqInsert("structures_contacts", _liste_pairs(valeurs, CHAMPS_CONTACT))
+
+    def ModifierContact(self, IDcontact, donnees):
+        if not IDcontact:
+            raise ValueError("IDcontact obligatoire")
+        valeurs = NormaliserContact(donnees)
+        return self.db.ReqMAJ(
+            "structures_contacts",
+            _liste_pairs(valeurs, CHAMPS_CONTACT),
+            "IDcontact",
+            int(IDcontact),
+        )
+
+    def ListerContacts(self, IDstructure, actifs_seulement=True):
+        condition_actif = " AND actif=1" if actifs_seulement else ""
+        req = "SELECT IDcontact, %s FROM structures_contacts WHERE IDstructure=%d%s ORDER BY contact_principal DESC, nom, prenom;" % (
+            ", ".join(CHAMPS_CONTACT), int(IDstructure), condition_actif)
+        if self.db.ExecuterReq(req) != 1:
+            return []
+        champs = ("IDcontact",) + CHAMPS_CONTACT
+        return [dict(zip(champs, ligne)) for ligne in self.db.ResultatReq()]

--- a/tests/test_noe_062a_tiers.py
+++ b/tests/test_noe_062a_tiers.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+import datetime
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _charger_module(path, nom):
+    spec = importlib.util.spec_from_file_location(nom, str(ROOT / path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+TIERS = _charger_module("noethys/Utils/UTILS_Tiers.py", "UTILS_Tiers_noe062a")
+SCHEMA = _charger_module("noethys/Data/DATA_Structures.py", "DATA_Structures_noe062a")
+
+
+class FakeDB(object):
+    def __init__(self):
+        self.insertions = []
+        self.maj = []
+        self.requetes = []
+        self.resultats = []
+
+    def ReqInsert(self, table, donnees, commit=True):
+        self.insertions.append((table, list(donnees), commit))
+        return 42
+
+    def ReqMAJ(self, table, donnees, cle, ID, IDestChaine=False, commit=True):
+        self.maj.append((table, list(donnees), cle, ID, commit))
+        return True
+
+    def ExecuterReq(self, req):
+        self.requetes.append(req)
+        return 1
+
+    def ResultatReq(self):
+        return list(self.resultats)
+
+
+def test_schema_structure_contient_uid_et_dates():
+    champs = SCHEMA.GetChamps("structures")
+    assert champs[0] == "IDstructure"
+    assert "uid" in champs
+    assert "type_structure" in champs
+    assert "nom" in champs
+    assert "date_creation" in champs
+    assert "date_modification" in champs
+
+
+def test_schema_contacts_et_relations_restent_additifs():
+    noms = SCHEMA.GetNomsTables()
+    assert "structures" in noms
+    assert "structures_contacts" in noms
+    assert "structures_relations" in noms
+    assert "structures_payeurs" in noms
+
+
+def test_normalisation_structure_cree_uid_stable_et_dates():
+    date = datetime.date(2026, 8, 27)
+    data = TIERS.NormaliserStructure({
+        "type_structure": "association",
+        "nom": "  Club test  ",
+        "mail": " contact@example.org ",
+    }, date=date, creation=True)
+
+    assert data["uid"].startswith("STR-")
+    assert len(data["uid"]) > 10
+    assert data["nom"] == "Club test"
+    assert data["mail"] == "contact@example.org"
+    assert data["date_creation"] == "2026-08-27"
+    assert data["date_modification"] == "2026-08-27"
+    assert data["actif"] == 1
+
+
+def test_normalisation_refuse_type_inconnu_et_nom_vide():
+    try:
+        TIERS.NormaliserStructure({"type_structure": "bidule", "nom": "X"}, creation=True)
+        assert False, "type inconnu accepté"
+    except ValueError:
+        pass
+
+    try:
+        TIERS.NormaliserStructure({"type_structure": "ecole", "nom": "   "}, creation=True)
+        assert False, "nom vide accepté"
+    except ValueError:
+        pass
+
+
+def test_creation_structure_utilise_uniquement_le_schema_canonique():
+    db = FakeDB()
+    gestion = TIERS.GestionnaireTiers(db)
+    ID = gestion.CreerStructure({
+        "type_structure": "mairie_collectivite",
+        "nom": "Mairie de Test",
+        "siret": "12345678900012",
+        "champ_inconnu": "ne doit pas partir en base",
+    }, date=datetime.date(2026, 8, 27))
+
+    assert ID == 42
+    table, paires, commit = db.insertions[0]
+    assert table == "structures"
+    champs = [champ for champ, valeur in paires]
+    assert "uid" in champs
+    assert "champ_inconnu" not in champs
+    assert set(champs).issubset(set(SCHEMA.GetChamps("structures")))
+    assert commit is True
+
+
+def test_contact_exige_structure_et_identite_minimale():
+    try:
+        TIERS.NormaliserContact({"nom": "Dupont"})
+        assert False, "contact sans structure accepté"
+    except ValueError:
+        pass
+
+    try:
+        TIERS.NormaliserContact({"IDstructure": 1})
+        assert False, "contact vide accepté"
+    except ValueError:
+        pass
+
+    contact = TIERS.NormaliserContact({
+        "IDstructure": 1,
+        "fonction": " Direction ",
+        "mail": " direction@example.org ",
+        "contact_principal": True,
+    })
+    assert contact["fonction"] == "Direction"
+    assert contact["mail"] == "direction@example.org"
+    assert contact["contact_principal"] == 1
+    assert contact["actif"] == 1
+
+
+def test_crud_minimal_contacts():
+    db = FakeDB()
+    gestion = TIERS.GestionnaireTiers(db)
+    ID = gestion.CreerContact({
+        "IDstructure": 7,
+        "nom": "Martin",
+        "prenom": "Alice",
+        "fonction": "Facturation",
+    })
+    assert ID == 42
+    table, paires, _ = db.insertions[0]
+    assert table == "structures_contacts"
+    assert ("IDstructure", 7) in paires
+    assert ("actif", 1) in paires
+
+
+def test_lister_structures_filtre_actives_par_defaut():
+    db = FakeDB()
+    gestion = TIERS.GestionnaireTiers(db)
+    db.resultats = [tuple([3] + ["x"] * len(TIERS.CHAMPS_STRUCTURE))]
+    resultats = gestion.ListerStructures()
+    assert "WHERE actif=1" in db.requetes[-1]
+    assert resultats[0]["IDstructure"] == 3
+
+
+def test_lister_contacts_est_borne_a_la_structure():
+    db = FakeDB()
+    gestion = TIERS.GestionnaireTiers(db)
+    db.resultats = []
+    assert gestion.ListerContacts(9) == []
+    assert "WHERE IDstructure=9" in db.requetes[-1]
+    assert "AND actif=1" in db.requetes[-1]

--- a/tests/test_noe_062a_tiers.py
+++ b/tests/test_noe_062a_tiers.py
@@ -110,6 +110,22 @@ def test_creation_structure_utilise_uniquement_le_schema_canonique():
     assert commit is True
 
 
+def test_mise_a_jour_partielle_structure_ne_vide_pas_les_autres_champs():
+    data = TIERS.NormaliserStructure({"actif": 0}, date=datetime.date(2026, 8, 27), creation=False)
+    assert data == {"actif": 0, "date_modification": "2026-08-27"}
+
+    db = FakeDB()
+    gestion = TIERS.GestionnaireTiers(db)
+    assert gestion.ArchiverStructure(12, date=datetime.date(2026, 8, 27)) is True
+    table, paires, cle, ID, commit = db.maj[0]
+    assert table == "structures"
+    assert cle == "IDstructure"
+    assert ID == 12
+    assert ("actif", 0) in paires
+    assert not any(champ in ("nom", "mail", "rue", "siret") for champ, valeur in paires)
+    assert commit is True
+
+
 def test_contact_exige_structure_et_identite_minimale():
     try:
         TIERS.NormaliserContact({"nom": "Dupont"})
@@ -133,6 +149,21 @@ def test_contact_exige_structure_et_identite_minimale():
     assert contact["mail"] == "direction@example.org"
     assert contact["contact_principal"] == 1
     assert contact["actif"] == 1
+
+
+def test_mise_a_jour_partielle_contact_ne_vide_pas_identite():
+    data = TIERS.NormaliserContact({"mail": " new@example.org "}, creation=False)
+    assert data == {"mail": "new@example.org"}
+
+    db = FakeDB()
+    gestion = TIERS.GestionnaireTiers(db)
+    assert gestion.ArchiverContact(22) is True
+    table, paires, cle, ID, commit = db.maj[0]
+    assert table == "structures_contacts"
+    assert paires == [("actif", 0)]
+    assert cle == "IDcontact"
+    assert ID == 22
+    assert commit is True
 
 
 def test_crud_minimal_contacts():


### PR DESCRIPTION
## Objectif
Démarrer le lot prioritaire Noe-062A avec une première brique métier testable et sans dépendance à la refonte graphique.

## Contenu
- consolide `DATA_Structures.py` comme contrat de schéma additif ;
- ajoute un UID stable `STR-...` pour les échanges futurs PMSL-Équipe / Dolibarr ;
- ajoute `nom_court` et `date_modification` ;
- ajoute `UTILS_Tiers.py`, couche métier sans wxPython ;
- normalise/valide les structures et contacts ;
- CRUD minimal structures + contacts avec DB injectée ;
- tests unitaires du schéma, de la normalisation et du CRUD.

## Garde-fous
- aucune table n'est encore créée automatiquement dans une base existante ;
- aucune migration destructive ;
- aucune nouvelle dépendance ;
- aucune refonte UI ;
- compatible avec la stratégie SQLite + MySQL/MariaDB historique.

## Suite
Après validation de ce socle : activation additive contrôlée des tables, puis écran minimal liste/fiche, puis rôles/groupes et relations contractuelles.

Closes part of #211. Relates #60.