### PR TITLE
Noe-062B — séances de sport pour les écoles

### DIFF
--- a/noethys/Data/DATA_Structures.py
+++ b/noethys/Data/DATA_Structures.py
@@ -95,6 +95,25 @@ DB_STRUCTURES = {
         ("memo", "VARCHAR(1000)", u"Mémo"),
     ],
 
+    "interventions": [
+        ("IDintervention", "INTEGER PRIMARY KEY AUTOINCREMENT", u"ID local de l'intervention"),
+        ("uid", "VARCHAR(64)", u"Identifiant stable inter-applications"),
+        ("IDstructure", "INTEGER", u"Structure bénéficiaire"),
+        ("IDgroupe_structure", "INTEGER", u"Classe / groupe optionnel"),
+        ("IDrelation_structure", "INTEGER", u"Relation / convention optionnelle"),
+        ("nature", "VARCHAR(50)", u"Nature : sport, animation, autre"),
+        ("date", "DATE", u"Date de l'intervention"),
+        ("heure_debut", "VARCHAR(5)", u"Heure de début HH:MM"),
+        ("heure_fin", "VARCHAR(5)", u"Heure de fin HH:MM"),
+        ("duree_minutes", "INTEGER", u"Durée calculée en minutes"),
+        ("libelle", "VARCHAR(300)", u"Libellé de la séance"),
+        ("statut", "VARCHAR(50)", u"planifiee, realisee, annulee"),
+        ("notes", "VARCHAR(2000)", u"Notes libres"),
+        ("actif", "INTEGER", u"Intervention active 0/1"),
+        ("date_creation", "DATE", u"Date de création"),
+        ("date_modification", "DATE", u"Date de dernière modification"),
+    ],
+
     "structures_relations": [
         ("IDrelation_structure", "INTEGER PRIMARY KEY AUTOINCREMENT", u"ID relation/prestation"),
         ("IDstructure", "INTEGER", u"Structure contractante ou bénéficiaire"),

--- a/noethys/Dlg/DLG_Ecoles.py
+++ b/noethys/Dlg/DLG_Ecoles.py
@@ -36,6 +36,7 @@ class Dialog(wx.Dialog):
         self.bouton_ajouter = wx.BitmapButton(self, -1, wx.Bitmap(Chemins.GetStaticPath("Images/16x16/Ajouter.png"), wx.BITMAP_TYPE_ANY))
         self.bouton_modifier = wx.BitmapButton(self, -1, wx.Bitmap(Chemins.GetStaticPath("Images/16x16/Modifier.png"), wx.BITMAP_TYPE_ANY))
         self.bouton_supprimer = wx.BitmapButton(self, -1, wx.Bitmap(Chemins.GetStaticPath("Images/16x16/Supprimer.png"), wx.BITMAP_TYPE_ANY))
+        self.bouton_seances_sport = wx.Button(self, -1, _(u"Séances sport"))
         
         self.bouton_aide = CTRL_Bouton_image.CTRL(self, texte=_(u"Aide"), cheminImage="Images/32x32/Aide.png")
         self.bouton_fermer = CTRL_Bouton_image.CTRL(self, id=wx.ID_CANCEL, texte=_(u"Fermer"), cheminImage="Images/32x32/Fermer.png")
@@ -46,6 +47,7 @@ class Dialog(wx.Dialog):
         self.Bind(wx.EVT_BUTTON, self.Ajouter, self.bouton_ajouter)
         self.Bind(wx.EVT_BUTTON, self.Modifier, self.bouton_modifier)
         self.Bind(wx.EVT_BUTTON, self.Supprimer, self.bouton_supprimer)
+        self.Bind(wx.EVT_BUTTON, self.SeancesSport, self.bouton_seances_sport)
         self.Bind(wx.EVT_BUTTON, self.OnBoutonAide, self.bouton_aide)
 
 
@@ -53,6 +55,7 @@ class Dialog(wx.Dialog):
         self.bouton_ajouter.SetToolTip(wx.ToolTip(_(u"Cliquez ici pour ajouter une école")))
         self.bouton_modifier.SetToolTip(wx.ToolTip(_(u"Cliquez ici pour modifier l'école sélectionnée dans la liste")))
         self.bouton_supprimer.SetToolTip(wx.ToolTip(_(u"Cliquez ici pour supprimer l'école sélectionnée dans la iste")))
+        self.bouton_seances_sport.SetToolTip(wx.ToolTip(_(u"Enregistrer les séances de sport de l'école sélectionnée")))
         self.bouton_aide.SetToolTip(wx.ToolTip(_(u"Cliquez ici pour obtenir de l'aide")))
         self.bouton_fermer.SetToolTip(wx.ToolTip(_(u"Cliquez ici pour fermer")))
         self.SetMinSize((750, 600))
@@ -61,7 +64,7 @@ class Dialog(wx.Dialog):
         grid_sizer_base = wx.FlexGridSizer(rows=3, cols=1, vgap=10, hgap=10)
         grid_sizer_boutons = wx.FlexGridSizer(rows=1, cols=4, vgap=10, hgap=10)
         grid_sizer_contenu = wx.FlexGridSizer(rows=1, cols=2, vgap=5, hgap=5)
-        grid_sizer_droit = wx.FlexGridSizer(rows=4, cols=1, vgap=5, hgap=5)
+        grid_sizer_droit = wx.FlexGridSizer(rows=5, cols=1, vgap=5, hgap=5)
         grid_sizer_gauche = wx.FlexGridSizer(rows=3, cols=1, vgap=10, hgap=10)
         grid_sizer_base.Add(self.ctrl_bandeau, 0, wx.EXPAND, 0)
         grid_sizer_gauche.Add(self.ctrl_listview, 0, wx.EXPAND, 0)
@@ -72,6 +75,7 @@ class Dialog(wx.Dialog):
         grid_sizer_droit.Add(self.bouton_ajouter, 0, 0, 0)
         grid_sizer_droit.Add(self.bouton_modifier, 0, 0, 0)
         grid_sizer_droit.Add(self.bouton_supprimer, 0, 0, 0)
+        grid_sizer_droit.Add(self.bouton_seances_sport, 0, wx.TOP, 10)
         grid_sizer_contenu.Add(grid_sizer_droit, 1, wx.EXPAND, 0)
         grid_sizer_contenu.AddGrowableRow(0)
         grid_sizer_contenu.AddGrowableCol(0)
@@ -96,6 +100,24 @@ class Dialog(wx.Dialog):
 
     def Supprimer(self, event):
         self.ctrl_listview.Supprimer(None)
+
+    def SeancesSport(self, event):
+        selection = self.ctrl_listview.Selection()
+        if len(selection) == 0:
+            dlg = wx.MessageDialog(
+                self,
+                _(u"Sélectionnez d'abord une école pour enregistrer ses séances de sport."),
+                _(u"Séances sport"),
+                wx.OK | wx.ICON_INFORMATION,
+            )
+            dlg.ShowModal()
+            dlg.Destroy()
+            return
+        ecole = selection[0]
+        from Dlg import DLG_Seances_sport_ecoles
+        dlg = DLG_Seances_sport_ecoles.Dialog(self, IDecole=ecole.IDecole, nom_ecole=ecole.nom)
+        dlg.ShowModal()
+        dlg.Destroy()
             
     def OnBoutonAide(self, event): 
         from Utils import UTILS_Aide

--- a/noethys/Dlg/DLG_Seances_sport_ecoles.py
+++ b/noethys/Dlg/DLG_Seances_sport_ecoles.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Saisie quotidienne des séances de sport réalisées pour une école."""
+
+from __future__ import unicode_literals
+
+import datetime
+
+import wx
+
+import GestionDB
+from Utils.UTILS_Traduction import _
+from Utils import UTILS_Interventions
+from Utils import UTILS_Tiers_Schema
+
+
+STATUTS_UI = (
+    ("planifiee", _(u"Planifiée")),
+    ("realisee", _(u"Réalisée")),
+    ("annulee", _(u"Annulée")),
+)
+
+
+def _date_fr(date_iso):
+    try:
+        return datetime.datetime.strptime(date_iso, "%Y-%m-%d").strftime("%d/%m/%Y")
+    except Exception:
+        return date_iso or u""
+
+
+def _duree_humaine(minutes):
+    try:
+        minutes = int(minutes or 0)
+    except Exception:
+        minutes = 0
+    heures, reste = divmod(minutes, 60)
+    if heures and reste:
+        return u"%dh%02d" % (heures, reste)
+    if heures:
+        return u"%dh" % heures
+    return u"%d min" % reste
+
+
+class DialogSeance(wx.Dialog):
+    def __init__(self, parent, seance=None):
+        wx.Dialog.__init__(
+            self,
+            parent,
+            -1,
+            title=_(u"Séance de sport"),
+            style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER,
+        )
+        self.seance = dict(seance or {})
+
+        self.label_date = wx.StaticText(self, -1, _(u"Date"))
+        self.ctrl_date = wx.TextCtrl(self, -1)
+        self.label_debut = wx.StaticText(self, -1, _(u"Heure de début"))
+        self.ctrl_debut = wx.TextCtrl(self, -1)
+        self.label_fin = wx.StaticText(self, -1, _(u"Heure de fin"))
+        self.ctrl_fin = wx.TextCtrl(self, -1)
+        self.label_libelle = wx.StaticText(self, -1, _(u"Libellé"))
+        self.ctrl_libelle = wx.TextCtrl(self, -1)
+        self.label_statut = wx.StaticText(self, -1, _(u"Statut"))
+        self.ctrl_statut = wx.Choice(self, -1, choices=[label for code, label in STATUTS_UI])
+        self.label_notes = wx.StaticText(self, -1, _(u"Notes"))
+        self.ctrl_notes = wx.TextCtrl(self, -1, style=wx.TE_MULTILINE)
+
+        self.bouton_ok = wx.Button(self, wx.ID_OK, _(u"Enregistrer"))
+        self.bouton_annuler = wx.Button(self, wx.ID_CANCEL, _(u"Annuler"))
+        self.bouton_ok.SetDefault()
+
+        self._initialiser_valeurs()
+        self._layout()
+        self.Bind(wx.EVT_BUTTON, self.OnOK, self.bouton_ok)
+
+    def _initialiser_valeurs(self):
+        self.ctrl_date.SetValue(_date_fr(self.seance.get("date")) or datetime.date.today().strftime("%d/%m/%Y"))
+        self.ctrl_debut.SetValue(self.seance.get("heure_debut") or "09:00")
+        self.ctrl_fin.SetValue(self.seance.get("heure_fin") or "10:00")
+        self.ctrl_libelle.SetValue(self.seance.get("libelle") or _(u"Séance de sport"))
+        statut = self.seance.get("statut") or "realisee"
+        codes = [code for code, label in STATUTS_UI]
+        self.ctrl_statut.SetSelection(codes.index(statut) if statut in codes else 1)
+        self.ctrl_notes.SetValue(self.seance.get("notes") or u"")
+
+    def _layout(self):
+        grille = wx.FlexGridSizer(rows=6, cols=2, vgap=8, hgap=12)
+        grille.Add(self.label_date, 0, wx.ALIGN_CENTER_VERTICAL)
+        grille.Add(self.ctrl_date, 1, wx.EXPAND)
+        grille.Add(self.label_debut, 0, wx.ALIGN_CENTER_VERTICAL)
+        grille.Add(self.ctrl_debut, 1, wx.EXPAND)
+        grille.Add(self.label_fin, 0, wx.ALIGN_CENTER_VERTICAL)
+        grille.Add(self.ctrl_fin, 1, wx.EXPAND)
+        grille.Add(self.label_libelle, 0, wx.ALIGN_CENTER_VERTICAL)
+        grille.Add(self.ctrl_libelle, 1, wx.EXPAND)
+        grille.Add(self.label_statut, 0, wx.ALIGN_CENTER_VERTICAL)
+        grille.Add(self.ctrl_statut, 1, wx.EXPAND)
+        grille.Add(self.label_notes, 0, wx.ALIGN_TOP)
+        grille.Add(self.ctrl_notes, 1, wx.EXPAND)
+        grille.AddGrowableCol(1)
+        grille.AddGrowableRow(5)
+
+        boutons = wx.BoxSizer(wx.HORIZONTAL)
+        boutons.AddStretchSpacer(1)
+        boutons.Add(self.bouton_annuler, 0, wx.RIGHT, 8)
+        boutons.Add(self.bouton_ok, 0)
+
+        base = wx.BoxSizer(wx.VERTICAL)
+        base.Add(grille, 1, wx.ALL | wx.EXPAND, 16)
+        base.Add(boutons, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 16)
+        self.SetSizer(base)
+        self.SetMinSize((500, 390))
+        self.SetSize((560, 430))
+        self.CenterOnParent()
+
+    def GetDonnees(self):
+        index = self.ctrl_statut.GetSelection()
+        if index < 0:
+            index = 1
+        return {
+            "date": self.ctrl_date.GetValue(),
+            "heure_debut": self.ctrl_debut.GetValue(),
+            "heure_fin": self.ctrl_fin.GetValue(),
+            "libelle": self.ctrl_libelle.GetValue(),
+            "statut": STATUTS_UI[index][0],
+            "notes": self.ctrl_notes.GetValue(),
+        }
+
+    def OnOK(self, event):
+        donnees = self.GetDonnees()
+        try:
+            UTILS_Interventions._date_iso(donnees["date"])
+            UTILS_Interventions.CalculerDureeMinutes(donnees["heure_debut"], donnees["heure_fin"])
+        except ValueError as err:
+            dlg = wx.MessageDialog(self, str(err), _(u"Erreur de saisie"), wx.OK | wx.ICON_EXCLAMATION)
+            dlg.ShowModal()
+            dlg.Destroy()
+            return
+        self.EndModal(wx.ID_OK)
+
+
+class Dialog(wx.Dialog):
+    def __init__(self, parent, IDecole, nom_ecole=u""):
+        wx.Dialog.__init__(
+            self,
+            parent,
+            -1,
+            title=_(u"Séances sport — %s") % nom_ecole,
+            name="DLG_Seances_sport_ecoles",
+            style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER | wx.MAXIMIZE_BOX,
+        )
+        self.IDecole = int(IDecole)
+        self.nom_ecole = nom_ecole
+        self.db = GestionDB.DB()
+        self.service = UTILS_Interventions.GestionnaireInterventions(self.db)
+        self.ecole = None
+        self.schema_ok = False
+        self.dict_seances = {}
+
+        self.titre = wx.StaticText(self, -1, _(u"École : %s") % nom_ecole)
+        font = self.titre.GetFont()
+        font.SetWeight(wx.FONTWEIGHT_BOLD)
+        font.SetPointSize(max(font.GetPointSize() + 2, 11))
+        self.titre.SetFont(font)
+        self.sous_titre = wx.StaticText(
+            self,
+            -1,
+            _(u"Enregistrez ici les séances de sport réalisées ou planifiées pour cette école."),
+        )
+
+        self.liste = wx.ListCtrl(self, -1, style=wx.LC_REPORT | wx.LC_SINGLE_SEL | wx.BORDER_SIMPLE)
+        self.liste.InsertColumn(0, _(u"Date"), width=95)
+        self.liste.InsertColumn(1, _(u"Horaire"), width=125)
+        self.liste.InsertColumn(2, _(u"Durée"), width=80)
+        self.liste.InsertColumn(3, _(u"Libellé"), width=260)
+        self.liste.InsertColumn(4, _(u"Statut"), width=100)
+
+        self.bouton_ajouter = wx.Button(self, -1, _(u"Ajouter une séance"))
+        self.bouton_modifier = wx.Button(self, -1, _(u"Modifier"))
+        self.bouton_archiver = wx.Button(self, -1, _(u"Archiver"))
+        self.bouton_fermer = wx.Button(self, wx.ID_CANCEL, _(u"Fermer"))
+
+        self._layout()
+        self.Bind(wx.EVT_BUTTON, self.Ajouter, self.bouton_ajouter)
+        self.Bind(wx.EVT_BUTTON, self.Modifier, self.bouton_modifier)
+        self.Bind(wx.EVT_BUTTON, self.Archiver, self.bouton_archiver)
+        self.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self.Modifier, self.liste)
+        self.Bind(wx.EVT_CLOSE, self.OnClose)
+
+        self._initialiser_metier()
+
+    def _layout(self):
+        entete = wx.BoxSizer(wx.VERTICAL)
+        entete.Add(self.titre, 0, wx.BOTTOM, 4)
+        entete.Add(self.sous_titre, 0)
+
+        actions = wx.BoxSizer(wx.HORIZONTAL)
+        actions.Add(self.bouton_ajouter, 0, wx.RIGHT, 8)
+        actions.Add(self.bouton_modifier, 0, wx.RIGHT, 8)
+        actions.Add(self.bouton_archiver, 0)
+        actions.AddStretchSpacer(1)
+        actions.Add(self.bouton_fermer, 0)
+
+        base = wx.BoxSizer(wx.VERTICAL)
+        base.Add(entete, 0, wx.ALL | wx.EXPAND, 16)
+        base.Add(self.liste, 1, wx.LEFT | wx.RIGHT | wx.EXPAND, 16)
+        base.Add(actions, 0, wx.ALL | wx.EXPAND, 16)
+        self.SetSizer(base)
+        self.SetMinSize((760, 500))
+        self.SetSize((900, 620))
+        self.CenterOnParent()
+
+    def _initialiser_metier(self):
+        try:
+            resultat = UTILS_Tiers_Schema.AssurerSchema062B(self.db, appliquer=True)
+            if not resultat.get("ok"):
+                raise RuntimeError(
+                    "Schéma tiers/interventions incohérent : %s" % ", ".join(resultat.get("tables_incoherentes", ()))
+                )
+            self.ecole = self.service.SynchroniserEcoleHistorique(self.IDecole)
+            self.nom_ecole = self.ecole.get("nom") or self.nom_ecole
+            self.titre.SetLabel(_(u"École : %s") % self.nom_ecole)
+            self.SetTitle(_(u"Séances sport — %s") % self.nom_ecole)
+            self.schema_ok = True
+            self.MAJ()
+        except Exception as err:
+            self.schema_ok = False
+            self.bouton_ajouter.Enable(False)
+            self.bouton_modifier.Enable(False)
+            self.bouton_archiver.Enable(False)
+            dlg = wx.MessageDialog(
+                self,
+                _(u"Impossible d'activer la saisie des séances de sport.\n\n%s") % str(err),
+                _(u"Séances sport"),
+                wx.OK | wx.ICON_ERROR,
+            )
+            dlg.ShowModal()
+            dlg.Destroy()
+
+    def _selection_id(self):
+        index = self.liste.GetFirstSelected()
+        if index == -1:
+            return None
+        return self.liste.GetItemData(index)
+
+    def _selection_obligatoire(self):
+        IDintervention = self._selection_id()
+        if IDintervention is None:
+            dlg = wx.MessageDialog(
+                self,
+                _(u"Sélectionnez d'abord une séance."),
+                _(u"Séances sport"),
+                wx.OK | wx.ICON_INFORMATION,
+            )
+            dlg.ShowModal()
+            dlg.Destroy()
+        return IDintervention
+
+    def MAJ(self, selection=None):
+        if not self.schema_ok or not self.ecole:
+            return
+        self.liste.DeleteAllItems()
+        self.dict_seances = {}
+        seances = self.service.ListerSeancesSportEcole(self.ecole["IDstructure"])
+        labels_statut = dict(STATUTS_UI)
+        selection_index = None
+        for ligne, seance in enumerate(seances):
+            IDintervention = int(seance["IDintervention"])
+            index = self.liste.InsertItem(ligne, _date_fr(seance.get("date")))
+            self.liste.SetItem(index, 1, u"%s – %s" % (seance.get("heure_debut") or u"", seance.get("heure_fin") or u""))
+            self.liste.SetItem(index, 2, _duree_humaine(seance.get("duree_minutes")))
+            self.liste.SetItem(index, 3, seance.get("libelle") or u"")
+            self.liste.SetItem(index, 4, labels_statut.get(seance.get("statut"), seance.get("statut") or u""))
+            self.liste.SetItemData(index, IDintervention)
+            self.dict_seances[IDintervention] = seance
+            if selection == IDintervention:
+                selection_index = index
+        if selection_index is not None:
+            self.liste.Select(selection_index)
+            self.liste.EnsureVisible(selection_index)
+
+    def Ajouter(self, event):
+        if not self.schema_ok:
+            return
+        dlg = DialogSeance(self)
+        if dlg.ShowModal() == wx.ID_OK:
+            donnees = dlg.GetDonnees()
+            try:
+                IDintervention = self.service.CreerSeanceSportEcole(
+                    self.ecole["IDstructure"],
+                    donnees["date"],
+                    donnees["heure_debut"],
+                    donnees["heure_fin"],
+                    libelle=donnees["libelle"],
+                    statut=donnees["statut"],
+                    notes=donnees["notes"],
+                )
+                self.MAJ(selection=IDintervention)
+            except Exception as err:
+                self._afficher_erreur(err)
+        dlg.Destroy()
+
+    def Modifier(self, event):
+        IDintervention = self._selection_obligatoire()
+        if IDintervention is None:
+            return
+        seance = self.dict_seances.get(IDintervention) or self.service.LireIntervention(IDintervention)
+        dlg = DialogSeance(self, seance=seance)
+        if dlg.ShowModal() == wx.ID_OK:
+            donnees = dlg.GetDonnees()
+            try:
+                self.service.ModifierSeanceSport(IDintervention, donnees)
+                self.MAJ(selection=IDintervention)
+            except Exception as err:
+                self._afficher_erreur(err)
+        dlg.Destroy()
+
+    def Archiver(self, event):
+        IDintervention = self._selection_obligatoire()
+        if IDintervention is None:
+            return
+        dlg = wx.MessageDialog(
+            self,
+            _(u"Archiver cette séance ? Elle ne sera pas supprimée de l'historique."),
+            _(u"Séances sport"),
+            wx.YES_NO | wx.NO_DEFAULT | wx.ICON_QUESTION,
+        )
+        reponse = dlg.ShowModal()
+        dlg.Destroy()
+        if reponse != wx.ID_YES:
+            return
+        try:
+            self.service.ArchiverSeanceSport(IDintervention)
+            self.MAJ()
+        except Exception as err:
+            self._afficher_erreur(err)
+
+    def _afficher_erreur(self, err):
+        dlg = wx.MessageDialog(self, str(err), _(u"Erreur de saisie"), wx.OK | wx.ICON_EXCLAMATION)
+        dlg.ShowModal()
+        dlg.Destroy()
+
+    def OnClose(self, event):
+        try:
+            self.db.Close()
+        except Exception:
+            pass
+        event.Skip()
+
+    def Destroy(self):
+        try:
+            self.db.Close()
+        except Exception:
+            pass
+        return wx.Dialog.Destroy(self)

--- a/noethys/Utils/UTILS_Interventions.py
+++ b/noethys/Utils/UTILS_Interventions.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Interventions métier liées aux structures, premier vertical Noe-062B.
+
+Le premier cas activé est volontairement simple : enregistrer une séance de
+sport pour une école. Les conventions, groupes/classes et payeurs restent des
+liens optionnels ; ils ne bloquent pas la saisie quotidienne.
+"""
+
+from __future__ import unicode_literals
+
+import datetime
+import uuid
+
+from Utils import UTILS_Tiers
+
+
+CHAMPS_INTERVENTION = (
+    "uid",
+    "IDstructure",
+    "IDgroupe_structure",
+    "IDrelation_structure",
+    "nature",
+    "date",
+    "heure_debut",
+    "heure_fin",
+    "duree_minutes",
+    "libelle",
+    "statut",
+    "notes",
+    "actif",
+    "date_creation",
+    "date_modification",
+)
+
+STATUTS_SEANCE = ("planifiee", "realisee", "annulee")
+
+
+def _texte(valeur):
+    if valeur is None:
+        return u""
+    try:
+        return valeur.strip()
+    except Exception:
+        return valeur
+
+
+def _date_iso(valeur=None):
+    valeur = valeur or datetime.date.today()
+    if isinstance(valeur, datetime.datetime):
+        valeur = valeur.date()
+    if isinstance(valeur, datetime.date):
+        return valeur.isoformat()
+    texte = _texte(valeur)
+    for format_date in ("%Y-%m-%d", "%d/%m/%Y"):
+        try:
+            return datetime.datetime.strptime(texte, format_date).date().isoformat()
+        except (TypeError, ValueError):
+            pass
+    raise ValueError("Date invalide : utilisez JJ/MM/AAAA ou AAAA-MM-JJ")
+
+
+def _heure_hhmm(valeur):
+    texte = _texte(valeur)
+    try:
+        heure = datetime.datetime.strptime(texte, "%H:%M")
+    except (TypeError, ValueError):
+        raise ValueError("Heure invalide : utilisez HH:MM")
+    return heure.strftime("%H:%M")
+
+
+def CalculerDureeMinutes(heure_debut, heure_fin):
+    debut = datetime.datetime.strptime(_heure_hhmm(heure_debut), "%H:%M")
+    fin = datetime.datetime.strptime(_heure_hhmm(heure_fin), "%H:%M")
+    minutes = int((fin - debut).total_seconds() // 60)
+    if minutes <= 0:
+        raise ValueError("L'heure de fin doit être postérieure à l'heure de début")
+    return minutes
+
+
+def GenererUIDIntervention():
+    return "INT-%s" % uuid.uuid4().hex
+
+
+def _liste_pairs(donnees):
+    return [(champ, donnees[champ]) for champ in CHAMPS_INTERVENTION if champ in donnees]
+
+
+class GestionnaireInterventions(object):
+    def __init__(self, db):
+        self.db = db
+        self.tiers = UTILS_Tiers.GestionnaireTiers(db)
+
+    def _verifier_ecole(self, IDstructure):
+        structure = self.tiers.LireStructure(int(IDstructure))
+        if not structure:
+            raise ValueError("École introuvable dans le référentiel des structures")
+        if structure.get("type_structure") != "ecole":
+            raise ValueError("La structure sélectionnée n'est pas une école")
+        if structure.get("actif") in (0, False, "0"):
+            raise ValueError("Cette école est archivée")
+        return structure
+
+    def SynchroniserEcoleHistorique(self, IDecole):
+        """Crée/met à jour le tiers école depuis la table historique ``ecoles``.
+
+        Le lien est stable grâce à l'UID ``ECOLE-NOETHYS-<IDecole>``. La table
+        historique reste la source de vérité de la fiche école tant que sa
+        migration complète n'est pas décidée.
+        """
+        IDecole = int(IDecole)
+        req = """SELECT IDecole, nom, rue, cp, ville, tel, mail
+        FROM ecoles WHERE IDecole=%d;""" % IDecole
+        if self.db.ExecuterReq(req) != 1:
+            raise ValueError("Impossible de lire l'école historique")
+        lignes = self.db.ResultatReq()
+        if not lignes:
+            raise ValueError("École historique introuvable")
+
+        IDecole, nom, rue, cp, ville, tel, mail = lignes[0]
+        uid = "ECOLE-NOETHYS-%d" % int(IDecole)
+        donnees = {
+            "type_structure": "ecole",
+            "nom": _texte(nom),
+            "rue": _texte(rue),
+            "cp": _texte(cp),
+            "ville": _texte(ville),
+            "tel": _texte(tel),
+            "mail": _texte(mail),
+            "actif": 1,
+        }
+
+        structure_existante = None
+        for structure in self.tiers.ListerStructures(actifs_seulement=False):
+            if structure.get("uid") == uid:
+                structure_existante = structure
+                break
+
+        if structure_existante is None:
+            donnees["uid"] = uid
+            IDstructure = self.tiers.CreerStructure(donnees)
+            if IDstructure is None:
+                raise RuntimeError("La création du tiers école a échoué")
+            return self.tiers.LireStructure(IDstructure)
+
+        IDstructure = structure_existante["IDstructure"]
+        if self.tiers.ModifierStructure(IDstructure, donnees) is False:
+            raise RuntimeError("La synchronisation du tiers école a échoué")
+        return self.tiers.LireStructure(IDstructure)
+
+    def CreerSeanceSportEcole(self, IDstructure, date, heure_debut, heure_fin,
+                              libelle=u"Séance de sport", statut="realisee",
+                              notes=u"", IDgroupe_structure=None,
+                              IDrelation_structure=None):
+        self._verifier_ecole(IDstructure)
+        statut = _texte(statut) or "realisee"
+        if statut not in STATUTS_SEANCE:
+            raise ValueError("Statut de séance inconnu : %s" % statut)
+        debut = _heure_hhmm(heure_debut)
+        fin = _heure_hhmm(heure_fin)
+        aujourd_hui = datetime.date.today().isoformat()
+        valeurs = {
+            "uid": GenererUIDIntervention(),
+            "IDstructure": int(IDstructure),
+            "IDgroupe_structure": IDgroupe_structure,
+            "IDrelation_structure": IDrelation_structure,
+            "nature": "sport",
+            "date": _date_iso(date),
+            "heure_debut": debut,
+            "heure_fin": fin,
+            "duree_minutes": CalculerDureeMinutes(debut, fin),
+            "libelle": _texte(libelle) or u"Séance de sport",
+            "statut": statut,
+            "notes": _texte(notes),
+            "actif": 1,
+            "date_creation": aujourd_hui,
+            "date_modification": aujourd_hui,
+        }
+        return self.db.ReqInsert("interventions", _liste_pairs(valeurs))
+
+    def LireIntervention(self, IDintervention):
+        req = "SELECT IDintervention, %s FROM interventions WHERE IDintervention=%d;" % (
+            ", ".join(CHAMPS_INTERVENTION), int(IDintervention))
+        if self.db.ExecuterReq(req) != 1:
+            return None
+        lignes = self.db.ResultatReq()
+        if not lignes:
+            return None
+        return dict(zip(("IDintervention",) + CHAMPS_INTERVENTION, lignes[0]))
+
+    def ModifierSeanceSport(self, IDintervention, donnees):
+        courant = self.LireIntervention(IDintervention)
+        if not courant or courant.get("nature") != "sport":
+            raise ValueError("Séance de sport introuvable")
+        donnees = dict(donnees or {})
+        if not donnees:
+            raise ValueError("Aucune donnée à modifier")
+
+        valeurs = {}
+        if "IDstructure" in donnees:
+            self._verifier_ecole(donnees["IDstructure"])
+            valeurs["IDstructure"] = int(donnees["IDstructure"])
+        if "IDgroupe_structure" in donnees:
+            valeurs["IDgroupe_structure"] = donnees["IDgroupe_structure"]
+        if "IDrelation_structure" in donnees:
+            valeurs["IDrelation_structure"] = donnees["IDrelation_structure"]
+        if "date" in donnees:
+            valeurs["date"] = _date_iso(donnees["date"])
+        if "libelle" in donnees:
+            valeurs["libelle"] = _texte(donnees["libelle"]) or u"Séance de sport"
+        if "notes" in donnees:
+            valeurs["notes"] = _texte(donnees["notes"])
+        if "statut" in donnees:
+            statut = _texte(donnees["statut"])
+            if statut not in STATUTS_SEANCE:
+                raise ValueError("Statut de séance inconnu : %s" % statut)
+            valeurs["statut"] = statut
+        if "actif" in donnees:
+            valeurs["actif"] = 1 if donnees["actif"] not in (0, False, "0") else 0
+
+        if "heure_debut" in donnees or "heure_fin" in donnees:
+            debut = _heure_hhmm(donnees.get("heure_debut", courant["heure_debut"]))
+            fin = _heure_hhmm(donnees.get("heure_fin", courant["heure_fin"]))
+            if "heure_debut" in donnees:
+                valeurs["heure_debut"] = debut
+            if "heure_fin" in donnees:
+                valeurs["heure_fin"] = fin
+            valeurs["duree_minutes"] = CalculerDureeMinutes(debut, fin)
+
+        valeurs["date_modification"] = datetime.date.today().isoformat()
+        return self.db.ReqMAJ(
+            "interventions",
+            _liste_pairs(valeurs),
+            "IDintervention",
+            int(IDintervention),
+        )
+
+    def ArchiverSeanceSport(self, IDintervention):
+        return self.ModifierSeanceSport(IDintervention, {"actif": 0})
+
+    def ListerSeancesSportEcole(self, IDstructure=None, date_debut=None,
+                                date_fin=None, actifs_seulement=True):
+        conditions = ["i.nature='sport'"]
+        if IDstructure is not None:
+            conditions.append("i.IDstructure=%d" % int(IDstructure))
+        if date_debut is not None:
+            conditions.append("i.date>='%s'" % _date_iso(date_debut))
+        if date_fin is not None:
+            conditions.append("i.date<='%s'" % _date_iso(date_fin))
+        if actifs_seulement:
+            conditions.append("i.actif=1")
+
+        req = """SELECT i.IDintervention, %s, s.nom
+        FROM interventions i
+        LEFT JOIN structures s ON s.IDstructure=i.IDstructure
+        WHERE %s
+        ORDER BY i.date DESC, i.heure_debut DESC, i.IDintervention DESC;""" % (
+            ", ".join("i.%s" % champ for champ in CHAMPS_INTERVENTION),
+            " AND ".join(conditions),
+        )
+        if self.db.ExecuterReq(req) != 1:
+            return []
+        champs = ("IDintervention",) + CHAMPS_INTERVENTION + ("nom_ecole",)
+        return [dict(zip(champs, ligne)) for ligne in self.db.ResultatReq()]

--- a/noethys/Utils/UTILS_Tiers_Schema.py
+++ b/noethys/Utils/UTILS_Tiers_Schema.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""Activation additive contrôlée du schéma Noe-062A.
+"""Activation additive contrôlée du schéma tiers Noe-062.
 
 Ce module ne s'exécute jamais au simple import. L'appelant choisit explicitement
 ``appliquer=True`` pour créer les tables manquantes. Une table déjà existante
@@ -16,6 +16,8 @@ from Data import DATA_Structures
 
 
 TABLES_062A = ("structures", "structures_contacts")
+TABLES_062B = ("interventions",)
+TABLES_062B_COMPLET = TABLES_062A + TABLES_062B
 
 
 def _descriptions_attendues(nom_table):
@@ -112,12 +114,12 @@ def _metadata_table(db, nom_table):
     return colonnes
 
 
-def InspecterSchema(db):
+def InspecterSchema(db, tables=TABLES_062A):
     """Retourne un rapport déterministe sans modifier la base."""
     rapport = {}
     is_network = bool(getattr(db, "isNetwork", False))
 
-    for nom_table in TABLES_062A:
+    for nom_table in tuple(tables):
         existe = bool(db.IsTableExists(nom_table))
         descriptions = _descriptions_attendues(nom_table)
         champs_attendus = tuple(champ[0] for champ in descriptions)
@@ -161,13 +163,14 @@ def InspecterSchema(db):
     return rapport
 
 
-def _resultat(rapport, appliquer, creees=()):
+def _resultat(rapport, appliquer, creees=(), tables=TABLES_062A):
+    tables = tuple(tables)
     incoherentes = tuple(
-        nom_table for nom_table in TABLES_062A
+        nom_table for nom_table in tables
         if rapport[nom_table]["existe"] and not rapport[nom_table]["conforme"]
     )
     absentes = tuple(
-        nom_table for nom_table in TABLES_062A
+        nom_table for nom_table in tables
         if not rapport[nom_table]["existe"]
     )
     return {
@@ -180,15 +183,11 @@ def _resultat(rapport, appliquer, creees=()):
     }
 
 
-def AssurerSchema(db, appliquer=False):
-    """Crée uniquement les tables 062A absentes, de manière idempotente.
-
-    Toute table existante incohérente bloque *avant la première écriture*. Une
-    activation qui échoue au préflight ne peut donc pas laisser seulement une
-    partie du référentiel créée.
-    """
-    avant = InspecterSchema(db)
-    preflight = _resultat(avant, appliquer=False)
+def _assurer_schema(db, tables, appliquer=False):
+    """Implémentation commune : préflight complet avant la première écriture."""
+    tables = tuple(tables)
+    avant = InspecterSchema(db, tables=tables)
+    preflight = _resultat(avant, appliquer=False, tables=tables)
 
     if preflight["tables_incoherentes"]:
         return {
@@ -202,11 +201,30 @@ def AssurerSchema(db, appliquer=False):
 
     creees = []
     if appliquer:
-        for nom_table in TABLES_062A:
+        for nom_table in tables:
             if not avant[nom_table]["existe"]:
                 db.CreationTable(nom_table, DATA_Structures.DB_STRUCTURES)
                 db.Commit()
                 creees.append(nom_table)
 
-    apres = InspecterSchema(db)
-    return _resultat(apres, appliquer=appliquer, creees=creees)
+    apres = InspecterSchema(db, tables=tables)
+    return _resultat(apres, appliquer=appliquer, creees=creees, tables=tables)
+
+
+def AssurerSchema(db, appliquer=False):
+    """Conserve le contrat 062A : structures + contacts uniquement."""
+    return _assurer_schema(db, TABLES_062A, appliquer=appliquer)
+
+
+def InspecterSchema062B(db):
+    """Inspecte le socle complet nécessaire aux séances école/sport."""
+    return InspecterSchema(db, tables=TABLES_062B_COMPLET)
+
+
+def AssurerSchema062B(db, appliquer=False):
+    """Active explicitement structures, contacts et interventions.
+
+    Aucun groupe ni convention n'est exigé pour saisir une première séance :
+    ces liens restent optionnels et pourront être enrichis ensuite.
+    """
+    return _assurer_schema(db, TABLES_062B_COMPLET, appliquer=appliquer)

--- a/tests/test_noe_062b_interventions.py
+++ b/tests/test_noe_062b_interventions.py
@@ -2,9 +2,8 @@
 import importlib.util
 import sqlite3
 import sys
+import unittest
 from pathlib import Path
-
-import pytest
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -106,116 +105,117 @@ def _db_pret():
     return db
 
 
-def test_schema_062b_est_additif_et_idempotent():
-    db = SQLiteDB()
-    try:
-        resultat = SCHEMA.AssurerSchema062B(db, appliquer=True)
-        assert resultat["ok"] is True
-        assert resultat["tables_creees"] == ("structures", "structures_contacts", "interventions")
-        assert set(db.creations) == {"structures", "structures_contacts", "interventions"}
+class Noe062BInterventionsTests(unittest.TestCase):
 
-        creations = list(db.creations)
-        resultat2 = SCHEMA.AssurerSchema062B(db, appliquer=True)
-        assert resultat2["ok"] is True
-        assert resultat2["tables_creees"] == ()
-        assert db.creations == creations
-    finally:
-        db.Close()
+    def test_schema_062b_est_additif_et_idempotent(self):
+        db = SQLiteDB()
+        try:
+            resultat = SCHEMA.AssurerSchema062B(db, appliquer=True)
+            self.assertTrue(resultat["ok"])
+            self.assertEqual(resultat["tables_creees"], ("structures", "structures_contacts", "interventions"))
+            self.assertEqual(set(db.creations), {"structures", "structures_contacts", "interventions"})
+
+            creations = list(db.creations)
+            resultat2 = SCHEMA.AssurerSchema062B(db, appliquer=True)
+            self.assertTrue(resultat2["ok"])
+            self.assertEqual(resultat2["tables_creees"], ())
+            self.assertEqual(db.creations, creations)
+        finally:
+            db.Close()
+
+    def test_ecole_historique_devient_un_tiers_ecole_sans_perdre_sa_denomination(self):
+        db = _db_pret()
+        try:
+            service = INTERVENTIONS.GestionnaireInterventions(db)
+            ecole = service.SynchroniserEcoleHistorique(1)
+            self.assertEqual(ecole["type_structure"], "ecole")
+            self.assertEqual(ecole["nom"], "École Jean-Moulin")
+            self.assertEqual(ecole["uid"], "ECOLE-NOETHYS-1")
+
+            # Une seconde synchronisation met à jour la même fiche, sans doublon.
+            db.cursor.execute("UPDATE ecoles SET nom=? WHERE IDecole=1", ("École Jean-Moulin - Centre",))
+            db.connexion.commit()
+            ecole2 = service.SynchroniserEcoleHistorique(1)
+            self.assertEqual(ecole2["IDstructure"], ecole["IDstructure"])
+            self.assertEqual(ecole2["nom"], "École Jean-Moulin - Centre")
+            self.assertEqual(len(service.tiers.ListerStructures(actifs_seulement=False)), 1)
+        finally:
+            db.Close()
+
+    def test_enregistrer_une_seance_sport_ecole_calcule_la_duree_et_restitue_le_nom(self):
+        db = _db_pret()
+        try:
+            service = INTERVENTIONS.GestionnaireInterventions(db)
+            ecole = service.SynchroniserEcoleHistorique(1)
+            IDseance = service.CreerSeanceSportEcole(
+                ecole["IDstructure"],
+                "04/09/2026",
+                "09:00",
+                "10:30",
+                libelle="EPS - cycle athlétisme",
+            )
+            self.assertTrue(IDseance)
+
+            seances = service.ListerSeancesSportEcole(ecole["IDstructure"])
+            self.assertEqual(len(seances), 1)
+            self.assertEqual(seances[0]["nom_ecole"], "École Jean-Moulin")
+            self.assertEqual(seances[0]["duree_minutes"], 90)
+            self.assertEqual(seances[0]["date"], "2026-09-04")
+            self.assertEqual(seances[0]["libelle"], "EPS - cycle athlétisme")
+        finally:
+            db.Close()
+
+    def test_horaire_incoherent_est_refuse_avant_ecriture(self):
+        db = _db_pret()
+        try:
+            service = INTERVENTIONS.GestionnaireInterventions(db)
+            ecole = service.SynchroniserEcoleHistorique(1)
+            with self.assertRaises(ValueError):
+                service.CreerSeanceSportEcole(ecole["IDstructure"], "04/09/2026", "10:30", "09:00")
+            self.assertEqual(service.ListerSeancesSportEcole(ecole["IDstructure"]), [])
+        finally:
+            db.Close()
+
+    def test_modification_partielle_et_archivage_ne_detruisent_pas_la_seance(self):
+        db = _db_pret()
+        try:
+            service = INTERVENTIONS.GestionnaireInterventions(db)
+            ecole = service.SynchroniserEcoleHistorique(1)
+            IDseance = service.CreerSeanceSportEcole(
+                ecole["IDstructure"], "04/09/2026", "09:00", "10:30",
+                libelle="EPS - cycle athlétisme", notes="Cour de l'école",
+            )
+            self.assertTrue(service.ModifierSeanceSport(IDseance, {"heure_fin": "11:00"}))
+            seance = service.LireIntervention(IDseance)
+            self.assertEqual(seance["heure_debut"], "09:00")
+            self.assertEqual(seance["heure_fin"], "11:00")
+            self.assertEqual(seance["duree_minutes"], 120)
+            self.assertEqual(seance["libelle"], "EPS - cycle athlétisme")
+            self.assertEqual(seance["notes"], "Cour de l'école")
+
+            self.assertTrue(service.ArchiverSeanceSport(IDseance))
+            self.assertEqual(service.ListerSeancesSportEcole(ecole["IDstructure"]), [])
+            archivee = service.ListerSeancesSportEcole(ecole["IDstructure"], actifs_seulement=False)
+            self.assertEqual(len(archivee), 1)
+            self.assertEqual(archivee[0]["libelle"], "EPS - cycle athlétisme")
+            self.assertEqual(archivee[0]["actif"], 0)
+        finally:
+            db.Close()
+
+    def test_filtre_par_periode_ne_retourne_que_les_seances_demandees(self):
+        db = _db_pret()
+        try:
+            service = INTERVENTIONS.GestionnaireInterventions(db)
+            ecole = service.SynchroniserEcoleHistorique(1)
+            for date in ("2026-09-02", "2026-10-07", "2026-11-04"):
+                service.CreerSeanceSportEcole(ecole["IDstructure"], date, "14:00", "15:00")
+            seances = service.ListerSeancesSportEcole(
+                ecole["IDstructure"], date_debut="01/10/2026", date_fin="31/10/2026"
+            )
+            self.assertEqual([item["date"] for item in seances], ["2026-10-07"])
+        finally:
+            db.Close()
 
 
-def test_ecole_historique_devient_un_tiers_ecole_sans_perdre_sa_denomination():
-    db = _db_pret()
-    try:
-        service = INTERVENTIONS.GestionnaireInterventions(db)
-        ecole = service.SynchroniserEcoleHistorique(1)
-        assert ecole["type_structure"] == "ecole"
-        assert ecole["nom"] == "École Jean-Moulin"
-        assert ecole["uid"] == "ECOLE-NOETHYS-1"
-
-        # Une seconde synchronisation met à jour la même fiche, sans doublon.
-        db.cursor.execute("UPDATE ecoles SET nom=? WHERE IDecole=1", ("École Jean-Moulin - Centre",))
-        db.connexion.commit()
-        ecole2 = service.SynchroniserEcoleHistorique(1)
-        assert ecole2["IDstructure"] == ecole["IDstructure"]
-        assert ecole2["nom"] == "École Jean-Moulin - Centre"
-        assert len(service.tiers.ListerStructures(actifs_seulement=False)) == 1
-    finally:
-        db.Close()
-
-
-def test_enregistrer_une_seance_sport_ecole_calcule_la_duree_et_restitue_le_nom():
-    db = _db_pret()
-    try:
-        service = INTERVENTIONS.GestionnaireInterventions(db)
-        ecole = service.SynchroniserEcoleHistorique(1)
-        IDseance = service.CreerSeanceSportEcole(
-            ecole["IDstructure"],
-            "04/09/2026",
-            "09:00",
-            "10:30",
-            libelle="EPS - cycle athlétisme",
-        )
-        assert IDseance
-
-        seances = service.ListerSeancesSportEcole(ecole["IDstructure"])
-        assert len(seances) == 1
-        assert seances[0]["nom_ecole"] == "École Jean-Moulin"
-        assert seances[0]["duree_minutes"] == 90
-        assert seances[0]["date"] == "2026-09-04"
-        assert seances[0]["libelle"] == "EPS - cycle athlétisme"
-    finally:
-        db.Close()
-
-
-def test_horaire_incoherent_est_refuse_avant_ecriture():
-    db = _db_pret()
-    try:
-        service = INTERVENTIONS.GestionnaireInterventions(db)
-        ecole = service.SynchroniserEcoleHistorique(1)
-        with pytest.raises(ValueError):
-            service.CreerSeanceSportEcole(ecole["IDstructure"], "04/09/2026", "10:30", "09:00")
-        assert service.ListerSeancesSportEcole(ecole["IDstructure"]) == []
-    finally:
-        db.Close()
-
-
-def test_modification_partielle_et_archivage_ne_detruisent_pas_la_seance():
-    db = _db_pret()
-    try:
-        service = INTERVENTIONS.GestionnaireInterventions(db)
-        ecole = service.SynchroniserEcoleHistorique(1)
-        IDseance = service.CreerSeanceSportEcole(
-            ecole["IDstructure"], "04/09/2026", "09:00", "10:30",
-            libelle="EPS - cycle athlétisme", notes="Cour de l'école",
-        )
-        assert service.ModifierSeanceSport(IDseance, {"heure_fin": "11:00"}) is True
-        seance = service.LireIntervention(IDseance)
-        assert seance["heure_debut"] == "09:00"
-        assert seance["heure_fin"] == "11:00"
-        assert seance["duree_minutes"] == 120
-        assert seance["libelle"] == "EPS - cycle athlétisme"
-        assert seance["notes"] == "Cour de l'école"
-
-        assert service.ArchiverSeanceSport(IDseance) is True
-        assert service.ListerSeancesSportEcole(ecole["IDstructure"]) == []
-        archivee = service.ListerSeancesSportEcole(ecole["IDstructure"], actifs_seulement=False)
-        assert len(archivee) == 1
-        assert archivee[0]["libelle"] == "EPS - cycle athlétisme"
-        assert archivee[0]["actif"] == 0
-    finally:
-        db.Close()
-
-
-def test_filtre_par_periode_ne_retourne_que_les_seances_demandees():
-    db = _db_pret()
-    try:
-        service = INTERVENTIONS.GestionnaireInterventions(db)
-        ecole = service.SynchroniserEcoleHistorique(1)
-        for date in ("2026-09-02", "2026-10-07", "2026-11-04"):
-            service.CreerSeanceSportEcole(ecole["IDstructure"], date, "14:00", "15:00")
-        seances = service.ListerSeancesSportEcole(
-            ecole["IDstructure"], date_debut="01/10/2026", date_fin="31/10/2026"
-        )
-        assert [item["date"] for item in seances] == ["2026-10-07"]
-    finally:
-        db.Close()
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_noe_062b_interventions.py
+++ b/tests/test_noe_062b_interventions.py
@@ -1,0 +1,221 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOETHYS = ROOT / "noethys"
+if str(NOETHYS) not in sys.path:
+    sys.path.insert(0, str(NOETHYS))
+
+
+def _charger_module(path, nom):
+    spec = importlib.util.spec_from_file_location(nom, str(ROOT / path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+SCHEMA = _charger_module("noethys/Utils/UTILS_Tiers_Schema.py", "UTILS_Tiers_Schema_noe062b")
+INTERVENTIONS = _charger_module("noethys/Utils/UTILS_Interventions.py", "UTILS_Interventions_noe062b")
+
+
+class SQLiteDB(object):
+    """Petit adaptateur du contrat GestionDB utilisé par le métier 062B."""
+    isNetwork = False
+
+    def __init__(self):
+        self.connexion = sqlite3.connect(":memory:")
+        self.cursor = self.connexion.cursor()
+        self.creations = []
+        self.commits = 0
+
+    def Close(self):
+        self.connexion.close()
+
+    def IsTableExists(self, nom_table):
+        self.cursor.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (nom_table,))
+        return self.cursor.fetchone() is not None
+
+    def ExecuterReq(self, req):
+        try:
+            self.cursor.execute(req)
+            return 1
+        except Exception:
+            return 0
+
+    def ResultatReq(self):
+        return self.cursor.fetchall()
+
+    def CreationTable(self, nom_table, dico):
+        champs = []
+        for nom, type_champ, info in dico[nom_table]:
+            if type_champ == "LONGBLOB":
+                type_champ = "BLOB"
+            if type_champ == "BIGINT":
+                type_champ = "INTEGER"
+            champs.append("%s %s" % (nom, type_champ))
+        self.cursor.execute("CREATE TABLE %s (%s)" % (nom_table, ", ".join(champs)))
+        self.creations.append(nom_table)
+
+    def Commit(self):
+        self.connexion.commit()
+        self.commits += 1
+
+    def ReqInsert(self, nom_table, liste_donnees, commit=True):
+        noms = [nom for nom, valeur in liste_donnees]
+        valeurs = [valeur for nom, valeur in liste_donnees]
+        marqueurs = ", ".join("?" for nom in noms)
+        self.cursor.execute(
+            "INSERT INTO %s (%s) VALUES (%s)" % (nom_table, ", ".join(noms), marqueurs),
+            tuple(valeurs),
+        )
+        if commit:
+            self.connexion.commit()
+        return self.cursor.lastrowid
+
+    def ReqMAJ(self, nom_table, liste_donnees, nom_champ_id, ID, IDestChaine=False, commit=True):
+        clauses = ["%s=?" % nom for nom, valeur in liste_donnees]
+        valeurs = [valeur for nom, valeur in liste_donnees]
+        valeurs.append(ID)
+        self.cursor.execute(
+            "UPDATE %s SET %s WHERE %s=?" % (nom_table, ", ".join(clauses), nom_champ_id),
+            tuple(valeurs),
+        )
+        if commit:
+            self.connexion.commit()
+        return True
+
+
+def _db_pret():
+    db = SQLiteDB()
+    resultat = SCHEMA.AssurerSchema062B(db, appliquer=True)
+    assert resultat["ok"] is True
+    db.cursor.execute(
+        "CREATE TABLE ecoles (IDecole INTEGER PRIMARY KEY AUTOINCREMENT, nom TEXT, rue TEXT, cp TEXT, ville TEXT, tel TEXT, mail TEXT)"
+    )
+    db.cursor.execute(
+        "INSERT INTO ecoles (nom, rue, cp, ville, tel, mail) VALUES (?, ?, ?, ?, ?, ?)",
+        ("École Jean-Moulin", "1 rue des Écoles", "35130", "La Guerche-de-Bretagne", "0200000000", "ecole@example.fr"),
+    )
+    db.connexion.commit()
+    return db
+
+
+def test_schema_062b_est_additif_et_idempotent():
+    db = SQLiteDB()
+    try:
+        resultat = SCHEMA.AssurerSchema062B(db, appliquer=True)
+        assert resultat["ok"] is True
+        assert resultat["tables_creees"] == ("structures", "structures_contacts", "interventions")
+        assert set(db.creations) == {"structures", "structures_contacts", "interventions"}
+
+        creations = list(db.creations)
+        resultat2 = SCHEMA.AssurerSchema062B(db, appliquer=True)
+        assert resultat2["ok"] is True
+        assert resultat2["tables_creees"] == ()
+        assert db.creations == creations
+    finally:
+        db.Close()
+
+
+def test_ecole_historique_devient_un_tiers_ecole_sans_perdre_sa_denomination():
+    db = _db_pret()
+    try:
+        service = INTERVENTIONS.GestionnaireInterventions(db)
+        ecole = service.SynchroniserEcoleHistorique(1)
+        assert ecole["type_structure"] == "ecole"
+        assert ecole["nom"] == "École Jean-Moulin"
+        assert ecole["uid"] == "ECOLE-NOETHYS-1"
+
+        # Une seconde synchronisation met à jour la même fiche, sans doublon.
+        db.cursor.execute("UPDATE ecoles SET nom=? WHERE IDecole=1", ("École Jean-Moulin - Centre",))
+        db.connexion.commit()
+        ecole2 = service.SynchroniserEcoleHistorique(1)
+        assert ecole2["IDstructure"] == ecole["IDstructure"]
+        assert ecole2["nom"] == "École Jean-Moulin - Centre"
+        assert len(service.tiers.ListerStructures(actifs_seulement=False)) == 1
+    finally:
+        db.Close()
+
+
+def test_enregistrer_une_seance_sport_ecole_calcule_la_duree_et_restitue_le_nom():
+    db = _db_pret()
+    try:
+        service = INTERVENTIONS.GestionnaireInterventions(db)
+        ecole = service.SynchroniserEcoleHistorique(1)
+        IDseance = service.CreerSeanceSportEcole(
+            ecole["IDstructure"],
+            "04/09/2026",
+            "09:00",
+            "10:30",
+            libelle="EPS - cycle athlétisme",
+        )
+        assert IDseance
+
+        seances = service.ListerSeancesSportEcole(ecole["IDstructure"])
+        assert len(seances) == 1
+        assert seances[0]["nom_ecole"] == "École Jean-Moulin"
+        assert seances[0]["duree_minutes"] == 90
+        assert seances[0]["date"] == "2026-09-04"
+        assert seances[0]["libelle"] == "EPS - cycle athlétisme"
+    finally:
+        db.Close()
+
+
+def test_horaire_incoherent_est_refuse_avant_ecriture():
+    db = _db_pret()
+    try:
+        service = INTERVENTIONS.GestionnaireInterventions(db)
+        ecole = service.SynchroniserEcoleHistorique(1)
+        with pytest.raises(ValueError):
+            service.CreerSeanceSportEcole(ecole["IDstructure"], "04/09/2026", "10:30", "09:00")
+        assert service.ListerSeancesSportEcole(ecole["IDstructure"]) == []
+    finally:
+        db.Close()
+
+
+def test_modification_partielle_et_archivage_ne_detruisent_pas_la_seance():
+    db = _db_pret()
+    try:
+        service = INTERVENTIONS.GestionnaireInterventions(db)
+        ecole = service.SynchroniserEcoleHistorique(1)
+        IDseance = service.CreerSeanceSportEcole(
+            ecole["IDstructure"], "04/09/2026", "09:00", "10:30",
+            libelle="EPS - cycle athlétisme", notes="Cour de l'école",
+        )
+        assert service.ModifierSeanceSport(IDseance, {"heure_fin": "11:00"}) is True
+        seance = service.LireIntervention(IDseance)
+        assert seance["heure_debut"] == "09:00"
+        assert seance["heure_fin"] == "11:00"
+        assert seance["duree_minutes"] == 120
+        assert seance["libelle"] == "EPS - cycle athlétisme"
+        assert seance["notes"] == "Cour de l'école"
+
+        assert service.ArchiverSeanceSport(IDseance) is True
+        assert service.ListerSeancesSportEcole(ecole["IDstructure"]) == []
+        archivee = service.ListerSeancesSportEcole(ecole["IDstructure"], actifs_seulement=False)
+        assert len(archivee) == 1
+        assert archivee[0]["libelle"] == "EPS - cycle athlétisme"
+        assert archivee[0]["actif"] == 0
+    finally:
+        db.Close()
+
+
+def test_filtre_par_periode_ne_retourne_que_les_seances_demandees():
+    db = _db_pret()
+    try:
+        service = INTERVENTIONS.GestionnaireInterventions(db)
+        ecole = service.SynchroniserEcoleHistorique(1)
+        for date in ("2026-09-02", "2026-10-07", "2026-11-04"):
+            service.CreerSeanceSportEcole(ecole["IDstructure"], date, "14:00", "15:00")
+        seances = service.ListerSeancesSportEcole(
+            ecole["IDstructure"], date_debut="01/10/2026", date_fin="31/10/2026"
+        )
+        assert [item["date"] for item in seances] == ["2026-10-07"]
+    finally:
+        db.Close()


### PR DESCRIPTION
## Objectif
Livrer un premier vertical métier réellement utilisable : depuis **Paramétrage > Scolarité > Écoles**, sélectionner une école et enregistrer ses séances de sport avec sa dénomination réelle.

## Fonctionnel
- nouveau bouton **Séances sport** dans la gestion des écoles ;
- reprise automatique de l'école historique dans le référentiel `structures` avec `type_structure=ecole` ;
- UID stable `ECOLE-NOETHYS-<IDecole>` : pas de doublon à chaque ouverture ;
- saisie date, heure début/fin, libellé, statut et notes ;
- durée calculée automatiquement ;
- liste des séances de l'école ;
- modification et archivage sans suppression d'historique.

## Schéma
- ajoute uniquement la table additive `interventions` au contrat de données ;
- conserve le contrat 062A inchangé pour `AssurerSchema()` ;
- nouvelle activation explicite `AssurerSchema062B()` pour `structures` + `structures_contacts` + `interventions` ;
- aucun groupe ni convention requis pour la première saisie ; ces liens restent optionnels ;
- préflight d'incohérence avant toute création.

## Tests
Couverture du schéma idempotent, synchronisation école historique → tiers école, conservation de la dénomination, calcul de durée, horaires invalides, mise à jour partielle, archivage et filtres de période.

Relates #211. Relates #60.