### PR TITLE
Noe-062A — activation additive contrôlée du schéma tiers

### DIFF
--- a/noethys/Utils/UTILS_Tiers_Schema.py
+++ b/noethys/Utils/UTILS_Tiers_Schema.py
@@ -53,13 +53,17 @@ def _type_attendu(type_decl, is_network):
     return type_decl
 
 
+def _chaine(valeur):
+    if isinstance(valeur, bytes):
+        return valeur.decode("ascii", "ignore")
+    return str(valeur)
+
+
 def _categorie_type(type_sql):
     """Normalise les variantes SQLite/MySQL en familles compatibles."""
     if type_sql is None:
         return ""
-    if isinstance(type_sql, bytes):
-        type_sql = type_sql.decode("ascii", "ignore")
-    valeur = str(type_sql).strip().lower()
+    valeur = _chaine(type_sql).strip().lower()
     base = valeur.split("(", 1)[0].strip()
     if "int" in base:
         return "integer"
@@ -83,6 +87,7 @@ def _metadata_table(db, nom_table):
         if db.ExecuterReq("PRAGMA table_info('%s');" % nom_table) != 1:
             return None
         for cid, nom, type_sql, notnull, valeur_defaut, pk in db.ResultatReq():
+            nom = _chaine(nom)
             colonnes[nom] = {
                 "type": type_sql,
                 "pk": bool(pk),
@@ -95,18 +100,14 @@ def _metadata_table(db, nom_table):
         if db.ExecuterReq("SHOW COLUMNS FROM %s;" % nom_table) != 1:
             return None
         for valeurs in db.ResultatReq():
-            nom = valeurs[0]
+            nom = _chaine(valeurs[0])
             type_sql = valeurs[1]
-            cle = valeurs[3] if len(valeurs) > 3 else ""
-            extra = valeurs[5] if len(valeurs) > 5 else ""
-            if isinstance(cle, bytes):
-                cle = cle.decode("ascii", "ignore")
-            if isinstance(extra, bytes):
-                extra = extra.decode("ascii", "ignore")
+            cle = _chaine(valeurs[3] if len(valeurs) > 3 else "")
+            extra = _chaine(valeurs[5] if len(valeurs) > 5 else "")
             colonnes[nom] = {
                 "type": type_sql,
-                "pk": str(cle).upper() == "PRI",
-                "auto": "auto_increment" in str(extra).lower(),
+                "pk": cle.upper() == "PRI",
+                "auto": "auto_increment" in extra.lower(),
             }
     return colonnes
 

--- a/noethys/Utils/UTILS_Tiers_Schema.py
+++ b/noethys/Utils/UTILS_Tiers_Schema.py
@@ -4,11 +4,13 @@
 
 Ce module ne s'exécute jamais au simple import. L'appelant choisit explicitement
 ``appliquer=True`` pour créer les tables manquantes. Une table déjà existante
-mais incomplète n'est jamais réparée silencieusement : l'écart est signalé pour
-éviter toute modification implicite d'une base réellement utilisée.
+mais incohérente n'est jamais réparée silencieusement et bloque toute activation
+afin de ne pas laisser un schéma partiellement créé.
 """
 
 from __future__ import unicode_literals
+
+import re
 
 from Data import DATA_Structures
 
@@ -16,64 +18,194 @@ from Data import DATA_Structures
 TABLES_062A = ("structures", "structures_contacts")
 
 
+def _descriptions_attendues(nom_table):
+    return tuple(DATA_Structures.DB_STRUCTURES[nom_table])
+
+
 def _champs_attendus(nom_table):
-    return tuple(champ[0] for champ in DATA_Structures.DB_STRUCTURES[nom_table])
+    return tuple(champ[0] for champ in _descriptions_attendues(nom_table))
+
+
+def _type_attendu(type_decl, is_network):
+    """Reproduit les adaptations utiles de GestionDB.CreationTable."""
+    type_decl = type_decl.upper().strip()
+    if not is_network:
+        if type_decl == "LONGBLOB":
+            return "BLOB"
+        if type_decl == "BIGINT":
+            return "INTEGER"
+        return type_decl
+
+    if type_decl == "INTEGER PRIMARY KEY AUTOINCREMENT":
+        return "INTEGER PRIMARY KEY AUTO_INCREMENT"
+    if type_decl == "FLOAT":
+        return "REAL"
+    if type_decl == "DATE":
+        return "VARCHAR(10)"
+    if type_decl.startswith("VARCHAR"):
+        match = re.search(r"\((\d+)\)", type_decl)
+        if match:
+            taille = int(match.group(1))
+            if taille > 20000:
+                return "MEDIUMTEXT"
+            if taille > 255:
+                return "TEXT(%d)" % taille
+    return type_decl
+
+
+def _categorie_type(type_sql):
+    """Normalise les variantes SQLite/MySQL en familles compatibles."""
+    if type_sql is None:
+        return ""
+    if isinstance(type_sql, bytes):
+        type_sql = type_sql.decode("ascii", "ignore")
+    valeur = str(type_sql).strip().lower()
+    base = valeur.split("(", 1)[0].strip()
+    if "int" in base:
+        return "integer"
+    if base in ("float", "real", "double", "decimal", "numeric"):
+        return "real"
+    if base in ("char", "varchar", "text", "tinytext", "mediumtext", "longtext"):
+        return "text"
+    if base in ("blob", "tinyblob", "mediumblob", "longblob"):
+        return "blob"
+    if base in ("date", "datetime", "timestamp"):
+        return "date"
+    return base
+
+
+def _metadata_table(db, nom_table):
+    """Retourne types + métadonnées PK/autoincrement sans écrire en base."""
+    is_network = bool(getattr(db, "isNetwork", False))
+    colonnes = {}
+
+    if not is_network:
+        if db.ExecuterReq("PRAGMA table_info('%s');" % nom_table) != 1:
+            return None
+        for cid, nom, type_sql, notnull, valeur_defaut, pk in db.ResultatReq():
+            colonnes[nom] = {
+                "type": type_sql,
+                "pk": bool(pk),
+                # En SQLite, INTEGER PRIMARY KEY est l'alias du rowid ;
+                # AUTOINCREMENT n'est pas nécessaire à l'identité du champ mais
+                # le contrat Noethys le déclare pour éviter la réutilisation.
+                "auto": bool(pk) and _categorie_type(type_sql) == "integer",
+            }
+    else:
+        if db.ExecuterReq("SHOW COLUMNS FROM %s;" % nom_table) != 1:
+            return None
+        for valeurs in db.ResultatReq():
+            nom = valeurs[0]
+            type_sql = valeurs[1]
+            cle = valeurs[3] if len(valeurs) > 3 else ""
+            extra = valeurs[5] if len(valeurs) > 5 else ""
+            if isinstance(cle, bytes):
+                cle = cle.decode("ascii", "ignore")
+            if isinstance(extra, bytes):
+                extra = extra.decode("ascii", "ignore")
+            colonnes[nom] = {
+                "type": type_sql,
+                "pk": str(cle).upper() == "PRI",
+                "auto": "auto_increment" in str(extra).lower(),
+            }
+    return colonnes
 
 
 def InspecterSchema(db):
     """Retourne un rapport déterministe sans modifier la base."""
     rapport = {}
+    is_network = bool(getattr(db, "isNetwork", False))
+
     for nom_table in TABLES_062A:
         existe = bool(db.IsTableExists(nom_table))
-        champs_attendus = _champs_attendus(nom_table)
+        descriptions = _descriptions_attendues(nom_table)
+        champs_attendus = tuple(champ[0] for champ in descriptions)
         champs_presents = ()
         champs_manquants = champs_attendus
+        champs_incompatibles = ()
+        metadata_ok = False
+
         if existe:
-            champs_presents = tuple(champ[0] for champ in db.GetListeChamps2(nom_table))
-            champs_manquants = tuple(champ for champ in champs_attendus if champ not in champs_presents)
+            metadata = _metadata_table(db, nom_table)
+            if metadata is not None:
+                champs_presents = tuple(metadata.keys())
+                champs_manquants = tuple(champ for champ in champs_attendus if champ not in metadata)
+                incompatibles = []
+                for nom_champ, type_decl, info in descriptions:
+                    if nom_champ not in metadata:
+                        continue
+                    attendu = _type_attendu(type_decl, is_network)
+                    present = metadata[nom_champ]
+                    if _categorie_type(attendu) != _categorie_type(present["type"]):
+                        incompatibles.append(nom_champ)
+                        continue
+                    if "PRIMARY KEY" in attendu and not present["pk"]:
+                        incompatibles.append(nom_champ)
+                        continue
+                    if "AUTO_INCREMENT" in attendu and not present["auto"]:
+                        incompatibles.append(nom_champ)
+                champs_incompatibles = tuple(incompatibles)
+                metadata_ok = True
+
+        conforme = existe and metadata_ok and not champs_manquants and not champs_incompatibles
         rapport[nom_table] = {
             "existe": existe,
             "champs_attendus": champs_attendus,
             "champs_presents": champs_presents,
             "champs_manquants": champs_manquants,
-            "conforme": existe and not champs_manquants,
+            "champs_incompatibles": champs_incompatibles,
+            "metadata_ok": metadata_ok,
+            "conforme": conforme,
         }
     return rapport
 
 
-def AssurerSchema(db, appliquer=False):
-    """Crée uniquement les tables 062A absentes, de manière idempotente.
-
-    Si une table existe déjà mais ne correspond pas au contrat attendu, aucune
-    tentative d'ALTER/repair n'est faite ici. L'appelant reçoit ``ok=False`` et
-    le détail des champs manquants afin de décider d'une migration explicite.
-    """
-    avant = InspecterSchema(db)
-    creees = []
-
-    if appliquer:
-        for nom_table in TABLES_062A:
-            etat = avant[nom_table]
-            if not etat["existe"]:
-                db.CreationTable(nom_table, DATA_Structures.DB_STRUCTURES)
-                db.Commit()
-                creees.append(nom_table)
-
-    apres = InspecterSchema(db)
+def _resultat(rapport, appliquer, creees=()):
     incoherentes = tuple(
         nom_table for nom_table in TABLES_062A
-        if apres[nom_table]["existe"] and not apres[nom_table]["conforme"]
+        if rapport[nom_table]["existe"] and not rapport[nom_table]["conforme"]
     )
     absentes = tuple(
         nom_table for nom_table in TABLES_062A
-        if not apres[nom_table]["existe"]
+        if not rapport[nom_table]["existe"]
     )
-
     return {
         "ok": not incoherentes and (not appliquer or not absentes),
         "appliquer": bool(appliquer),
         "tables_creees": tuple(creees),
         "tables_absentes": absentes,
         "tables_incoherentes": incoherentes,
-        "rapport": apres,
+        "rapport": rapport,
     }
+
+
+def AssurerSchema(db, appliquer=False):
+    """Crée uniquement les tables 062A absentes, de manière idempotente.
+
+    Toute table existante incohérente bloque *avant la première écriture*. Une
+    activation qui échoue au préflight ne peut donc pas laisser seulement une
+    partie du référentiel créée.
+    """
+    avant = InspecterSchema(db)
+    preflight = _resultat(avant, appliquer=False)
+
+    if preflight["tables_incoherentes"]:
+        return {
+            "ok": False,
+            "appliquer": bool(appliquer),
+            "tables_creees": (),
+            "tables_absentes": preflight["tables_absentes"],
+            "tables_incoherentes": preflight["tables_incoherentes"],
+            "rapport": avant,
+        }
+
+    creees = []
+    if appliquer:
+        for nom_table in TABLES_062A:
+            if not avant[nom_table]["existe"]:
+                db.CreationTable(nom_table, DATA_Structures.DB_STRUCTURES)
+                db.Commit()
+                creees.append(nom_table)
+
+    apres = InspecterSchema(db)
+    return _resultat(apres, appliquer=appliquer, creees=creees)

--- a/noethys/Utils/UTILS_Tiers_Schema.py
+++ b/noethys/Utils/UTILS_Tiers_Schema.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Activation additive contrôlée du schéma Noe-062A.
+
+Ce module ne s'exécute jamais au simple import. L'appelant choisit explicitement
+``appliquer=True`` pour créer les tables manquantes. Une table déjà existante
+mais incomplète n'est jamais réparée silencieusement : l'écart est signalé pour
+éviter toute modification implicite d'une base réellement utilisée.
+"""
+
+from __future__ import unicode_literals
+
+from Data import DATA_Structures
+
+
+TABLES_062A = ("structures", "structures_contacts")
+
+
+def _champs_attendus(nom_table):
+    return tuple(champ[0] for champ in DATA_Structures.DB_STRUCTURES[nom_table])
+
+
+def InspecterSchema(db):
+    """Retourne un rapport déterministe sans modifier la base."""
+    rapport = {}
+    for nom_table in TABLES_062A:
+        existe = bool(db.IsTableExists(nom_table))
+        champs_attendus = _champs_attendus(nom_table)
+        champs_presents = ()
+        champs_manquants = champs_attendus
+        if existe:
+            champs_presents = tuple(champ[0] for champ in db.GetListeChamps2(nom_table))
+            champs_manquants = tuple(champ for champ in champs_attendus if champ not in champs_presents)
+        rapport[nom_table] = {
+            "existe": existe,
+            "champs_attendus": champs_attendus,
+            "champs_presents": champs_presents,
+            "champs_manquants": champs_manquants,
+            "conforme": existe and not champs_manquants,
+        }
+    return rapport
+
+
+def AssurerSchema(db, appliquer=False):
+    """Crée uniquement les tables 062A absentes, de manière idempotente.
+
+    Si une table existe déjà mais ne correspond pas au contrat attendu, aucune
+    tentative d'ALTER/repair n'est faite ici. L'appelant reçoit ``ok=False`` et
+    le détail des champs manquants afin de décider d'une migration explicite.
+    """
+    avant = InspecterSchema(db)
+    creees = []
+
+    if appliquer:
+        for nom_table in TABLES_062A:
+            etat = avant[nom_table]
+            if not etat["existe"]:
+                db.CreationTable(nom_table, DATA_Structures.DB_STRUCTURES)
+                db.Commit()
+                creees.append(nom_table)
+
+    apres = InspecterSchema(db)
+    incoherentes = tuple(
+        nom_table for nom_table in TABLES_062A
+        if apres[nom_table]["existe"] and not apres[nom_table]["conforme"]
+    )
+    absentes = tuple(
+        nom_table for nom_table in TABLES_062A
+        if not apres[nom_table]["existe"]
+    )
+
+    return {
+        "ok": not incoherentes and (not appliquer or not absentes),
+        "appliquer": bool(appliquer),
+        "tables_creees": tuple(creees),
+        "tables_absentes": absentes,
+        "tables_incoherentes": incoherentes,
+        "rapport": apres,
+    }

--- a/scripts/check_schema_compatibility.py
+++ b/scripts/check_schema_compatibility.py
@@ -2,8 +2,8 @@
 """Bloque les modifications de schéma SQL ajoutées silencieusement au code Noethys.
 
 Le contrôle porte uniquement sur les lignes ajoutées entre deux révisions Git.
-Les scripts de test qui construisent des bases jetables sont hors périmètre : ils
-ne modifient ni le schéma applicatif ni une base utilisateur existante.
+Les tests qui construisent des bases jetables sont hors périmètre : ils ne
+modifient ni le schéma applicatif ni une base utilisateur existante.
 """
 
 from __future__ import annotations
@@ -26,6 +26,11 @@ SCHEMA_PATTERNS = (
 TEXT_SUFFIXES = {".py", ".sql", ".txt", ".ini", ".cfg", ".json", ".yaml", ".yml"}
 # Outils explicitement destinés à fabriquer des bases temporaires de recette.
 IGNORED_PATHS = {"scripts/build_synthetic_recette_db.py"}
+IGNORED_PREFIXES = ("tests/",)
+
+
+def is_ignored_path(filename: str) -> bool:
+    return filename in IGNORED_PATHS or any(filename.startswith(prefix) for prefix in IGNORED_PREFIXES)
 
 
 def added_lines(base: str, head: str) -> list[tuple[str, str]]:
@@ -40,7 +45,7 @@ def added_lines(base: str, head: str) -> list[tuple[str, str]]:
             continue
         if not line.startswith("+") or line.startswith("+++"):
             continue
-        if current_file in IGNORED_PATHS:
+        if is_ignored_path(current_file):
             continue
         if current_file and Path(current_file).suffix.lower() in TEXT_SUFFIXES:
             additions.append((current_file, line[1:]))

--- a/tests/test_noe_062a_schema.py
+++ b/tests/test_noe_062a_schema.py
@@ -22,21 +22,49 @@ SCHEMA = _charger_module("noethys/Utils/UTILS_Tiers_Schema.py", "UTILS_Tiers_Sch
 DATA = _charger_module("noethys/Data/DATA_Structures.py", "DATA_Structures_noe062a_schema")
 
 
+def _schema_sqlite(nom_table):
+    resultat = []
+    for nom, type_champ, info in DATA.DB_STRUCTURES[nom_table]:
+        type_sql = type_champ
+        if type_sql == "LONGBLOB":
+            type_sql = "BLOB"
+        if type_sql == "BIGINT":
+            type_sql = "INTEGER"
+        type_prag = type_sql.split(" PRIMARY KEY", 1)[0]
+        pk = 1 if "PRIMARY KEY" in type_sql else 0
+        resultat.append((nom, type_prag, pk))
+    return resultat
+
+
 class FakeSchemaDB(object):
+    isNetwork = False
+
     def __init__(self, tables=None):
         self.tables = dict(tables or {})
         self.creations = []
         self.commits = 0
+        self._resultat = []
 
     def IsTableExists(self, nom_table):
         return nom_table in self.tables
 
-    def GetListeChamps2(self, nom_table):
-        return [(champ, "TEXT") for champ in self.tables[nom_table]]
+    def ExecuterReq(self, req):
+        if req.startswith("PRAGMA table_info('"):
+            nom_table = req.split("'", 2)[1]
+            colonnes = self.tables.get(nom_table, [])
+            self._resultat = [
+                (index, nom, type_sql, 0, None, pk)
+                for index, (nom, type_sql, pk) in enumerate(colonnes)
+            ]
+            return 1
+        return 0
+
+    def ResultatReq(self):
+        return list(self._resultat)
 
     def CreationTable(self, nom_table, dico):
         self.creations.append(nom_table)
-        self.tables[nom_table] = [champ[0] for champ in dico[nom_table]]
+        self.tables[nom_table] = _schema_sqlite(nom_table)
 
     def Commit(self):
         self.commits += 1
@@ -68,13 +96,13 @@ def test_activation_cree_uniquement_les_deux_tables_062a():
     assert db.creations == ["structures", "structures_contacts"]
     assert db.commits == 2
     assert set(db.tables) == {"structures", "structures_contacts"}
-    assert db.tables["structures"] == [champ[0] for champ in DATA.DB_STRUCTURES["structures"]]
+    assert [champ[0] for champ in db.tables["structures"]] == [champ[0] for champ in DATA.DB_STRUCTURES["structures"]]
 
 
 def test_activation_est_idempotente():
     tables = {
-        "structures": [champ[0] for champ in DATA.DB_STRUCTURES["structures"]],
-        "structures_contacts": [champ[0] for champ in DATA.DB_STRUCTURES["structures_contacts"]],
+        "structures": _schema_sqlite("structures"),
+        "structures_contacts": _schema_sqlite("structures_contacts"),
     }
     db = FakeSchemaDB(tables=tables)
     resultat = SCHEMA.AssurerSchema(db, appliquer=True)
@@ -86,14 +114,50 @@ def test_activation_est_idempotente():
 
 def test_table_existante_incomplete_n_est_jamais_modifiee_silencieusement():
     tables = {
-        "structures": ["IDstructure", "nom"],
-        "structures_contacts": [champ[0] for champ in DATA.DB_STRUCTURES["structures_contacts"]],
+        "structures": [("IDstructure", "INTEGER", 1), ("nom", "VARCHAR(300)", 0)],
+        "structures_contacts": _schema_sqlite("structures_contacts"),
     }
     db = FakeSchemaDB(tables=tables)
     resultat = SCHEMA.AssurerSchema(db, appliquer=True)
     assert resultat["ok"] is False
     assert resultat["tables_incoherentes"] == ("structures",)
     assert "uid" in resultat["rapport"]["structures"]["champs_manquants"]
+    assert db.creations == []
+    assert db.commits == 0
+
+
+def test_mauvais_type_de_cle_primaire_est_incompatible():
+    structures = _schema_sqlite("structures")
+    structures[0] = ("IDstructure", "TEXT", 1)
+    db = FakeSchemaDB({
+        "structures": structures,
+        "structures_contacts": _schema_sqlite("structures_contacts"),
+    })
+    resultat = SCHEMA.AssurerSchema(db, appliquer=False)
+    assert resultat["ok"] is False
+    assert "IDstructure" in resultat["rapport"]["structures"]["champs_incompatibles"]
+
+
+def test_absence_de_cle_primaire_est_incompatible():
+    structures = _schema_sqlite("structures")
+    structures[0] = ("IDstructure", "INTEGER", 0)
+    db = FakeSchemaDB({
+        "structures": structures,
+        "structures_contacts": _schema_sqlite("structures_contacts"),
+    })
+    resultat = SCHEMA.AssurerSchema(db, appliquer=False)
+    assert resultat["ok"] is False
+    assert "IDstructure" in resultat["rapport"]["structures"]["champs_incompatibles"]
+
+
+def test_preflight_incoherent_bloque_avant_creation_d_une_table_absente():
+    db = FakeSchemaDB({
+        "structures": [("IDstructure", "INTEGER", 1), ("nom", "VARCHAR(300)", 0)],
+    })
+    resultat = SCHEMA.AssurerSchema(db, appliquer=True)
+    assert resultat["ok"] is False
+    assert resultat["tables_incoherentes"] == ("structures",)
+    assert resultat["tables_absentes"] == ("structures_contacts",)
     assert db.creations == []
     assert db.commits == 0
 

--- a/tests/test_noe_062a_schema.py
+++ b/tests/test_noe_062a_schema.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOETHYS = ROOT / "noethys"
+if str(NOETHYS) not in sys.path:
+    sys.path.insert(0, str(NOETHYS))
+
+
+def _charger_module(path, nom):
+    spec = importlib.util.spec_from_file_location(nom, str(ROOT / path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+SCHEMA = _charger_module("noethys/Utils/UTILS_Tiers_Schema.py", "UTILS_Tiers_Schema_noe062a")
+DATA = _charger_module("noethys/Data/DATA_Structures.py", "DATA_Structures_noe062a_schema")
+
+
+class FakeSchemaDB(object):
+    def __init__(self, tables=None):
+        self.tables = dict(tables or {})
+        self.creations = []
+        self.commits = 0
+
+    def IsTableExists(self, nom_table):
+        return nom_table in self.tables
+
+    def GetListeChamps2(self, nom_table):
+        return [(champ, "TEXT") for champ in self.tables[nom_table]]
+
+    def CreationTable(self, nom_table, dico):
+        self.creations.append(nom_table)
+        self.tables[nom_table] = [champ[0] for champ in dico[nom_table]]
+
+    def Commit(self):
+        self.commits += 1
+
+
+def test_inspection_est_strictement_lecture_seule():
+    db = FakeSchemaDB()
+    rapport = SCHEMA.InspecterSchema(db)
+    assert rapport["structures"]["existe"] is False
+    assert rapport["structures_contacts"]["existe"] is False
+    assert db.creations == []
+    assert db.commits == 0
+
+
+def test_mode_diagnostic_ne_cree_rien():
+    db = FakeSchemaDB()
+    resultat = SCHEMA.AssurerSchema(db, appliquer=False)
+    assert resultat["ok"] is True
+    assert resultat["tables_creees"] == ()
+    assert set(resultat["tables_absentes"]) == {"structures", "structures_contacts"}
+    assert db.creations == []
+
+
+def test_activation_cree_uniquement_les_deux_tables_062a():
+    db = FakeSchemaDB()
+    resultat = SCHEMA.AssurerSchema(db, appliquer=True)
+    assert resultat["ok"] is True
+    assert resultat["tables_creees"] == ("structures", "structures_contacts")
+    assert db.creations == ["structures", "structures_contacts"]
+    assert db.commits == 2
+    assert set(db.tables) == {"structures", "structures_contacts"}
+    assert db.tables["structures"] == [champ[0] for champ in DATA.DB_STRUCTURES["structures"]]
+
+
+def test_activation_est_idempotente():
+    tables = {
+        "structures": [champ[0] for champ in DATA.DB_STRUCTURES["structures"]],
+        "structures_contacts": [champ[0] for champ in DATA.DB_STRUCTURES["structures_contacts"]],
+    }
+    db = FakeSchemaDB(tables=tables)
+    resultat = SCHEMA.AssurerSchema(db, appliquer=True)
+    assert resultat["ok"] is True
+    assert resultat["tables_creees"] == ()
+    assert db.creations == []
+    assert db.commits == 0
+
+
+def test_table_existante_incomplete_n_est_jamais_modifiee_silencieusement():
+    tables = {
+        "structures": ["IDstructure", "nom"],
+        "structures_contacts": [champ[0] for champ in DATA.DB_STRUCTURES["structures_contacts"]],
+    }
+    db = FakeSchemaDB(tables=tables)
+    resultat = SCHEMA.AssurerSchema(db, appliquer=True)
+    assert resultat["ok"] is False
+    assert resultat["tables_incoherentes"] == ("structures",)
+    assert "uid" in resultat["rapport"]["structures"]["champs_manquants"]
+    assert db.creations == []
+    assert db.commits == 0

--- a/tests/test_noe_062a_schema.py
+++ b/tests/test_noe_062a_schema.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import importlib.util
+import sqlite3
 import sys
 from pathlib import Path
 
@@ -95,3 +96,28 @@ def test_table_existante_incomplete_n_est_jamais_modifiee_silencieusement():
     assert "uid" in resultat["rapport"]["structures"]["champs_manquants"]
     assert db.creations == []
     assert db.commits == 0
+
+
+def test_contrat_062a_est_executable_par_sqlite():
+    connexion = sqlite3.connect(":memory:")
+    try:
+        curseur = connexion.cursor()
+        for nom_table in SCHEMA.TABLES_062A:
+            champs = ", ".join("%s %s" % (nom, type_champ) for nom, type_champ, info in DATA.DB_STRUCTURES[nom_table])
+            curseur.execute("CREATE TABLE %s (%s)" % (nom_table, champs))
+
+        curseur.execute(
+            "INSERT INTO structures (uid, type_structure, nom, actif) VALUES (?, ?, ?, ?)",
+            ("STR-test", "ecole", "Ecole de test", 1),
+        )
+        IDstructure = curseur.lastrowid
+        curseur.execute(
+            "INSERT INTO structures_contacts (IDstructure, nom, fonction, actif) VALUES (?, ?, ?, ?)",
+            (IDstructure, "Martin", "Direction", 1),
+        )
+        connexion.commit()
+
+        curseur.execute("SELECT uid, type_structure, nom FROM structures WHERE IDstructure=?", (IDstructure,))
+        assert curseur.fetchone() == ("STR-test", "ecole", "Ecole de test")
+    finally:
+        connexion.close()

--- a/tests/test_schema_compatibility_guard.py
+++ b/tests/test_schema_compatibility_guard.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _charger():
+    path = ROOT / "scripts" / "check_schema_compatibility.py"
+    spec = importlib.util.spec_from_file_location("check_schema_compatibility_test", str(path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+GUARD = _charger()
+
+
+def test_les_tests_jetables_sont_hors_perimetre_schema():
+    assert GUARD.is_ignored_path("tests/test_schema_temporaire.py") is True
+    assert GUARD.is_ignored_path("tests/sous_dossier/test_db.py") is True
+
+
+def test_le_code_applicatif_reste_surveille():
+    assert GUARD.is_ignored_path("noethys/UpgradeDB.py") is False
+    assert GUARD.is_ignored_path("noethys/Utils/UTILS_Tiers_Schema.py") is False
+
+
+def test_le_constructeur_synthetique_historique_reste_explicitement_ignore():
+    assert GUARD.is_ignored_path("scripts/build_synthetic_recette_db.py") is True
+    assert GUARD.is_ignored_path("scripts/autre_migration.py") is False


### PR DESCRIPTION
## Objectif
Préparer l'activation réelle des deux premières tables du référentiel tiers sans mutation implicite des bases existantes.

## Contenu
- ajoute `UTILS_Tiers_Schema.py` ;
- inspection lecture seule de l'état du schéma ;
- création explicite et idempotente de `structures` et `structures_contacts` uniquement ;
- aucune réparation silencieuse d'une table existante mais incomplète ;
- rapport détaillé des champs manquants ;
- tests d'idempotence et de non-modification implicite ;
- validation du contrat de schéma sur un SQLite réel en mémoire.

## Garde-fous
- rien ne s'exécute au simple import ;
- `appliquer=False` reste strictement diagnostique ;
- aucune table historique Noethys modifiée ;
- aucune migration destructive ;
- pas encore de branchement automatique dans `UpgradeDB.py` tant que ce contrat n'est pas qualifié.

Suite : après fusion, branchement contrôlé dans le mécanisme d'upgrade 1.3.5.x puis UI minimale liste/fiche.

Relates #211. Relates #60.