### PR TITLE
Audit — rendre la couverture des sources explicite et bloquante

### DIFF
--- a/scripts/audit_branch_assignment_gaps.py
+++ b/scripts/audit_branch_assignment_gaps.py
@@ -5,7 +5,7 @@
 Le contrôle est volontairement conservateur : il ne signale qu'une affectation
 présente dans une seule branche, sans définition antérieure visible, lorsque le
 premier usage ultérieur de ce nom est une lecture. Les résultats restent des
-candidats à qualifier humainement.
+candidats à qualifier humainement. La couverture des sources est bloquante.
 """
 
 from __future__ import annotations
@@ -16,6 +16,10 @@ import json
 from collections import Counter
 from pathlib import Path
 
+try:
+    from scripts.audit_source_coverage import SourceAuditSession
+except ModuleNotFoundError:
+    from audit_source_coverage import SourceAuditSession
 
 ROOT = Path(__file__).resolve().parents[1]
 NOETHYS = ROOT / "noethys"
@@ -106,11 +110,6 @@ def direct_definitions(statement):
 
 
 def direct_definitions_in_sequence(statements):
-    """Noms définis par des instructions inconditionnelles du bloc courant.
-
-    On ne descend volontairement pas dans les ``if``/boucles/``try`` imbriqués :
-    leur exécution ne garantit pas qu'un nom existe à la sortie du bloc.
-    """
     result = set()
     for statement in statements:
         result.update(direct_definitions(statement))
@@ -185,9 +184,6 @@ def scan_sequence(statements, predefined, relpath, function_name, findings):
             scan_sequence(statement.body, defined, relpath, function_name, findings)
             scan_sequence(statement.orelse, defined, relpath, function_name, findings)
 
-            # Si les deux branches affectent directement un nom, celui-ci est
-            # garanti pour les instructions suivantes. Sans cette propagation,
-            # un second ``if`` qui réaffecte ce nom était signalé à tort.
             if statement.orelse:
                 body_defined = direct_definitions_in_sequence(statement.body)
                 else_defined = direct_definitions_in_sequence(statement.orelse)
@@ -219,34 +215,32 @@ def scan_sequence(statements, predefined, relpath, function_name, findings):
             scan_sequence(statement.orelse, defined, relpath, function_name, findings)
             scan_sequence(statement.finalbody, defined, relpath, function_name, findings)
 
-            # Si chaque chemin d'exception quitte le bloc courant, continuer
-            # après le ``try`` implique que son corps (et son ``else`` éventuel)
-            # s'est terminé normalement. Leurs affectations directes sont donc
-            # disponibles pour les contrôles suivants.
             handlers_terminate = not statement.handlers or all(
                 block_terminates(handler.body) for handler in statement.handlers
             )
             if handlers_terminate:
                 defined.update(direct_definitions_in_sequence(statement.body))
                 defined.update(direct_definitions_in_sequence(statement.orelse))
-
-            # Un ``finally`` exécuté jusqu'au bout l'est sur tout chemin qui
-            # continue après le ``try``.
             defined.update(direct_definitions_in_sequence(statement.finalbody))
 
         defined.update(direct_definitions(statement))
 
 
-def scan_file(path, root=NOETHYS):
-    try:
-        tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"), filename=str(path))
-    except (OSError, SyntaxError):
-        return []
+def _scan_loaded(tree, path, root=NOETHYS):
     relpath = str(path.relative_to(root)).replace("\\", "/")
     findings = []
     for function in (node for node in ast.walk(tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))):
         scan_sequence(function.body, function_args(function), relpath, function.name, findings)
     return findings
+
+
+def scan_file(path, root=NOETHYS):
+    session = SourceAuditSession([path])
+    loaded = session.parse(path)
+    session.require_complete()
+    assert loaded is not None
+    _source, tree = loaded
+    return _scan_loaded(tree, path, root)
 
 
 def build_report(root=NOETHYS):
@@ -266,10 +260,22 @@ def build_report(root=NOETHYS):
     }
 
 
+def _coverage_session(root=NOETHYS):
+    session = SourceAuditSession(iter_python_files(root))
+    for path in session.paths:
+        session.parse(path)
+    return session
+
+
 def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--json", default="", metavar="FILE")
     args = parser.parse_args(argv)
+
+    coverage = _coverage_session()
+    coverage.report(prefix="Couverture audit affectations conditionnelles")
+    coverage.require_complete()
+
     report = build_report()
     print(f"BRANCH_ASSIGNMENT_GAPS={report['count']}")
     for item in report["findings"]:

--- a/scripts/audit_bytes_text_boundaries.py
+++ b/scripts/audit_bytes_text_boundaries.py
@@ -1,14 +1,20 @@
 #!/usr/bin/env python3
 """Repère les mélanges bytes/str susceptibles de casser Noethys sous Python 3.
 
-Audit informatif uniquement. Il cible surtout les valeurs encodées envoyées à
-wxPython, les chemins encodés et les écritures texte/binaire incohérentes.
+Audit informatif sur les occurrences, mais bloquant sur sa couverture. Il cible
+surtout les valeurs encodées envoyées à wxPython, les chemins encodés et les
+écritures texte/binaire incohérentes.
 """
 from __future__ import annotations
 
 import ast
 import sys
 from pathlib import Path
+
+try:
+    from scripts.audit_source_coverage import SourceAuditSession, iter_python_files
+except ModuleNotFoundError:
+    from audit_source_coverage import SourceAuditSession, iter_python_files
 
 ROOT = Path(sys.argv[1] if len(sys.argv) > 1 else "noethys")
 WX_TEXT_METHODS = {
@@ -79,13 +85,7 @@ def is_write_to_known_bytesio(node: ast.Call, known: set[str]) -> bool:
     )
 
 
-def scan(path: Path) -> list[tuple[int, str]]:
-    try:
-        source = path.read_text(encoding="utf-8", errors="replace")
-        tree = ast.parse(source, filename=str(path))
-    except SyntaxError:
-        return []
-
+def scan_tree(tree: ast.AST) -> list[tuple[int, str]]:
     known_bytesio = bytesio_names(tree)
     findings: set[tuple[int, str]] = set()
     for node in ast.walk(tree):
@@ -108,13 +108,30 @@ def scan(path: Path) -> list[tuple[int, str]]:
     return sorted(findings)
 
 
+def scan(path: Path) -> list[tuple[int, str]]:
+    session = SourceAuditSession([path])
+    loaded = session.parse(path)
+    if loaded is None:
+        raise RuntimeError(session.coverage.failures[0].format())
+    _source, tree = loaded
+    return scan_tree(tree)
+
+
 def main() -> int:
+    session = SourceAuditSession(iter_python_files(ROOT))
     total = 0
-    for path in sorted(ROOT.rglob("*.py")):
-        for lineno, message in scan(path):
+    for path in session.paths:
+        loaded = session.parse(path)
+        if loaded is None:
+            continue
+        _source, tree = loaded
+        for lineno, message in scan_tree(tree):
             total += 1
             print(f"{path}:{lineno}: {message}")
     print(f"\n{total} frontière(s) bytes/texte à examiner.")
+    if not session.report():
+        print("Audit incomplet : inventaire bytes/texte non exhaustif.")
+        return 2
     return 0
 
 

--- a/scripts/audit_critical_business_modules.py
+++ b/scripts/audit_critical_business_modules.py
@@ -3,12 +3,18 @@
 
 Le contrôle ne charge ni wxPython ni aucune base : il analyse l'AST et résout
 les imports locaux uniquement à partir des chemins présents dans le dépôt.
+La couverture des modules sélectionnés est bloquante.
 """
 from __future__ import annotations
 
 import ast
 import sys
 from pathlib import Path
+
+try:
+    from scripts.audit_source_coverage import SourceAuditSession
+except ModuleNotFoundError:
+    from audit_source_coverage import SourceAuditSession
 
 ROOT = Path(sys.argv[1] if len(sys.argv) > 1 else "noethys").resolve()
 KEYWORDS = (
@@ -34,9 +40,7 @@ def local_module_exists(name: str) -> bool:
     )
 
 
-def imported_modules(path: Path) -> set[str]:
-    source = path.read_text(encoding="utf-8")
-    tree = ast.parse(source, filename=str(path))
+def imported_modules_from_tree(tree: ast.AST) -> set[str]:
     result: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
@@ -44,6 +48,15 @@ def imported_modules(path: Path) -> set[str]:
         elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
             result.add(node.module)
     return result
+
+
+def imported_modules(path: Path) -> set[str]:
+    session = SourceAuditSession([path])
+    loaded = session.parse(path)
+    session.require_complete()
+    assert loaded is not None
+    _source, tree = loaded
+    return imported_modules_from_tree(tree)
 
 
 def main() -> int:
@@ -56,23 +69,27 @@ def main() -> int:
         print("Aucun module métier critique détecté.")
         return 1
 
+    session = SourceAuditSession(targets)
     failures: list[str] = []
     checked_imports = 0
-    for path in targets:
-        try:
-            imports = imported_modules(path)
-        except (OSError, SyntaxError, UnicodeDecodeError) as err:
-            failures.append(f"{path}: analyse impossible: {err}")
+    for path in session.paths:
+        loaded = session.parse(path)
+        if loaded is None:
             continue
-        for name in sorted(imports):
+        _source, tree = loaded
+        for name in sorted(imported_modules_from_tree(tree)):
             if not name.startswith(LOCAL_PREFIXES):
                 continue
             checked_imports += 1
             if not local_module_exists(name):
                 failures.append(f"{path}: import local introuvable: {name}")
 
-    print(f"{len(targets)} module(s) métier critique(s) analysé(s).")
+    print(f"{len(targets)} module(s) métier critique(s) trouvé(s).")
     print(f"{checked_imports} import(s) local(aux) vérifié(s).")
+    session.report(prefix="Couverture audit modules métier critiques")
+    if not session.coverage.complete:
+        return 2
+
     if failures:
         print("\nAnomalies détectées :")
         for failure in failures:

--- a/scripts/audit_csv_boundaries.py
+++ b/scripts/audit_csv_boundaries.py
@@ -1,10 +1,19 @@
 #!/usr/bin/env python3
-"""Audit des usages CSV potentiellement fragiles sous Python 3/Windows."""
+"""Audit des usages CSV potentiellement fragiles sous Python 3/Windows.
+
+Les occurrences restent informatives. La couverture des sources, elle, est
+bloquante : un fichier illisible ou non parsable invalide l'inventaire.
+"""
 from __future__ import annotations
 
 import ast
 import sys
 from pathlib import Path
+
+try:
+    from scripts.audit_source_coverage import SourceAuditSession, iter_python_files
+except ModuleNotFoundError:
+    from audit_source_coverage import SourceAuditSession, iter_python_files
 
 ROOT = Path(sys.argv[1] if len(sys.argv) > 1 else "noethys")
 SKIP_DIRS = {".git", ".venv", "__pycache__", "build", "dist", "venv"}
@@ -44,13 +53,7 @@ def is_csv_path(node: ast.AST | None) -> bool:
     return isinstance(value, str) and value.lower().endswith(".csv")
 
 
-def scan(path: Path) -> list[tuple[int, str]]:
-    try:
-        source = path.read_text(encoding="utf-8")
-        tree = ast.parse(source, filename=str(path))
-    except (OSError, SyntaxError, UnicodeDecodeError):
-        return []
-
+def scan_tree(tree: ast.AST) -> list[tuple[int, str]]:
     findings: list[tuple[int, str]] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
@@ -74,15 +77,30 @@ def scan(path: Path) -> list[tuple[int, str]]:
     return sorted(set(findings))
 
 
+def scan(path: Path) -> list[tuple[int, str]]:
+    session = SourceAuditSession([path])
+    loaded = session.parse(path)
+    if loaded is None:
+        raise RuntimeError(session.coverage.failures[0].format())
+    _source, tree = loaded
+    return scan_tree(tree)
+
+
 def main() -> int:
+    session = SourceAuditSession(iter_python_files(ROOT, skip_dirs=SKIP_DIRS))
     total = 0
-    for path in sorted(ROOT.rglob("*.py")):
-        if any(part in SKIP_DIRS for part in path.parts):
+    for path in session.paths:
+        loaded = session.parse(path)
+        if loaded is None:
             continue
-        for lineno, message in scan(path):
+        _source, tree = loaded
+        for lineno, message in scan_tree(tree):
             total += 1
             print(f"{path}:{lineno}: {message}")
     print(f"\n{total} frontière(s) CSV à examiner.")
+    if not session.report():
+        print("Audit incomplet : inventaire CSV non exhaustif.")
+        return 2
     return 0
 
 

--- a/scripts/audit_dependency_usage.py
+++ b/scripts/audit_dependency_usage.py
@@ -1,12 +1,9 @@
 #!/usr/bin/env python3
 """Inventorie les imports externes réellement utilisés par Noethys.
 
-Le script utilise uniquement la bibliothèque standard. Il compare les imports
-trouvés dans ``noethys/`` avec ``requirements.txt`` et signale les dépendances
-potentiellement absentes ou inutilisées. Le résultat est informatif.
-
-Les modules internes sont détectés récursivement afin de tenir compte des anciens
-imports "à plat" de Noethys (par exemple CellEditor, OLVEvent, wxSchedule...).
+Le résultat fonctionnel reste informatif. En revanche, la couverture des
+fichiers Python est bloquante : aucun fichier non lu ou non parsé ne peut être
+assimilé à une absence d'import.
 """
 from __future__ import annotations
 
@@ -16,13 +13,17 @@ import sys
 from collections import Counter, defaultdict
 from pathlib import Path
 
+try:
+    from scripts.audit_source_coverage import SourceAuditSession, iter_python_files
+except ModuleNotFoundError:
+    from audit_source_coverage import SourceAuditSession, iter_python_files
+
 ROOT = Path(__file__).resolve().parents[1]
 SOURCE = ROOT / "noethys"
 REQUIREMENTS = ROOT / "requirements.txt"
 BUILD_REQUIREMENTS = ROOT / "requirements-build.txt"
 SKIP_DIRS = {".git", "build", "dist", "__pycache__", "venv", ".venv"}
 
-# Correspondance nom PyPI -> racine de module importée.
 DIST_TO_MODULE = {
     "pillow": "PIL",
     "python-dateutil": "dateutil",
@@ -41,17 +42,7 @@ DIST_TO_MODULE = {
 }
 
 
-def iter_python_files(root: Path):
-    for path in root.rglob("*.py"):
-        if not any(part in SKIP_DIRS for part in path.parts):
-            yield path
-
-
-def imported_roots(path: Path) -> set[str]:
-    try:
-        tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"), filename=str(path))
-    except (OSError, SyntaxError):
-        return set()
+def imported_roots(tree: ast.AST) -> set[str]:
     roots: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
@@ -66,7 +57,7 @@ def requirement_modules(path: Path) -> dict[str, str]:
     modules: dict[str, str] = {}
     if not path.exists():
         return modules
-    for raw in path.read_text(encoding="utf-8", errors="replace").splitlines():
+    for raw in path.read_text(encoding="utf-8").splitlines():
         line = raw.strip()
         if not line or line.startswith("#") or line.startswith("-"):
             continue
@@ -76,10 +67,8 @@ def requirement_modules(path: Path) -> dict[str, str]:
     return modules
 
 
-def local_module_names() -> set[str]:
-    names: set[str] = set()
-    for path in iter_python_files(SOURCE):
-        names.add(path.stem)
+def local_module_names(paths: tuple[Path, ...]) -> set[str]:
+    names: set[str] = {path.stem for path in paths}
     for path in SOURCE.rglob("*"):
         if path.is_dir() and not any(part in SKIP_DIRS for part in path.parts):
             names.add(path.name)
@@ -87,16 +76,23 @@ def local_module_names() -> set[str]:
 
 
 def main() -> int:
+    paths = tuple(iter_python_files(SOURCE, skip_dirs=SKIP_DIRS))
+    session = SourceAuditSession(paths)
     counts: Counter[str] = Counter()
     locations: dict[str, set[str]] = defaultdict(set)
-    for path in iter_python_files(SOURCE):
-        roots = imported_roots(path)
+
+    for path in session.paths:
+        loaded = session.parse(path)
+        if loaded is None:
+            continue
+        _source, tree = loaded
+        roots = imported_roots(tree)
         counts.update(roots)
         relative = str(path.relative_to(ROOT))
         for name in roots:
             locations[name].add(relative)
 
-    local_modules = local_module_names()
+    local_modules = local_module_names(paths)
     stdlib = set(getattr(sys, "stdlib_module_names", ()))
 
     external = {
@@ -125,6 +121,9 @@ def main() -> int:
         print(f"- {name}: {files}")
 
     print(f"\nRésumé: {len(external)} module(s) externe(s), {len(missing)} sans déclaration évidente.")
+    if not session.report():
+        print("Audit incomplet : inventaire des dépendances non exhaustif.")
+        return 2
     return 0
 
 

--- a/scripts/audit_deprecated_runtime_apis.py
+++ b/scripts/audit_deprecated_runtime_apis.py
@@ -96,7 +96,7 @@ def scan_file(path, root=ROOT):
     return scan_tree(source, tree, path, root)
 
 
-def build_report(root=ROOT):
+def _build_report_with_session(root=ROOT):
     session = SourceAuditSession(iter_python_files(root))
     findings = []
     for path in session.paths:
@@ -106,12 +106,18 @@ def build_report(root=ROOT):
         source, tree = loaded
         findings.extend(scan_tree(source, tree, path, root))
     findings.sort(key=lambda item: (item["file"], item["line"], item["kind"]))
-    return {
+    report = {
         "count": len(findings),
         "kinds": dict(Counter(item["kind"] for item in findings)),
         "findings": findings,
-        "_coverage": session,
     }
+    return report, session
+
+
+def build_report(root=ROOT):
+    report, session = _build_report_with_session(root)
+    session.require_complete()
+    return report
 
 
 def main(argv=None):
@@ -122,8 +128,7 @@ def main(argv=None):
     parser.add_argument("--fail-on-any", action="store_true")
     args = parser.parse_args(argv)
 
-    report = build_report()
-    session = report.pop("_coverage")
+    report, session = _build_report_with_session()
     print(f"DEPRECATED_RUNTIME_API={report['count']} — {report['kinds']}")
     for item in report["findings"]:
         print(f"- {item['file']}:{item['line']} {item['api']} — {item['reason']}")

--- a/scripts/audit_deprecated_runtime_apis.py
+++ b/scripts/audit_deprecated_runtime_apis.py
@@ -5,6 +5,7 @@
 Le périmètre est volontairement limité aux motifs dont le remplacement est
 sémantiquement clair. L'objectif n'est pas de signaler toutes les dépréciations,
 mais les appels susceptibles de tomber immédiatement en AttributeError.
+La couverture des fichiers analysés est bloquante.
 """
 
 from __future__ import annotations
@@ -14,6 +15,10 @@ import json
 from collections import Counter
 from pathlib import Path
 
+try:
+    from scripts.audit_source_coverage import SourceAuditSession
+except ModuleNotFoundError:
+    from audit_source_coverage import SourceAuditSession
 
 ROOT = Path(__file__).resolve().parents[1] / "noethys"
 EXCLUDED_PARTS = {"ObjectListView", "Outils"}
@@ -48,12 +53,7 @@ def _qualified_name(node):
     return ".".join(reversed(parts))
 
 
-def scan_file(path, root=ROOT):
-    try:
-        source = path.read_text(encoding="utf-8", errors="replace")
-        tree = ast.parse(source, filename=str(path))
-    except (OSError, SyntaxError):
-        return []
+def scan_tree(source, tree, path, root=ROOT):
     lines = source.splitlines()
     rel = str(path.relative_to(root)).replace("\\", "/")
     findings = []
@@ -67,9 +67,6 @@ def scan_file(path, root=ROOT):
 
         kind, reason = ATTRIBUTE_RULES[attr]
         qualified = _qualified_name(node.func)
-        # clock/getargspec/formatargspec/base64 aliases ne sont dangereux que
-        # lorsqu'on peut identifier le module standard. Les méthodes isAlive/
-        # isSet sont suffisamment spécifiques pour être signalées partout.
         if attr == "clock" and not qualified.startswith("time."):
             continue
         if attr in {"getargspec", "formatargspec"} and not qualified.startswith("inspect."):
@@ -90,15 +87,30 @@ def scan_file(path, root=ROOT):
     return findings
 
 
+def scan_file(path, root=ROOT):
+    session = SourceAuditSession([path])
+    loaded = session.parse(path)
+    session.require_complete()
+    assert loaded is not None
+    source, tree = loaded
+    return scan_tree(source, tree, path, root)
+
+
 def build_report(root=ROOT):
+    session = SourceAuditSession(iter_python_files(root))
     findings = []
-    for path in iter_python_files(root):
-        findings.extend(scan_file(path, root))
+    for path in session.paths:
+        loaded = session.parse(path)
+        if loaded is None:
+            continue
+        source, tree = loaded
+        findings.extend(scan_tree(source, tree, path, root))
     findings.sort(key=lambda item: (item["file"], item["line"], item["kind"]))
     return {
         "count": len(findings),
         "kinds": dict(Counter(item["kind"] for item in findings)),
         "findings": findings,
+        "_coverage": session,
     }
 
 
@@ -111,9 +123,12 @@ def main(argv=None):
     args = parser.parse_args(argv)
 
     report = build_report()
+    session = report.pop("_coverage")
     print(f"DEPRECATED_RUNTIME_API={report['count']} — {report['kinds']}")
     for item in report["findings"]:
         print(f"- {item['file']}:{item['line']} {item['api']} — {item['reason']}")
+    session.report(prefix="Couverture audit API runtime dépréciées")
+    session.require_complete()
 
     if args.json:
         output = Path(args.json)

--- a/scripts/audit_dynamic_import_risks.py
+++ b/scripts/audit_dynamic_import_risks.py
@@ -8,7 +8,8 @@ téléchargé) ou encapsulés dans des helpers génériques. Ils sont signalés 
 sont pas comptés comme risques PyInstaller non couverts.
 
 Les appels exec/eval historiques sont signalés séparément : ils constituent un
-sujet de dette technique/sécurité distinct.
+sujet de dette technique/sécurité distinct. La couverture des sources est
+bloquante : aucun fichier non lu ou non parsé n'est assimilé à zéro occurrence.
 """
 from __future__ import annotations
 
@@ -16,25 +17,22 @@ import argparse
 import ast
 from pathlib import Path
 
+try:
+    from scripts.audit_source_coverage import SourceAuditSession, iter_python_files
+except ModuleNotFoundError:
+    from audit_source_coverage import SourceAuditSession, iter_python_files
+
 ROOT = Path("noethys")
 SKIP_DIRS = {".git", "build", "dist", "__pycache__", "venv", ".venv"}
 
-# Chargements volontairement externes au bundle PyInstaller.
 RUNTIME_EXTERNAL = {
     "noethys/Dlg/DLG_Extensions.py",
     "noethys/Utils/UTILS_Portail_synchro.py",
 }
-
-# Helpers génériques : ils chargent dynamiquement pour le compte d'appelants.
-# Leurs propres import_module() ne constituent pas, à eux seuls, un module
-# manquant du bundle.
 DYNAMIC_HELPERS = {
     "noethys/Outils/mail/module_loading.py",
     "noethys/Utils/UTILS_Adaptations.py",
 }
-
-# Cette famille est importée statiquement dans CTRL_Assistants_liste.py
-# précisément pour être visible de la compilation Windows.
 STATICALLY_COVERED = {
     "noethys/Ol/OL_Activites.py",
 }
@@ -60,13 +58,7 @@ def is_literal_string(node: ast.AST | None) -> bool:
     return isinstance(node, ast.Constant) and isinstance(node.value, str)
 
 
-def scan(path: Path) -> tuple[list[tuple[int, str]], list[tuple[int, str]]]:
-    try:
-        source = path.read_text(encoding="utf-8", errors="replace")
-        tree = ast.parse(source, filename=str(path))
-    except (OSError, SyntaxError):
-        return [], []
-
+def scan_tree(tree: ast.AST) -> tuple[list[tuple[int, str]], list[tuple[int, str]]]:
     import_risks: list[tuple[int, str]] = []
     eval_uses: list[tuple[int, str]] = []
     for node in ast.walk(tree):
@@ -82,6 +74,15 @@ def scan(path: Path) -> tuple[list[tuple[int, str]], list[tuple[int, str]]]:
         elif name in {"exec", "eval"}:
             eval_uses.append((node.lineno, f"exécution dynamique via {name}()"))
     return sorted(set(import_risks)), sorted(set(eval_uses))
+
+
+def scan(path: Path) -> tuple[list[tuple[int, str]], list[tuple[int, str]]]:
+    session = SourceAuditSession([path])
+    loaded = session.parse(path)
+    session.require_complete()
+    assert loaded is not None
+    _source, tree = loaded
+    return scan_tree(tree)
 
 
 def classification(path: Path) -> str:
@@ -102,13 +103,16 @@ def main() -> int:
     args = parser.parse_args()
 
     root = Path(args.root)
+    session = SourceAuditSession(iter_python_files(root, skip_dirs=SKIP_DIRS))
     import_total = 0
     qualified_total = 0
     eval_total = 0
-    for path in sorted(root.rglob("*.py")):
-        if any(part in SKIP_DIRS for part in path.parts):
+    for path in session.paths:
+        loaded = session.parse(path)
+        if loaded is None:
             continue
-        import_risks, eval_uses = scan(path)
+        _source, tree = loaded
+        import_risks, eval_uses = scan_tree(tree)
         category = classification(path)
         for lineno, message in import_risks:
             if category == "RISQUE-PYINSTALLER":
@@ -123,6 +127,8 @@ def main() -> int:
     print(f"\n{import_total} risque(s) PyInstaller non qualifié(s).")
     print(f"{qualified_total} import(s) dynamique(s) attendu(s)/qualifié(s).")
     print(f"{eval_total} usage(s) exec/eval historique(s), informatif(s).")
+    session.report(prefix="Couverture audit imports dynamiques")
+    session.require_complete()
 
     if args.max_import_risks is not None and import_total > args.max_import_risks:
         print(

--- a/scripts/audit_fragile_date_parsing.py
+++ b/scripts/audit_fragile_date_parsing.py
@@ -2,13 +2,20 @@
 """Repère les conversions de dates fragiles héritées de Python 2.
 
 Cible les conversions directes en entier de tranches fixes et les constructions
-manuelles de dates à partir de ces tranches. Audit informatif uniquement.
+manuelles de dates à partir de ces tranches. Les occurrences restent
+informatives, mais la couverture des fichiers est désormais bloquante : aucun
+fichier illisible ou non parsable ne peut être assimilé à zéro occurrence.
 """
 from __future__ import annotations
 
 import ast
 import sys
 from pathlib import Path
+
+try:
+    from scripts.audit_source_coverage import SourceAuditSession, iter_python_files
+except ModuleNotFoundError:  # exécution directe depuis scripts/
+    from audit_source_coverage import SourceAuditSession, iter_python_files
 
 ROOT = Path(sys.argv[1] if len(sys.argv) > 1 else "noethys")
 DATE_HINTS = (
@@ -62,11 +69,7 @@ def call_name(node: ast.Call) -> str:
     return ""
 
 
-def scan(path: Path) -> list[tuple[int, str]]:
-    try:
-        tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"), filename=str(path))
-    except (OSError, SyntaxError):
-        return []
+def scan_tree(tree: ast.AST) -> list[tuple[int, str]]:
     findings = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
@@ -80,13 +83,35 @@ def scan(path: Path) -> list[tuple[int, str]]:
     return sorted(set(findings))
 
 
+def scan(path: Path) -> list[tuple[int, str]]:
+    """Analyse un fichier isolé et échoue explicitement si sa couverture est incomplète."""
+    session = SourceAuditSession([path])
+    loaded = session.parse(path)
+    if loaded is None:
+        failure = session.coverage.failures[0]
+        raise RuntimeError(failure.format())
+    _source, tree = loaded
+    return scan_tree(tree)
+
+
 def main() -> int:
+    paths = tuple(iter_python_files(ROOT))
+    session = SourceAuditSession(paths)
     total = 0
-    for path in sorted(ROOT.rglob("*.py")):
-        for lineno, message in scan(path):
+
+    for path in session.paths:
+        loaded = session.parse(path)
+        if loaded is None:
+            continue
+        _source, tree = loaded
+        for lineno, message in scan_tree(tree):
             total += 1
             print(f"{path}:{lineno}: {message}")
+
     print(f"\n{total} occurrence(s) de parsing de date fragile détectée(s).")
+    if not session.report():
+        print("Audit incomplet : le nombre d'occurrences ci-dessus ne peut pas être considéré comme exhaustif.")
+        return 2
     return 0
 
 

--- a/scripts/audit_legacy_list_tools.py
+++ b/scripts/audit_legacy_list_tools.py
@@ -2,9 +2,9 @@
 # -*- coding: utf-8 -*-
 """Inventorie les raccords encore dépendants des outils de listes historiques.
 
-L'objectif n'est pas de faire échouer la CI : ce script fournit une dette
-mesurable pour terminer la migration Repens écran par écran sans chercher des
-usages à la main.
+L'objectif n'est pas de faire échouer la CI sur les occurrences : ce script
+fournit une dette mesurable pour terminer la migration Repens écran par écran.
+En revanche, sa couverture des sources est bloquante.
 """
 
 from __future__ import annotations
@@ -14,6 +14,10 @@ import json
 import re
 from pathlib import Path
 
+try:
+    from scripts.audit_source_coverage import SourceAuditSession, iter_python_files
+except ModuleNotFoundError:
+    from audit_source_coverage import SourceAuditSession, iter_python_files
 
 PATTERNS = {
     "ctrl_outils_historique": re.compile(r"\bCTRL_ObjectListView\.CTRL_Outils\b"),
@@ -35,12 +39,7 @@ CODES_ECRAN = {
 }
 
 
-def scan_file(path: Path) -> list[dict[str, object]]:
-    try:
-        text = path.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return []
-
+def scan_text(path: Path, text: str) -> list[dict[str, object]]:
     findings = []
     for lineno, line in enumerate(text.splitlines(), start=1):
         for code, pattern in PATTERNS.items():
@@ -54,6 +53,15 @@ def scan_file(path: Path) -> list[dict[str, object]]:
     return findings
 
 
+def scan_file(path: Path) -> list[dict[str, object]]:
+    session = SourceAuditSession([path])
+    loaded = session.parse(path)
+    session.require_complete()
+    assert loaded is not None
+    text, _tree = loaded
+    return scan_text(path, text)
+
+
 def _est_source_historique(path: Path, root: Path) -> bool:
     try:
         relatif = path.relative_to(root).as_posix()
@@ -62,18 +70,24 @@ def _est_source_historique(path: Path, root: Path) -> bool:
     return relatif == SOURCE_HISTORIQUE or relatif.endswith("/" + SOURCE_HISTORIQUE)
 
 
-def scan(root: Path) -> list[dict[str, object]]:
+def _scan_with_session(root: Path):
+    session = SourceAuditSession(iter_python_files(root, skip_dirs=SKIP_DIRS))
     findings = []
-    for path in sorted(root.rglob("*.py")):
-        if any(part in SKIP_DIRS for part in path.parts):
+    for path in session.paths:
+        loaded = session.parse(path)
+        if loaded is None:
             continue
-        items = scan_file(path)
+        text, _tree = loaded
+        items = scan_text(path, text)
         if _est_source_historique(path, root):
-            # La définition historique n'est pas un écran restant à migrer.
-            # On ne conserve ici que ses anciens assets afin de matérialiser le
-            # dernier raccord central encore à retirer une fois les appels partis.
             items = [item for item in items if item["code"] == "assets_filtre_16px"]
         findings.extend(items)
+    return findings, session
+
+
+def scan(root: Path) -> list[dict[str, object]]:
+    findings, session = _scan_with_session(root)
+    session.require_complete()
     return findings
 
 
@@ -85,7 +99,6 @@ def summarize(findings: list[dict[str, object]]) -> dict[str, int]:
 
 
 def screens(findings: list[dict[str, object]]) -> list[str]:
-    """Retourne les écrans encore raccordés aux anciens outils, sans doublons."""
     return sorted({
         str(item["path"])
         for item in findings
@@ -100,19 +113,19 @@ def main() -> int:
     args = parser.parse_args()
 
     root = Path(args.root)
-    findings = scan(root)
+    findings, session = _scan_with_session(root)
     counts = summarize(findings)
     legacy_screens = screens(findings)
 
     for item in findings:
-        print(
-            "{code} {path}:{line}: {text}".format(**item)
-        )
+        print("{code} {path}:{line}: {text}".format(**item))
 
     print("\nDette outils de listes :")
     for code in PATTERNS:
         print(f"- {code}: {counts[code]}")
     print(f"- ecrans_metier_restants: {len(legacy_screens)}")
+    session.report(prefix="Couverture audit outils de listes historiques")
+    session.require_complete()
 
     if args.json_path:
         output = Path(args.json_path)

--- a/scripts/audit_pre_rc.py
+++ b/scripts/audit_pre_rc.py
@@ -6,9 +6,9 @@ Ce script ne modifie ni le code ni les bases. Il regroupe en une commande les
 inventaires SQL strict, cycle de vie wxPython et anciens outils de listes afin
 d'éviter trois procédures parallèles et des chiffres recopiés à la main.
 
-Les résultats restent des diagnostics : une occurrence n'est pas un bug par
-elle-même. Les catégories wxPython structurelles à risque sont simplement
-signalées explicitement dans le résumé pour faciliter la revue pré-RC.
+Avant tout inventaire, il impose le contrat global de couverture des sources :
+tout ``noethys/**/*.py`` doit être trouvé, lu selon son encodage Python et
+parsable. Les occurrences restent ensuite des diagnostics à qualifier.
 """
 
 from __future__ import annotations
@@ -24,6 +24,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from scripts import audit_legacy_list_tools  # noqa: E402
+from scripts import audit_source_coverage  # noqa: E402
 from scripts import audit_sql_strict  # noqa: E402
 from scripts import audit_wx_lifecycle  # noqa: E402
 
@@ -44,7 +45,6 @@ def _relative(path: Path, root: Path) -> str:
 
 
 def _display_path(path: Path) -> str:
-    """Privilégie un chemin relatif au dépôt dans les rapports partageables."""
     return _relative(path, ROOT)
 
 
@@ -77,8 +77,20 @@ def _write_json(path: Path, payload) -> None:
     )
 
 
+def _require_source_coverage(root: Path):
+    session = audit_source_coverage.SourceAuditSession(
+        audit_source_coverage.iter_python_files(root)
+    )
+    for path in session.paths:
+        session.parse(path)
+    session.report(prefix="Couverture globale des sources pré-RC")
+    session.require_complete()
+    return session.coverage
+
+
 def collect(root: Path = DEFAULT_ROOT) -> dict:
     root = root.resolve()
+    coverage = _require_source_coverage(root)
 
     sql_candidates = audit_sql_strict.scan(root)
     sql_counts = Counter(item.classification for item in sql_candidates)
@@ -103,6 +115,12 @@ def collect(root: Path = DEFAULT_ROOT) -> dict:
 
     return {
         "summary": {
+            "source_coverage": {
+                "found": coverage.found,
+                "read": coverage.read,
+                "parsed": coverage.parsed,
+                "complete": coverage.complete,
+            },
             "sql": {
                 "total": len(sql_candidates),
                 "REVIEW": sql_counts.get("REVIEW", 0),
@@ -155,12 +173,18 @@ def write_reports(data: dict, output_dir: Path) -> None:
 
 def print_summary(data: dict, output_dir: Path) -> None:
     summary = data["summary"]
+    coverage = summary["source_coverage"]
     sql = summary["sql"]
     wx = summary["wx_lifecycle"]
     legacy = summary["legacy_list_tools"]
 
     print("Inventaires statiques pré-RC")
     print("===========================")
+    print(
+        "Sources     : {found} trouvés = {read} lus = {parsed} parsés".format(
+            **coverage
+        )
+    )
     print(
         "SQL strict : {total} candidats — REVIEW={REVIEW}, DEDUPE={DEDUPE}, SAFE={SAFE}".format(
             **sql

--- a/scripts/audit_runtime_hardening.py
+++ b/scripts/audit_runtime_hardening.py
@@ -3,11 +3,10 @@
 """Classe les alertes de ``audit_runtime_patterns`` pour une passe de hardening.
 
 L'audit historique privilégie le rappel : il signale volontairement des motifs
-qui peuvent être sûrs (agrégat SQL garanti sur une ligne, garde placée sur la
-même ligne, accès entouré d'un handler, sélection provenant du même dialogue,
-lookup d'une entité par sa clé, etc.). Ce module ne masque pas ces occurrences :
-il les classe afin que la passe anti-bugs consacre la revue humaine aux chemins
-réellement ambigus.
+qui peuvent être sûrs. Ce module ne masque pas ces occurrences : il les classe
+afin que la passe anti-bugs consacre la revue humaine aux chemins réellement
+ambigus. Les lectures complémentaires réutilisent le contrat de couverture des
+sources et ne tolèrent aucun décodage/parsing silencieusement dégradé.
 """
 
 from __future__ import annotations
@@ -16,34 +15,36 @@ import ast
 import json
 import re
 from collections import Counter
+from functools import lru_cache
 from pathlib import Path
 
 from scripts import audit_runtime_patterns as base
-
+from scripts.audit_source_coverage import SourceAuditSession
 
 ROOT = base.NOETHYS_ROOT
 
 
-def _source_lines(relpath: str) -> list[str]:
+@lru_cache(maxsize=None)
+def _loaded_source(relpath: str):
     path = ROOT / relpath
-    try:
-        return path.read_text(encoding="utf-8", errors="replace").splitlines()
-    except OSError:
-        return []
+    session = SourceAuditSession([path])
+    loaded = session.parse(path)
+    session.require_complete()
+    assert loaded is not None
+    return loaded
+
+
+def _source_lines(relpath: str) -> list[str]:
+    source, _tree = _loaded_source(relpath)
+    return source.splitlines()
 
 
 def _source_tree(relpath: str):
-    lines = _source_lines(relpath)
-    if not lines:
-        return None
-    try:
-        return ast.parse("\n".join(lines), filename=relpath)
-    except SyntaxError:
-        return None
+    _source, tree = _loaded_source(relpath)
+    return tree
 
 
 def _sql_window(lines: list[str], line_1based: int, lookback: int = 35) -> str:
-    """Retourne le contexte SQL proche sans prétendre reconstruire le flot."""
     start = max(0, line_1based - lookback - 1)
     end = min(len(lines), line_1based)
     return "\n".join(lines[start:end]).upper()
@@ -56,7 +57,6 @@ def _last_select_window(lines: list[str], line_1based: int) -> str:
 
 
 def _single_row_aggregate(lines: list[str], line_1based: int) -> bool:
-    """Agrégat SQL sans GROUP BY : SQL renvoie une ligne même sur ensemble vide."""
     query = _last_select_window(lines, line_1based)
     if not query or "GROUP BY" in query:
         return False
@@ -64,12 +64,6 @@ def _single_row_aggregate(lines: list[str], line_1based: int) -> bool:
 
 
 def _primary_key_lookup(lines: list[str], line_1based: int) -> bool:
-    """Lookup d'une entité unique par identifiant fourni par le contexte métier.
-
-    On ne le déclare pas « garanti par SQL » : l'intégrité de l'ID reste une
-    précondition métier. Il est simplement séparé des indexations réellement
-    ambiguës afin de ne pas confondre invariant d'entité et bug démontré.
-    """
     query = _last_select_window(lines, line_1based)
     if not query or "GROUP BY" in query:
         return False
@@ -97,8 +91,6 @@ def _line_inside(node, line: int) -> bool:
 
 def _inside_handled_try(relpath: str, line: int) -> bool:
     tree = _source_tree(relpath)
-    if tree is None:
-        return False
     for node in ast.walk(tree):
         if not isinstance(node, ast.Try) or not node.handlers:
             continue
@@ -110,8 +102,6 @@ def _inside_handled_try(relpath: str, line: int) -> bool:
 
 def _inside_main_guard(relpath: str, line: int) -> bool:
     tree = _source_tree(relpath)
-    if tree is None:
-        return False
     for node in ast.walk(tree):
         if not isinstance(node, ast.If) or not _line_inside(node, line):
             continue
@@ -207,15 +197,7 @@ def classify_result_assign(item: dict) -> dict:
 
 
 def _bare_except_shapes(relpath: str) -> dict[int, str]:
-    lines = _source_lines(relpath)
-    if not lines:
-        return {}
-    source = "\n".join(lines)
-    try:
-        tree = ast.parse(source)
-    except SyntaxError:
-        return {}
-
+    _source, tree = _loaded_source(relpath)
     shapes: dict[int, str] = {}
     for node in ast.walk(tree):
         if not isinstance(node, ast.ExceptHandler) or node.type is not None:
@@ -294,6 +276,11 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--json", default="", metavar="FILE")
     args = parser.parse_args()
+
+    # Le socle runtime affiche ici la preuve agrégée trouvés=lus=parsés.
+    raw_coverage = base._coverage_session(ROOT)
+    raw_coverage.report(prefix="Couverture classement runtime")
+    raw_coverage.require_complete()
 
     report = build_report()
     for kind, data in report["summary"].items():

--- a/scripts/audit_runtime_patterns.py
+++ b/scripts/audit_runtime_patterns.py
@@ -14,52 +14,35 @@ Motifs audités
 4.  BARE_EXCEPT        : clause ``except:`` sans type d'exception.
 5.  PY2_BUILTINS       : appels directs à unicode(), basestring(), raw_input() sans garde six.
 6.  UNSAFE_EXEC        : eval() ou exec() (hors commentaires).
-7.  INVALID_ESCAPE     : séquences d'échappement invalides (\\c, \\i, \\., \\ ...).
+7.  INVALID_ESCAPE     : séquences d'échappement invalides.
 8.  ENCODING_MBCS      : fichiers déclarés # -*- coding: mbcs -*- (Windows-only).
 
 Répertoires tiers exclus
 ------------------------
-- ObjectListView/   (Philip Piper, tiers)
-- Outils/           (wxScheduler, ultimatelistctrl, COM typelibs — tiers)
+- ObjectListView/
+- Outils/
 
-Usage
------
-    python scripts/audit_runtime_patterns.py [--fail-on MOTIF[,MOTIF...]] [--json FILE]
-
-    --fail-on  : exit(1) si l'un des motifs listés présente des occurrences.
-                 Valeurs acceptées : RESULT_UNGUARDED, RESULT_ASSIGN, DB_UNCLOSED,
-                                     BARE_EXCEPT, PY2_BUILTINS, UNSAFE_EXEC,
-                                     INVALID_ESCAPE, ENCODING_MBCS
-    --json     : exporte le rapport complet dans un fichier JSON.
-
-Seuils CI configurés
---------------------
-- PY2_BUILTINS  : fail si > 0 (aucun appel Python 2 non-gardé toléré)
-- DB_UNCLOSED   : informatif (seuil à abaisser au fil des corrections)
+La couverture du périmètre retenu est bloquante : aucun fichier illisible ou
+non parsable n'est transformé en zéro occurrence.
 """
 
 import json
 import os
 import re
 import sys
+from functools import lru_cache
 from pathlib import Path
 
-# ---------------------------------------------------------------------------
-# Configuration
-# ---------------------------------------------------------------------------
+try:
+    from scripts.audit_source_coverage import SourceAuditSession
+except ModuleNotFoundError:
+    from audit_source_coverage import SourceAuditSession
 
 NOETHYS_ROOT = Path(__file__).parent.parent / "noethys"
-
-# Répertoires tiers — exclus de l'audit
 THIRD_PARTY_DIRS = {"ObjectListView", "Outils"}
-
-# Motifs qui déclenchent exit(1) si des occurrences sont trouvées.
 FAIL_CONDITIONS = {
-    "PY2_BUILTINS": 0,  # Zéro tolérance pour les appels Python 2 non-gardés
+    "PY2_BUILTINS": 0,
 }
-
-# Séquences d'échappement invalides en Python 3.12+
-# (exclut les valides: \n \r \t \b \f \v \a \u \U \x \0-\9 \' \" \\)
 _VALID_ESCAPES = set("nrtbfvauU0123456789x'\"\\")
 _INVALID_ESCAPE_RE = re.compile(
     r'"[^"\\]*(?:\\(?![nrtbfvauU0123456789x\'\"\\])[^"\\]*)*"'
@@ -67,12 +50,7 @@ _INVALID_ESCAPE_RE = re.compile(
 )
 
 
-# ---------------------------------------------------------------------------
-# Collecte des fichiers
-# ---------------------------------------------------------------------------
-
 def iter_python_files(root: Path):
-    """Yield all .py files under root (skip __pycache__ and third-party dirs)."""
     for dirpath, dirs, files in os.walk(root):
         dirs[:] = [
             d for d in dirs
@@ -84,40 +62,33 @@ def iter_python_files(root: Path):
                 yield Path(dirpath) / fname
 
 
-# ---------------------------------------------------------------------------
-# Motif 8 : encodage mbcs
-# ---------------------------------------------------------------------------
+@lru_cache(maxsize=None)
+def _source_text(path: Path) -> str:
+    session = SourceAuditSession([path])
+    loaded = session.parse(path)
+    session.require_complete()
+    assert loaded is not None
+    source, _tree = loaded
+    return source
+
 
 def check_encoding_mbcs(path: Path, root: Path) -> list:
     issues = []
-    try:
-        first_line = path.read_bytes().split(b"\n")[0].decode("ascii", errors="replace")
-        if "coding: mbcs" in first_line or "coding:mbcs" in first_line:
-            issues.append({
-                "file": str(path.relative_to(root)),
-                "line": 1,
-                "snippet": first_line.strip(),
-            })
-    except Exception:
-        pass
+    first_line = path.read_bytes().split(b"\n")[0].decode("ascii", errors="strict")
+    if "coding: mbcs" in first_line or "coding:mbcs" in first_line:
+        issues.append({
+            "file": str(path.relative_to(root)),
+            "line": 1,
+            "snippet": first_line.strip(),
+        })
     return issues
 
 
-# ---------------------------------------------------------------------------
-# Analyses textuelles ligne par ligne
-# ---------------------------------------------------------------------------
-
 def _is_in_py2_only_block(lines: list, lineno_0indexed: int) -> bool:
-    """
-    Heuristic: return True if a line appears inside a ``if six.PY2:`` block
-    or in the ``else:`` branch of a ``if six.PY3:`` block.
-    Looks back up to 15 lines for the conditional.
-    """
     for j in range(lineno_0indexed - 1, max(-1, lineno_0indexed - 15), -1):
         s = lines[j].strip()
         if re.match(r"if\s+six\.PY2\s*:", s):
             return True
-        # else: after if six.PY3: — scan back further to find the conditional
         if s == "else:":
             for k in range(j - 1, max(-1, j - 10), -1):
                 prev = lines[k].strip()
@@ -127,7 +98,6 @@ def _is_in_py2_only_block(lines: list, lineno_0indexed: int) -> bool:
 
 
 def _has_six_xrange_compat(lines: list) -> bool:
-    """Détecte une importation explicite de xrange fournie par six.moves."""
     for raw in lines:
         if re.search(
             r"^\s*from\s+six\.moves\s+import\s+.*(?:\brange\s+as\s+xrange\b|\bxrange\b)",
@@ -138,7 +108,6 @@ def _has_six_xrange_compat(lines: list) -> bool:
 
 
 def check_text_patterns(path: Path, root: Path) -> dict:
-    """Returns dict of pattern_name -> list of {file, line, snippet}."""
     results = {
         "RESULT_UNGUARDED": [],
         "BARE_EXCEPT": [],
@@ -147,35 +116,25 @@ def check_text_patterns(path: Path, root: Path) -> dict:
         "INVALID_ESCAPE": [],
     }
 
-    try:
-        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
-    except Exception:
-        return results
-
+    lines = _source_text(path).splitlines()
     rel = str(path.relative_to(root))
     xrange_from_six = _has_six_xrange_compat(lines)
 
     for i, raw in enumerate(lines):
         stripped = raw.strip()
-
-        # Skip pure comment lines
         if stripped.startswith("#"):
             continue
 
-        # 1. RESULT_UNGUARDED: ResultatReq()[N] direct (not preceded by len check)
         if re.search(r"ResultatReq\s*\(\s*\)\s*\[", raw):
             results["RESULT_UNGUARDED"].append(
                 {"file": rel, "line": i + 1, "snippet": stripped[:120]}
             )
 
-        # 4. BARE_EXCEPT
         if re.match(r"\s*except\s*:", raw):
             results["BARE_EXCEPT"].append(
                 {"file": rel, "line": i + 1, "snippet": stripped[:120]}
             )
 
-        # 5a. unicode() call — only flag actual function calls, not strings/docstrings
-        #     and only if not in a six.PY2-only guarded block
         if re.search(r"\bunicode\s*\(", raw) and '"unicode"' not in raw and "'unicode'" not in raw:
             if not _is_in_py2_only_block(lines, i):
                 results["PY2_BUILTINS"].append(
@@ -183,7 +142,6 @@ def check_text_patterns(path: Path, root: Path) -> dict:
                      "builtin": "unicode", "snippet": stripped[:120]}
                 )
 
-        # 5b. basestring — in isinstance/type context (not in strings)
         if re.search(r"\bbasestring\b", raw) and '"basestring"' not in raw and "'basestring'" not in raw:
             if not _is_in_py2_only_block(lines, i):
                 results["PY2_BUILTINS"].append(
@@ -191,7 +149,6 @@ def check_text_patterns(path: Path, root: Path) -> dict:
                      "builtin": "basestring", "snippet": stripped[:120]}
                 )
 
-        # 5c. raw_input() — standalone call, et seulement hors branche Python 2.
         if re.search(r"(?<!\.)raw_input\s*\(", raw):
             if not _is_in_py2_only_block(lines, i):
                 results["PY2_BUILTINS"].append(
@@ -199,7 +156,6 @@ def check_text_patterns(path: Path, root: Path) -> dict:
                      "builtin": "raw_input", "snippet": stripped[:120]}
                 )
 
-        # 5d. xrange() — six.moves fournit une compatibilité Python 3 légitime.
         if re.search(r"\bxrange\s*\(", raw):
             if not xrange_from_six and not _is_in_py2_only_block(lines, i):
                 results["PY2_BUILTINS"].append(
@@ -207,14 +163,12 @@ def check_text_patterns(path: Path, root: Path) -> dict:
                      "builtin": "xrange", "snippet": stripped[:120]}
                 )
 
-        # 6. UNSAFE_EXEC
         code_only = raw.split("#", 1)[0]
         if re.search(r"\beval\s*\(|\bexec\s*\(", code_only):
             results["UNSAFE_EXEC"].append(
                 {"file": rel, "line": i + 1, "snippet": stripped[:120]}
             )
 
-        # 7. INVALID_ESCAPE — simple heuristic on lines containing strings
         if ("'" in raw or '"' in raw):
             for m in re.finditer(r'(?<!r)(?<!b)"([^"\\]|\\.)*"'
                                  r"|(?<!r)(?<!b)'([^'\\]|\\.)*'", raw):
@@ -230,18 +184,9 @@ def check_text_patterns(path: Path, root: Path) -> dict:
     return results
 
 
-# ---------------------------------------------------------------------------
-# Motif 2 : ResultatReq assign + unguarded access
-# ---------------------------------------------------------------------------
-
 def check_result_assign(path: Path, root: Path) -> list:
-    """Detect: var = ResultatReq() followed by var[N] without length guard."""
     issues = []
-    try:
-        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
-    except Exception:
-        return issues
-
+    lines = _source_text(path).splitlines()
     rel = str(path.relative_to(root))
 
     for i, line in enumerate(lines):
@@ -268,22 +213,9 @@ def check_result_assign(path: Path, root: Path) -> list:
     return issues
 
 
-# ---------------------------------------------------------------------------
-# Motif 3 : connexions DB non fermées
-# ---------------------------------------------------------------------------
-
 def check_db_unclosed(path: Path, root: Path) -> list:
-    """
-    Detect functions/methods that open GestionDB.DB() without calling DB.Close().
-    Excludes functions that receive DB as parameter (caller owns the connection).
-    """
     issues = []
-    try:
-        content = path.read_text(encoding="utf-8", errors="replace")
-        lines = content.splitlines()
-    except Exception:
-        return issues
-
+    lines = _source_text(path).splitlines()
     rel = str(path.relative_to(root))
 
     for i, line in enumerate(lines):
@@ -291,11 +223,9 @@ def check_db_unclosed(path: Path, root: Path) -> list:
         if not m:
             continue
         indent, funcname, params = m.group(1), m.group(2), m.group(3)
-        # Skip: DB received as argument (caller is responsible for Close)
         if re.search(r"\bDB\b", params):
             continue
 
-        # Collect function body until next same-level def/class
         body_lines = []
         for j in range(i + 1, len(lines)):
             bline = lines[j]
@@ -322,11 +252,20 @@ def check_db_unclosed(path: Path, root: Path) -> list:
     return issues
 
 
-# ---------------------------------------------------------------------------
-# Runner principal
-# ---------------------------------------------------------------------------
+def _coverage_session(root: Path):
+    paths = tuple(sorted(iter_python_files(root)))
+    session = SourceAuditSession(paths)
+    for path in session.paths:
+        session.parse(path)
+    return session
 
-def run_audit(root: Path = NOETHYS_ROOT) -> dict:
+
+def run_audit(root: Path = NOETHYS_ROOT, *, report_coverage: bool = False) -> dict:
+    coverage = _coverage_session(root)
+    if report_coverage:
+        coverage.report(prefix="Couverture audit motifs runtime")
+    coverage.require_complete()
+
     report = {
         "RESULT_UNGUARDED": [],
         "RESULT_ASSIGN": [],
@@ -338,7 +277,7 @@ def run_audit(root: Path = NOETHYS_ROOT) -> dict:
         "ENCODING_MBCS": [],
     }
 
-    for pyfile in sorted(iter_python_files(root)):
+    for pyfile in coverage.paths:
         report["ENCODING_MBCS"].extend(check_encoding_mbcs(pyfile, root))
         text = check_text_patterns(pyfile, root)
         for key in ("RESULT_UNGUARDED", "BARE_EXCEPT", "PY2_BUILTINS",
@@ -390,7 +329,7 @@ def main():
     if args.fail_on:
         FAIL_CONDITIONS = {k.strip(): 0 for k in args.fail_on.split(",")}
 
-    report = run_audit()
+    report = run_audit(report_coverage=True)
     print_report(report)
 
     if args.json:

--- a/scripts/audit_semantic_traps.py
+++ b/scripts/audit_semantic_traps.py
@@ -6,6 +6,7 @@ L'audit privilégie le rappel : chaque signal reste à qualifier humainement ava
 correction ou attribution à l'upstream. Les catégories visent des défauts qui
 échappent facilement à une recherche textuelle simple : état partagé par défaut,
 asymétrie validation/sauvegarde, cycle de vie modal et blocage de la boucle wx.
+La couverture des sources analysées est bloquante.
 """
 
 from __future__ import annotations
@@ -16,6 +17,10 @@ import json
 from collections import Counter
 from pathlib import Path
 
+try:
+    from scripts.audit_source_coverage import SourceAuditSession
+except ModuleNotFoundError:
+    from audit_source_coverage import SourceAuditSession
 
 ROOT = Path(__file__).resolve().parents[1]
 NOETHYS = ROOT / "noethys"
@@ -54,7 +59,6 @@ def _name_is_mutated(function, name):
             if isinstance(node.func.value, ast.Name) and node.func.value.id == name and node.func.attr in MUTATING_METHODS:
                 return True, node.lineno, node.func.attr
         if isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign, ast.Delete)):
-            targets = []
             if isinstance(node, ast.Assign):
                 targets = node.targets
             elif isinstance(node, ast.AnnAssign):
@@ -132,13 +136,7 @@ def _qualified_name(node):
     return ".".join(reversed(parts))
 
 
-def scan_file(path, root=NOETHYS):
-    try:
-        source = path.read_text(encoding="utf-8", errors="replace")
-        tree = ast.parse(source, filename=str(path))
-    except (OSError, SyntaxError):
-        return []
-
+def _scan_loaded(source, tree, path, root=NOETHYS):
     rel = str(path.relative_to(root)).replace("\\", "/")
     findings = []
 
@@ -215,6 +213,15 @@ def scan_file(path, root=NOETHYS):
     return findings
 
 
+def scan_file(path, root=NOETHYS):
+    session = SourceAuditSession([path])
+    loaded = session.parse(path)
+    session.require_complete()
+    assert loaded is not None
+    source, tree = loaded
+    return _scan_loaded(source, tree, path, root)
+
+
 def build_report(root=NOETHYS):
     findings = []
     for path in iter_python_files(root):
@@ -228,10 +235,22 @@ def build_report(root=NOETHYS):
     }
 
 
+def _coverage_session(root=NOETHYS):
+    session = SourceAuditSession(iter_python_files(root))
+    for path in session.paths:
+        session.parse(path)
+    return session
+
+
 def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--json", default="", metavar="FILE")
     args = parser.parse_args(argv)
+
+    coverage = _coverage_session()
+    coverage.report(prefix="Couverture audit pièges sémantiques")
+    coverage.require_complete()
+
     report = build_report()
     print(f"SEMANTIC_TRAPS={report['count']} — {report['kinds']} — {report['priorities']}")
     for item in report["findings"]:

--- a/scripts/audit_silent_exception_handlers.py
+++ b/scripts/audit_silent_exception_handlers.py
@@ -5,6 +5,7 @@
 Le remplacement des anciens ``except:`` nus empêche désormais d'avaler les
 BaseException. Cet audit cherche ensuite les erreurs encore réellement
 masquées, sans classer comme critique chaque simple affectation ou repli UI.
+La couverture des sources est bloquante.
 """
 
 from __future__ import annotations
@@ -16,6 +17,10 @@ import re
 from collections import Counter
 from pathlib import Path
 
+try:
+    from scripts.audit_source_coverage import SourceAuditSession
+except ModuleNotFoundError:
+    from audit_source_coverage import SourceAuditSession
 
 ROOT = Path(__file__).resolve().parents[1]
 NOETHYS = ROOT / "noethys"
@@ -94,11 +99,6 @@ def _contains_business_mutation(body):
 
 
 def _contains_filesystem_mutation(body):
-    """Ne classe HIGH que les appels de fichiers explicitement qualifiés.
-
-    Un simple ``texte.replace(...)`` ou ``label.replace(...)`` ne doit jamais
-    être pris pour ``os.replace(...)``.
-    """
     return any(name in FILESYSTEM_MUTATION_CALLS for name in _called_qualified_names(body))
 
 
@@ -128,12 +128,7 @@ def _snippet(lines, start, end):
     return "\n".join(f"{i:05d}: {lines[i - 1]}" for i in range(start, end + 1))
 
 
-def scan_file(path, root=NOETHYS):
-    try:
-        source = path.read_text(encoding="utf-8", errors="replace")
-        tree = ast.parse(source, filename=str(path))
-    except (OSError, SyntaxError):
-        return []
+def _scan_loaded(source, tree, path, root=NOETHYS):
     lines = source.splitlines()
     relpath = str(path.relative_to(root)).replace("\\", "/")
     findings = []
@@ -178,6 +173,15 @@ def scan_file(path, root=NOETHYS):
     return findings
 
 
+def scan_file(path, root=NOETHYS):
+    session = SourceAuditSession([path])
+    loaded = session.parse(path)
+    session.require_complete()
+    assert loaded is not None
+    source, tree = loaded
+    return _scan_loaded(source, tree, path, root)
+
+
 def scan(root=NOETHYS):
     findings = []
     for path in iter_python_files(root):
@@ -196,11 +200,22 @@ def build_report(root=NOETHYS):
     }
 
 
+def _coverage_session(root=NOETHYS):
+    session = SourceAuditSession(iter_python_files(root))
+    for path in session.paths:
+        session.parse(path)
+    return session
+
+
 def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--json", default="", metavar="FILE")
     parser.add_argument("--fail-on-high", action="store_true")
     args = parser.parse_args(argv)
+
+    coverage = _coverage_session()
+    coverage.report(prefix="Couverture audit handlers silencieux")
+    coverage.require_complete()
 
     report = build_report()
     print(f"SILENT_EXCEPTION={report['count']} — {report['classifications']}")

--- a/scripts/audit_source_coverage.py
+++ b/scripts/audit_source_coverage.py
@@ -7,6 +7,9 @@ périmètre n'a pas été lu et parsé. Ce module fournit :
 
 - une lecture respectant l'encodage Python déclaré (PEP 263 / BOM) via
   :func:`tokenize.open` ;
+- un traitement portable et traçable du vieux cookie ``mbcs`` lorsque le
+  contenu est strictement ASCII, donc identique sous toutes les pages de codes
+  ANSI Windows ;
 - un comptage explicite ``trouvés == lus == parsés`` ;
 - la conservation de chaque erreur de lecture ou de syntaxe ;
 - un code de sortie non nul dès qu'un fichier échappe à l'analyse.
@@ -18,12 +21,14 @@ from __future__ import annotations
 
 import argparse
 import ast
+import re
 import tokenize
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable
 
 SKIP_DIRS = {".git", ".venv", "venv", "__pycache__", "build", "dist"}
+_ENCODING_COOKIE = re.compile(br"^[ \t\f]*#.*?coding[:=][ \t]*([-\w.]+)")
 
 
 @dataclass(frozen=True)
@@ -37,19 +42,31 @@ class SourceFailure:
         return f"{self.path}: {self.stage}: {self.error_type}: {self.message}"
 
 
+@dataclass(frozen=True)
+class SourceDecodeNote:
+    path: Path
+    declared_encoding: str
+    effective_encoding: str
+    message: str
+
+    def format(self) -> str:
+        return (
+            f"{self.path}: encodage {self.declared_encoding} -> "
+            f"{self.effective_encoding}: {self.message}"
+        )
+
+
 @dataclass
 class SourceCoverage:
     found: int = 0
     read: int = 0
     parsed: int = 0
     failures: list[SourceFailure] = field(default_factory=list)
+    decode_notes: list[SourceDecodeNote] = field(default_factory=list)
 
     @property
     def complete(self) -> bool:
-        return (
-            not self.failures
-            and self.found == self.read == self.parsed
-        )
+        return not self.failures and self.found == self.read == self.parsed
 
     def summary(self) -> str:
         status = "OK" if self.complete else "ECHEC"
@@ -57,6 +74,54 @@ class SourceCoverage:
             f"Couverture sources: trouvés={self.found}, lus={self.read}, "
             f"parsés={self.parsed} — {status}"
         )
+
+
+def _declared_encoding(raw: bytes) -> str | None:
+    """Retourne le cookie PEP 263 sans demander au runtime de connaître le codec."""
+    lines = raw.splitlines(keepends=True)[:2]
+    for line in lines:
+        match = _ENCODING_COOKIE.match(line)
+        if match:
+            return match.group(1).decode("ascii").lower()
+    return None
+
+
+def _read_python_source(path: Path) -> tuple[str, SourceDecodeNote | None]:
+    """Lit une source Python sans masquer les erreurs d'encodage.
+
+    ``mbcs`` est un alias Windows dépendant de la page de codes active et n'est
+    pas disponible sur les runners POSIX. Pour un fichier ``mbcs`` composé
+    uniquement d'octets ASCII, le décodage ASCII est rigoureusement équivalent
+    quelle que soit la page ANSI Windows : ce cas est donc portable. Dès qu'un
+    octet non-ASCII apparaît, on refuse de deviner une page de codes.
+    """
+    try:
+        with tokenize.open(path) as stream:
+            return stream.read(), None
+    except SyntaxError as exc:
+        if "unknown encoding" not in str(exc).lower():
+            raise
+
+        raw = path.read_bytes()
+        declared = _declared_encoding(raw)
+        if declared != "mbcs":
+            raise
+
+        try:
+            source = raw.decode("ascii")
+        except UnicodeDecodeError as ascii_exc:
+            raise SyntaxError(
+                f"encodage mbcs non portable avec octets non-ASCII dans {path}; "
+                "normaliser le cookie/code page ou analyser ce fichier sous Windows"
+            ) from ascii_exc
+
+        note = SourceDecodeNote(
+            path=path,
+            declared_encoding="mbcs",
+            effective_encoding="ascii",
+            message="contenu ASCII, sous-ensemble invariant de toutes les pages ANSI Windows",
+        )
+        return source, note
 
 
 class SourceAuditSession:
@@ -69,8 +134,7 @@ class SourceAuditSession:
     def parse(self, path: Path) -> tuple[str, ast.AST] | None:
         path = Path(path)
         try:
-            with tokenize.open(path) as stream:
-                source = stream.read()
+            source, decode_note = _read_python_source(path)
         except (OSError, UnicodeDecodeError, SyntaxError) as exc:
             self.coverage.failures.append(
                 SourceFailure(path, "lecture", type(exc).__name__, str(exc))
@@ -78,6 +142,8 @@ class SourceAuditSession:
             return None
 
         self.coverage.read += 1
+        if decode_note is not None:
+            self.coverage.decode_notes.append(decode_note)
 
         try:
             tree = ast.parse(source, filename=str(path))
@@ -97,6 +163,8 @@ class SourceAuditSession:
         if prefix:
             print(prefix)
         print(self.coverage.summary())
+        for note in self.coverage.decode_notes:
+            print(f"NOTE ENCODAGE: {note.format()}")
         for failure in self.coverage.failures:
             print(f"ERREUR AUDIT: {failure.format()}")
         return self.coverage.complete

--- a/scripts/audit_source_coverage.py
+++ b/scripts/audit_source_coverage.py
@@ -31,6 +31,10 @@ SKIP_DIRS = {".git", ".venv", "venv", "__pycache__", "build", "dist"}
 _ENCODING_COOKIE = re.compile(br"^[ \t\f]*#.*?coding[:=][ \t]*([-\w.]+)")
 
 
+class AuditCoverageError(RuntimeError):
+    """Signale qu'un audit n'a pas réellement couvert tout son périmètre."""
+
+
 @dataclass(frozen=True)
 class SourceFailure:
     path: Path
@@ -159,14 +163,20 @@ class SourceAuditSession:
         self.coverage.parsed += 1
         return source, tree
 
+    def diagnostics(self) -> str:
+        lines = [self.coverage.summary()]
+        lines.extend(f"NOTE ENCODAGE: {note.format()}" for note in self.coverage.decode_notes)
+        lines.extend(f"ERREUR AUDIT: {failure.format()}" for failure in self.coverage.failures)
+        return "\n".join(lines)
+
+    def require_complete(self) -> None:
+        if not self.coverage.complete:
+            raise AuditCoverageError(self.diagnostics())
+
     def report(self, *, prefix: str = "") -> bool:
         if prefix:
             print(prefix)
-        print(self.coverage.summary())
-        for note in self.coverage.decode_notes:
-            print(f"NOTE ENCODAGE: {note.format()}")
-        for failure in self.coverage.failures:
-            print(f"ERREUR AUDIT: {failure.format()}")
+        print(self.diagnostics())
         return self.coverage.complete
 
 

--- a/scripts/audit_source_coverage.py
+++ b/scripts/audit_source_coverage.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Contrat commun de lecture/parsing pour les audits statiques Noethys.
+
+Un audit ne peut pas conclure à "zéro occurrence" si un fichier Python de son
+périmètre n'a pas été lu et parsé. Ce module fournit :
+
+- une lecture respectant l'encodage Python déclaré (PEP 263 / BOM) via
+  :func:`tokenize.open` ;
+- un comptage explicite ``trouvés == lus == parsés`` ;
+- la conservation de chaque erreur de lecture ou de syntaxe ;
+- un code de sortie non nul dès qu'un fichier échappe à l'analyse.
+
+Les occurrences détectées par les audits restent des diagnostics. En revanche,
+la couverture de l'audit est un contrat bloquant.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import tokenize
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+SKIP_DIRS = {".git", ".venv", "venv", "__pycache__", "build", "dist"}
+
+
+@dataclass(frozen=True)
+class SourceFailure:
+    path: Path
+    stage: str
+    error_type: str
+    message: str
+
+    def format(self) -> str:
+        return f"{self.path}: {self.stage}: {self.error_type}: {self.message}"
+
+
+@dataclass
+class SourceCoverage:
+    found: int = 0
+    read: int = 0
+    parsed: int = 0
+    failures: list[SourceFailure] = field(default_factory=list)
+
+    @property
+    def complete(self) -> bool:
+        return (
+            not self.failures
+            and self.found == self.read == self.parsed
+        )
+
+    def summary(self) -> str:
+        status = "OK" if self.complete else "ECHEC"
+        return (
+            f"Couverture sources: trouvés={self.found}, lus={self.read}, "
+            f"parsés={self.parsed} — {status}"
+        )
+
+
+class SourceAuditSession:
+    """Charge un ensemble figé de fichiers et mesure leur couverture réelle."""
+
+    def __init__(self, paths: Iterable[Path]):
+        self.paths = tuple(sorted(Path(path) for path in paths))
+        self.coverage = SourceCoverage(found=len(self.paths))
+
+    def parse(self, path: Path) -> tuple[str, ast.AST] | None:
+        path = Path(path)
+        try:
+            with tokenize.open(path) as stream:
+                source = stream.read()
+        except (OSError, UnicodeDecodeError, SyntaxError) as exc:
+            self.coverage.failures.append(
+                SourceFailure(path, "lecture", type(exc).__name__, str(exc))
+            )
+            return None
+
+        self.coverage.read += 1
+
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError as exc:
+            detail = exc.msg
+            if exc.lineno is not None:
+                detail = f"ligne {exc.lineno}: {detail}"
+            self.coverage.failures.append(
+                SourceFailure(path, "parsing", type(exc).__name__, detail)
+            )
+            return None
+
+        self.coverage.parsed += 1
+        return source, tree
+
+    def report(self, *, prefix: str = "") -> bool:
+        if prefix:
+            print(prefix)
+        print(self.coverage.summary())
+        for failure in self.coverage.failures:
+            print(f"ERREUR AUDIT: {failure.format()}")
+        return self.coverage.complete
+
+
+def iter_python_files(root: Path, *, skip_dirs: set[str] | None = None):
+    excluded = SKIP_DIRS if skip_dirs is None else set(skip_dirs)
+    for path in sorted(Path(root).rglob("*.py")):
+        if any(part in excluded for part in path.parts):
+            continue
+        yield path
+
+
+def check_tree(root: Path) -> SourceCoverage:
+    session = SourceAuditSession(iter_python_files(root))
+    for path in session.paths:
+        session.parse(path)
+    return session.coverage
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Vérifie que tous les fichiers Python d'un périmètre sont lisibles et parsables"
+    )
+    parser.add_argument("root", nargs="?", default="noethys", type=Path)
+    args = parser.parse_args()
+
+    session = SourceAuditSession(iter_python_files(args.root))
+    for path in session.paths:
+        session.parse(path)
+
+    return 0 if session.report(prefix="Contrat de couverture des audits statiques") else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_sql_group_by.py
+++ b/scripts/audit_sql_group_by.py
@@ -4,8 +4,8 @@
 
 Cet audit est volontairement conservateur : il ne modifie rien et ne prétend pas
 valider la sémantique SQL. Il sert de liste de travail reproductible pour la
-modernisation de Noethys, en particulier lors du maintien de la compatibilité
-avec les anciennes bases MySQL/MariaDB.
+modernisation de Noethys. Les occurrences restent informatives ; la couverture
+des sources Python est bloquante.
 """
 
 from __future__ import annotations
@@ -14,17 +14,16 @@ import argparse
 import re
 from pathlib import Path
 
+try:
+    from scripts.audit_source_coverage import SourceAuditSession, iter_python_files
+except ModuleNotFoundError:
+    from audit_source_coverage import SourceAuditSession, iter_python_files
+
 SQL_BLOCK_RE = re.compile(r'([ruRU]{0,2})?(["\']{3})(.*?)(?:\2)', re.DOTALL)
 GROUP_BY_RE = re.compile(r'\bGROUP\s+BY\b', re.IGNORECASE)
 SELECT_RE = re.compile(r'\bSELECT\b(.*?)\bFROM\b', re.IGNORECASE | re.DOTALL)
 AGGREGATE_RE = re.compile(r'\b(?:SUM|COUNT|AVG|MIN|MAX|GROUP_CONCAT)\s*\(', re.IGNORECASE)
-
-
-def iter_python_files(root: Path):
-    for path in root.rglob('*.py'):
-        if any(part in {'.git', '.venv', 'venv', '__pycache__'} for part in path.parts):
-            continue
-        yield path
+SKIP_DIRS = {'.git', '.venv', 'venv', '__pycache__'}
 
 
 def line_number(text: str, offset: int) -> int:
@@ -39,12 +38,7 @@ def classify(sql: str) -> str:
     return 'group-by-without-visible-aggregate'
 
 
-def scan_file(path: Path):
-    try:
-        text = path.read_text(encoding='utf-8')
-    except UnicodeDecodeError:
-        text = path.read_text(encoding='utf-8', errors='replace')
-
+def scan_text(text: str):
     findings = []
     for block in SQL_BLOCK_RE.finditer(text):
         sql = block.group(3)
@@ -52,6 +46,15 @@ def scan_file(path: Path):
             continue
         findings.append((line_number(text, block.start()), classify(sql), sql))
     return findings
+
+
+def scan_file(path: Path):
+    session = SourceAuditSession([path])
+    loaded = session.parse(path)
+    session.require_complete()
+    assert loaded is not None
+    text, _tree = loaded
+    return scan_text(text)
 
 
 def compact_sql(sql: str, limit: int = 220) -> str:
@@ -66,11 +69,16 @@ def main() -> int:
     args = parser.parse_args()
 
     root = Path(args.root)
+    session = SourceAuditSession(iter_python_files(root, skip_dirs=SKIP_DIRS))
     total = 0
     suspicious = 0
 
-    for path in iter_python_files(root):
-        for lineno, category, sql in scan_file(path):
+    for path in session.paths:
+        loaded = session.parse(path)
+        if loaded is None:
+            continue
+        text, _tree = loaded
+        for lineno, category, sql in scan_text(text):
             total += 1
             if category == 'group-by-without-visible-aggregate':
                 suspicious += 1
@@ -79,6 +87,8 @@ def main() -> int:
     print(f'\nGROUP BY trouvés: {total}')
     print(f'Sans agrégat visible dans SELECT: {suspicious}')
     print('Note: chaque résultat doit être revu manuellement avant modification.')
+    session.report(prefix='Couverture audit SQL GROUP BY')
+    session.require_complete()
 
     if args.fail_on_findings and total:
         return 1

--- a/scripts/audit_sql_strict.py
+++ b/scripts/audit_sql_strict.py
@@ -15,17 +15,20 @@ Analyse les chaînes SQL Python contenant un ``GROUP BY`` et distingue :
             DISTINCT, sans constituer à lui seul une incompatibilité stricte.
 
 Les sous-requêtes sont analysées dans leur propre portée. L'analyse ne tente
-pas d'inférer les dépendances fonctionnelles propres à un moteur SQL (par
-exemple une colonne dépendant d'une clé primaire groupée), afin de rester
-pertinente pour les anciennes installations MySQL/MariaDB.
-
-Le script ne modifie aucun fichier ni aucune base.
+pas d'inférer les dépendances fonctionnelles propres à un moteur SQL. Le script
+ne modifie aucun fichier ni aucune base. La couverture des sources Python est
+bloquante : aucun fichier non lu/non parsé ne peut produire zéro candidat.
 """
 
 import argparse
 import ast
 from pathlib import Path
 import re
+
+try:
+    from scripts.audit_source_coverage import SourceAuditSession
+except ModuleNotFoundError:
+    from audit_source_coverage import SourceAuditSession
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -58,7 +61,6 @@ def _is_ident_char(char):
 
 
 def _keyword_matches(sql, pos, keyword):
-    """Teste un mot-clé SQL à ``pos`` en tolérant les espaces multiples."""
     parts = keyword.split()
     cursor = pos
     for index, part in enumerate(parts):
@@ -79,7 +81,6 @@ def _keyword_matches(sql, pos, keyword):
 
 
 def _find_top_level_keyword(sql, keyword, start=0):
-    """Trouve un mot-clé hors parenthèses et hors chaînes SQL."""
     depth = 0
     quote = None
     pos = start
@@ -119,7 +120,6 @@ def _find_top_level_keyword(sql, keyword, start=0):
 
 
 def _split_top_level_csv(text):
-    """Découpe une liste SQL séparée par virgules hors parenthèses/quotes."""
     items = []
     current = []
     depth = 0
@@ -168,7 +168,6 @@ def _split_top_level_csv(text):
 
 
 def _parenthesized_selects(sql):
-    """Retourne les contenus parenthésés contenant SELECT + GROUP BY."""
     stack = []
     quote = None
     results = []
@@ -285,7 +284,6 @@ def _extract_select_and_group(sql):
 
 
 def _analyze_scope(sql):
-    """Analyse un SELECT/GROUP BY au niveau supérieur de ``sql``."""
     parsed = _extract_select_and_group(sql)
     if parsed is None:
         return None
@@ -332,7 +330,6 @@ def _analyze_scope(sql):
 
 
 def _collect_group_scopes(sql, seen=None):
-    """Analyse la portée principale et les sous-requêtes parenthésées."""
     if seen is None:
         seen = set()
     key = " ".join(sql.split())
@@ -410,17 +407,7 @@ def _string_value(node):
     return None
 
 
-def extract_sql_candidates(path):
-    try:
-        text = path.read_text(encoding="utf-8", errors="ignore")
-    except Exception:
-        return []
-
-    try:
-        tree = ast.parse(text, filename=str(path))
-    except SyntaxError:
-        return []
-
+def extract_sql_candidates_from_tree(path, tree):
     candidates = []
     seen = set()
     for node in ast.walk(tree):
@@ -441,6 +428,15 @@ def extract_sql_candidates(path):
     return candidates
 
 
+def extract_sql_candidates(path):
+    session = SourceAuditSession([path])
+    loaded = session.parse(path)
+    session.require_complete()
+    assert loaded is not None
+    _source, tree = loaded
+    return extract_sql_candidates_from_tree(path, tree)
+
+
 def iter_python_files(root):
     for path in root.rglob("*.py"):
         if "__pycache__" in path.parts or ".git" in path.parts:
@@ -448,12 +444,23 @@ def iter_python_files(root):
         yield path
 
 
-def scan(root):
+def _scan_with_session(root):
+    session = SourceAuditSession(iter_python_files(root))
     candidates = []
-    for path in iter_python_files(root):
-        candidates.extend(extract_sql_candidates(path))
+    for path in session.paths:
+        loaded = session.parse(path)
+        if loaded is None:
+            continue
+        _source, tree = loaded
+        candidates.extend(extract_sql_candidates_from_tree(path, tree))
     order = {"REVIEW": 0, "DEDUPE": 1, "SAFE": 2}
     candidates.sort(key=lambda item: (order[item.classification], str(item.path), item.line))
+    return candidates, session
+
+
+def scan(root):
+    candidates, session = _scan_with_session(root)
+    session.require_complete()
     return candidates
 
 
@@ -537,7 +544,9 @@ def main(argv=None):
     args = parser.parse_args(argv)
 
     root = Path(args.root).resolve()
-    candidates = scan(root)
+    candidates, session = _scan_with_session(root)
+    session.report(prefix="Couverture audit SQL strict")
+    session.require_complete()
     if args.format == "markdown":
         print_markdown(candidates, root, args.only)
     else:

--- a/scripts/audit_ui_layout.py
+++ b/scripts/audit_ui_layout.py
@@ -2,14 +2,11 @@
 # -*- coding: utf-8 -*-
 """Inventorie la dette UI wxPython à éliminer pendant la refonte Repens.
 
-L'audit ne modifie rien et n'échoue pas par défaut. Il sert de liste de travail
-exhaustive : tailles figées, toolbars dimensionnées localement, dépendances
-visuelles qui contournent la façade Repens, boutons bitmap historiques et
-combinaisons de flags connues pour produire des layouts bloqués.
-
-Les mécanismes qui masquent les assertions de cohérence des sizers constituent
-en revanche une erreur structurelle : ils sont détectés séparément afin que la
-CI puisse les interdire explicitement.
+L'audit ne modifie rien et n'échoue pas par défaut sur les occurrences. Il sert
+de liste de travail exhaustive : tailles figées, toolbars dimensionnées
+localement, dépendances visuelles qui contournent la façade Repens, boutons
+bitmap historiques et combinaisons de flags connues pour produire des layouts
+bloqués. La couverture des sources first-party est en revanche bloquante.
 
 La section « couverture Repens » fournit un indicateur reproductible. Il ne
 prétend pas mesurer la modernisation fonctionnelle de Noethys : il mesure la
@@ -26,6 +23,11 @@ import re
 from collections import Counter
 from pathlib import Path
 
+try:
+    from scripts.audit_source_coverage import SourceAuditSession
+except ModuleNotFoundError:
+    from audit_source_coverage import SourceAuditSession
+
 ROOT = Path(__file__).resolve().parents[1]
 NOETHYS = ROOT / "noethys"
 EXCLUS = {"ObjectListView", "Outils", "__pycache__"}
@@ -35,15 +37,10 @@ PATTERNS = {
     "toolbar_bitmap_fixed": re.compile(r"SetToolBitmapSize\s*\(\s*(?:wx\.Size\s*\()?\s*\(?\s*(?:16|20|24|32|40|48)\s*,"),
     "aui_pane_fixed_size": re.compile(r"\.(?:MinSize|BestSize)\s*\(\s*\(\s*-?\d+\s*,\s*-?\d+"),
     "window_fixed_min_size": re.compile(r"\.SetMinSize\s*\(\s*\(\s*-?\d+\s*,\s*-?\d+"),
-    # wx.EXPAND rend les flags d'alignement de l'axe concerné incohérents ou
-    # inutiles. L'audit reste informatif car l'axe dépend du sizer parent.
     "align_expand_conflict": re.compile(
         r"(?:wx\.EXPAND[^#\n]*wx\.ALIGN_(?:LEFT|RIGHT|TOP|BOTTOM|CENTER|CENTRE|CENTER_HORIZONTAL|CENTRE_HORIZONTAL|CENTER_VERTICAL|CENTRE_VERTICAL)"
         r"|wx\.ALIGN_(?:LEFT|RIGHT|TOP|BOTTOM|CENTER|CENTRE|CENTER_HORIZONTAL|CENTRE_HORIZONTAL|CENTER_VERTICAL|CENTRE_VERTICAL)[^#\n]*wx\.EXPAND)"
     ),
-    # Ne jamais faire taire wxWidgets pour rendre une CI verte. Ces deux formes
-    # couvrent la variable d'environnement officielle et l'API de désactivation
-    # des consistency checks lorsqu'elle est exposée par le binding.
     "sizer_assertion_suppression": re.compile(
         r"WXSUPPRESS_SIZER_FLAGS_CHECK|DisableConsistencyChecks\s*\("
     ),
@@ -72,10 +69,6 @@ def _first_party(path: Path) -> bool:
 def _ui_layer(path: Path) -> bool:
     rel = path.relative_to(NOETHYS)
     return bool(rel.parts) and rel.parts[0] in UI_LAYERS
-
-
-def _read_lines(path: Path) -> list[str]:
-    return path.read_text(encoding="utf-8", errors="replace").splitlines()
 
 
 def _repens_coverage(files: list[tuple[Path, list[str]]]) -> dict:
@@ -113,17 +106,18 @@ def _repens_coverage(files: list[tuple[Path, list[str]]]) -> dict:
     }
 
 
-def scan() -> tuple[list[dict], dict]:
+def _scan_with_session():
+    paths = [path for path in sorted(NOETHYS.rglob("*.py")) if _first_party(path)]
+    session = SourceAuditSession(paths)
     findings = []
     files = []
 
-    for path in sorted(NOETHYS.rglob("*.py")):
-        if not _first_party(path):
+    for path in session.paths:
+        loaded = session.parse(path)
+        if loaded is None:
             continue
-        try:
-            lines = _read_lines(path)
-        except OSError:
-            continue
+        source, _tree = loaded
+        lines = source.splitlines()
         files.append((path, lines))
         rel = str(path.relative_to(ROOT)).replace("\\", "/")
 
@@ -151,7 +145,13 @@ def scan() -> tuple[list[dict], dict]:
                         "snippet": code.strip()[:180],
                     })
 
-    return findings, _repens_coverage(files)
+    return findings, _repens_coverage(files), session
+
+
+def scan() -> tuple[list[dict], dict]:
+    findings, repens, session = _scan_with_session()
+    session.require_complete()
+    return findings, repens
 
 
 def main() -> int:
@@ -172,7 +172,9 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    findings, repens = scan()
+    findings, repens, session = _scan_with_session()
+    session.report(prefix="Couverture audit dette UI/layout")
+    session.require_complete()
     counts = Counter(item["kind"] for item in findings)
     all_kinds = set(PATTERNS) | {"legacy_style_dependency"}
 

--- a/scripts/audit_unbound_after_try.py
+++ b/scripts/audit_unbound_after_try.py
@@ -7,7 +7,7 @@ Ce motif produit un ``UnboundLocalError`` uniquement sur le chemin d'erreur et
 échappe donc facilement aux tests heureux. L'analyse reste conservative, mais
 respecte l'ordre d'exécution à l'intérieur des blocs suivants afin de ne pas
 confondre une réaffectation dans un nouveau ``try``/une boucle avec une lecture
-de l'ancienne variable.
+de l'ancienne variable. La couverture des sources est bloquante.
 """
 
 from __future__ import annotations
@@ -17,6 +17,10 @@ import ast
 import json
 from pathlib import Path
 
+try:
+    from scripts.audit_source_coverage import SourceAuditSession
+except ModuleNotFoundError:
+    from audit_source_coverage import SourceAuditSession
 
 ROOT = Path(__file__).resolve().parents[1]
 NOETHYS = ROOT / "noethys"
@@ -97,9 +101,6 @@ def _first_event(statements, name):
                 return "load", _first_name_line(stmt.iter, name, ast.Load)
             target_assigns = name in _assigned_names(stmt.target)
             if target_assigns:
-                # La cible est affectée avant chaque exécution du corps. Les
-                # lectures du corps sont donc sûres ; seul le ``else`` peut
-                # s'exécuter sans itération.
                 event, line = _first_event(stmt.orelse, name)
                 if event == "load":
                     return event, line
@@ -125,9 +126,6 @@ def _first_event(statements, name):
             event, line = _first_event(stmt.body, name)
             if event == "load":
                 return event, line
-            # Si le corps commence par une affectation, les lectures suivantes
-            # de ce même corps sont protégées. Un handler peut toutefois lire
-            # le nom si l'affectation a échoué avant de le lier.
             for handler in stmt.handlers:
                 handler_event, handler_line = _first_event(handler.body, name)
                 if handler_event == "load":
@@ -145,7 +143,6 @@ def _first_event(statements, name):
                 if name in _loaded_names(item.context_expr):
                     return "load", _first_name_line(item.context_expr, name, ast.Load)
                 if item.optional_vars is not None and name in _assigned_names(item.optional_vars):
-                    # Affecté avant le corps si l'entrée du contexte réussit.
                     event, line = _first_event(stmt.body, name)
                     if event == "load":
                         return "store", getattr(stmt, "lineno", line)
@@ -157,9 +154,6 @@ def _first_event(statements, name):
         if name in _loaded_names(stmt):
             return "load", _first_name_line(stmt, name, ast.Load) or getattr(stmt, "lineno", 0)
 
-        # Une affectation top-level dans une instruction simple garantit le nom
-        # pour la suite. Pour les structures complexes, les cas ci-dessus ont
-        # déjà traité les branches sans prétendre à une garantie globale.
         if name in _assigned_names(stmt):
             return "store", getattr(stmt, "lineno", 0)
 
@@ -240,15 +234,22 @@ def iter_python_files(root=NOETHYS):
 def scan(root=NOETHYS):
     findings = []
     for path in iter_python_files(root):
-        try:
-            source = path.read_text(encoding="utf-8", errors="replace")
-            tree = ast.parse(source, filename=str(path))
-        except (OSError, SyntaxError):
-            continue
+        session = SourceAuditSession([path])
+        loaded = session.parse(path)
+        session.require_complete()
+        assert loaded is not None
+        _source, tree = loaded
         relpath = str(path.relative_to(root)).replace("\\", "/")
         findings.extend(_scan_block(tree.body, relpath))
     findings.sort(key=lambda item: (item["file"], item["read_line"], item["name"]))
     return findings
+
+
+def _coverage_session(root=NOETHYS):
+    session = SourceAuditSession(iter_python_files(root))
+    for path in session.paths:
+        session.parse(path)
+    return session
 
 
 def main(argv=None):
@@ -256,6 +257,10 @@ def main(argv=None):
     parser.add_argument("--json", default="", metavar="FILE")
     parser.add_argument("--fail-on-findings", action="store_true")
     args = parser.parse_args(argv)
+
+    coverage = _coverage_session()
+    coverage.report(prefix="Couverture audit variables après try")
+    coverage.require_complete()
 
     findings = scan()
     print(f"TRY_DEFINED_USED_AFTER={len(findings)}")

--- a/scripts/audit_utf8_boundaries.py
+++ b/scripts/audit_utf8_boundaries.py
@@ -2,14 +2,18 @@
 """Inventorie les frontières d'encodage réellement actionnables sous Python 3.
 
 L'audit se concentre sur les flux texte ouverts sans encodage explicite.
-Les encode()/decode() explicites, CSV/JSON et flux binaires ne sont pas des
-anomalies en soi et ne sont donc plus comptés comme défauts.
+Les occurrences restent informatives ; la couverture des sources est bloquante.
 """
 from __future__ import annotations
 
 import ast
 import sys
 from pathlib import Path
+
+try:
+    from scripts.audit_source_coverage import SourceAuditSession, iter_python_files
+except ModuleNotFoundError:
+    from audit_source_coverage import SourceAuditSession, iter_python_files
 
 ROOT = Path(sys.argv[1] if len(sys.argv) > 1 else "noethys")
 SKIP_DIRS = {".git", "build", "dist", "__pycache__", "venv", ".venv"}
@@ -53,13 +57,7 @@ def positional_or_keyword(node: ast.Call, position: int, keyword: str) -> ast.AS
     return None
 
 
-def scan(path: Path) -> list[tuple[int, str]]:
-    try:
-        source = path.read_text(encoding="utf-8", errors="replace")
-        tree = ast.parse(source, filename=str(path))
-    except (OSError, SyntaxError):
-        return []
-
+def scan_tree(tree: ast.AST) -> list[tuple[int, str]]:
     findings: list[tuple[int, str]] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
@@ -84,19 +82,34 @@ def scan(path: Path) -> list[tuple[int, str]]:
     return sorted(set(findings))
 
 
+def scan(path: Path) -> list[tuple[int, str]]:
+    session = SourceAuditSession([path])
+    loaded = session.parse(path)
+    if loaded is None:
+        raise RuntimeError(session.coverage.failures[0].format())
+    _source, tree = loaded
+    return scan_tree(tree)
+
+
 def main() -> int:
+    session = SourceAuditSession(iter_python_files(ROOT, skip_dirs=SKIP_DIRS))
     total = 0
-    files = 0
-    for path in sorted(ROOT.rglob("*.py")):
-        if any(part in SKIP_DIRS for part in path.parts):
+    files_with_findings = 0
+    for path in session.paths:
+        loaded = session.parse(path)
+        if loaded is None:
             continue
-        findings = scan(path)
+        _source, tree = loaded
+        findings = scan_tree(tree)
         if findings:
-            files += 1
+            files_with_findings += 1
         for lineno, message in findings:
             total += 1
             print(f"{path}:{lineno}: {message}")
-    print(f"\n{total} frontière(s) texte/encodage actionnable(s) dans {files} fichier(s).")
+    print(f"\n{total} frontière(s) texte/encodage actionnable(s) dans {files_with_findings} fichier(s).")
+    if not session.report():
+        print("Audit incomplet : inventaire encodage non exhaustif.")
+        return 2
     return 0
 
 

--- a/scripts/audit_wx_lifecycle.py
+++ b/scripts/audit_wx_lifecycle.py
@@ -6,7 +6,8 @@ Objectif : repérer les contrôles qui confondent encore leur parent visuel wx
 avec un contrôleur métier, les callbacks exécutés trop tôt pendant ``__init__``
 et les accès directs à un objet wx local après son ``Destroy()``. L'audit reste
 informatif pour les familles historiques larges, mais distingue des signaux
-structurels précis avant de rendre une catégorie bloquante.
+structurels précis avant de rendre une catégorie bloquante. La couverture des
+fichiers UI first-party analysés est bloquante.
 """
 
 from __future__ import annotations
@@ -17,13 +18,16 @@ import json
 from collections import Counter
 from pathlib import Path
 
+try:
+    from scripts.audit_source_coverage import SourceAuditSession
+except ModuleNotFoundError:
+    from audit_source_coverage import SourceAuditSession
+
 ROOT = Path(__file__).resolve().parents[1]
 NOETHYS = ROOT / "noethys"
 UI_LAYERS = {"Ctrl", "Dlg", "Ol"}
 EXCLUS = {"ObjectListView", "Outils", "__pycache__"}
 
-# Méthodes purement visuelles usuelles : leur appel via le parent wx n'implique
-# pas, à lui seul, un couplage métier.
 WX_PARENT_METHODS = {
     "Bind", "Centre", "Center", "Close", "Destroy", "Disable", "Enable",
     "Fit", "Freeze", "GetBackgroundColour", "GetClientSize", "GetFont",
@@ -73,11 +77,6 @@ def _line(lines: list[str], lineno: int) -> str:
 
 
 def _looks_like_wx_constructor(init: ast.FunctionDef) -> bool:
-    """Ne retient que les constructeurs qui initialisent explicitement wx.*.
-
-    ``super().__init__`` seul n'est pas une preuve : l'ancienne heuristique
-    classait aussi des objets de données ``Track`` comme contrôles wxPython.
-    """
     for node in ast.walk(init):
         if not isinstance(node, ast.Call):
             continue
@@ -185,8 +184,6 @@ def _scan_parent_coupling(path: Path, tree: ast.AST, lines: list[str]) -> list[d
                             "snippet": _line(lines, node.lineno),
                         })
 
-                # ``self.GetGrandParent().controle_metier`` est le même type de
-                # dépendance fragile qu'un ``self.parent.parent`` explicite.
                 if isinstance(node.value, ast.Call):
                     call_chain = _call_name(node.value)
                     if call_chain == ["self", "GetGrandParent"] and node.attr not in WX_PARENT_METHODS:
@@ -225,7 +222,6 @@ def _scan_constructor_order(path: Path, tree: ast.AST, lines: list[str]) -> list
             if not chain:
                 continue
 
-            # Le premier marqueur de layout clôt la phase à inspecter.
             if chain[:1] == ["self"] and chain[-1] in LAYOUT_MARKERS:
                 layout_seen = True
                 continue
@@ -241,8 +237,6 @@ def _scan_constructor_order(path: Path, tree: ast.AST, lines: list[str]) -> list
                     "snippet": _line(lines, call.lineno),
                 })
 
-                # Signal fort : la méthode appelée lit réellement un attribut
-                # de ``self`` qui n'est créé que plus tard dans le constructeur.
                 if len(chain) == 2:
                     callback = _method(cls, chain[-1])
                     if callback is not None:
@@ -277,7 +271,6 @@ def _scan_constructor_order(path: Path, tree: ast.AST, lines: list[str]) -> list
 
 
 def _target_key(node: ast.AST) -> str | None:
-    """Retourne une cible locale simple suivie par l'audit de destruction."""
     if isinstance(node, ast.Name):
         return node.id
     if (
@@ -290,13 +283,6 @@ def _target_key(node: ast.AST) -> str | None:
 
 
 def _runtime_nodes(node: ast.AST):
-    """Parcourt seulement l'expression exécutée par l'instruction courante.
-
-    Les sous-blocs ``if``/``try``/``for`` sont analysés séparément par
-    ``_scan_destroy_block``. Ne pas y descendre ici évite qu'une réutilisation
-    légitime du nom ``dlg`` dans une branche soit attribuée au ``Destroy()`` du
-    bloc extérieur.
-    """
     for child in ast.iter_child_nodes(node):
         if isinstance(child, ast.stmt) or isinstance(child, ast.Lambda):
             continue
@@ -329,7 +315,6 @@ def _assigned_targets(statement: ast.stmt) -> set[str]:
 
 
 def _direct_destroy_target(statement: ast.stmt) -> str | None:
-    """Reconnaît uniquement ``objet.Destroy()`` exécuté sans condition."""
     if not isinstance(statement, ast.Expr) or not isinstance(statement.value, ast.Call):
         return None
     call = statement.value
@@ -339,7 +324,6 @@ def _direct_destroy_target(statement: ast.stmt) -> str | None:
 
 
 def _nested_statement_blocks(statement: ast.stmt):
-    """Renvoie les blocs exécutables internes, chacun analysé indépendamment."""
     for attr in ("body", "orelse", "finalbody"):
         block = getattr(statement, attr, None)
         if isinstance(block, list) and block:
@@ -366,15 +350,9 @@ def _scan_destroy_block(
 ) -> list[dict]:
     findings: list[dict] = []
     rel = str(path.relative_to(ROOT)).replace("\\", "/")
-    # Une branche exécutée après un Destroy() du bloc parent hérite de cet état.
-    # Elle travaille sur une copie : un Destroy conditionnel interne ne doit pas
-    # contaminer le bloc parent une fois la branche terminée.
     destroyed: dict[str, int] = dict(inherited_destroyed or {})
 
     for statement in statements:
-        # Un usage dans une instruction ultérieure au Destroy est risqué. On
-        # inspecte avant de considérer les réaffectations de cette instruction,
-        # afin de ne pas masquer ``dlg = transformer(dlg)``.
         for target in sorted(_loaded_targets(statement).intersection(destroyed)):
             findings.append({
                 "kind": "use_after_destroy",
@@ -387,8 +365,6 @@ def _scan_destroy_block(
                 "snippet": _line(lines, statement.lineno),
             })
 
-        # Les branches héritent uniquement des objets déjà détruits avant leur
-        # entrée. Leurs propres destructions/réaffectations restent locales.
         for block in _nested_statement_blocks(statement):
             findings.extend(
                 _scan_destroy_block(
@@ -408,8 +384,6 @@ def _scan_destroy_block(
         if target:
             destroyed[target] = statement.lineno
 
-        # Rien situé après un terminal direct du bloc n'est atteignable depuis
-        # ce chemin ; inutile de propager l'état de destruction.
         if isinstance(statement, TERMINAL_STATEMENTS):
             break
 
@@ -417,7 +391,6 @@ def _scan_destroy_block(
 
 
 def _scan_use_after_destroy(path: Path, tree: ast.AST, lines: list[str]) -> list[dict]:
-    """Détecte le motif Phoenix ``Destroy()`` puis réutilisation du même objet."""
     findings: list[dict] = []
     for node in tree.body:
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -446,21 +419,26 @@ def _dedupe(findings: list[dict]) -> list[dict]:
     return result
 
 
-def scan() -> list[dict]:
+def _scan_with_session():
+    paths = [path for path in sorted(NOETHYS.rglob("*.py")) if _ui_file(path)]
+    session = SourceAuditSession(paths)
     findings: list[dict] = []
-    for path in sorted(NOETHYS.rglob("*.py")):
-        if not _ui_file(path):
+    for path in session.paths:
+        loaded = session.parse(path)
+        if loaded is None:
             continue
-        try:
-            text = path.read_text(encoding="utf-8", errors="replace")
-            tree = ast.parse(text, filename=str(path))
-        except (OSError, SyntaxError):
-            continue
+        text, tree = loaded
         lines = text.splitlines()
         findings.extend(_scan_parent_coupling(path, tree, lines))
         findings.extend(_scan_constructor_order(path, tree, lines))
         findings.extend(_scan_use_after_destroy(path, tree, lines))
-    return _dedupe(findings)
+    return _dedupe(findings), session
+
+
+def scan() -> list[dict]:
+    findings, session = _scan_with_session()
+    session.require_complete()
+    return findings
 
 
 def main() -> int:
@@ -469,7 +447,9 @@ def main() -> int:
     parser.add_argument("--fail-on", action="append", default=[])
     args = parser.parse_args()
 
-    findings = scan()
+    findings, session = _scan_with_session()
+    session.report(prefix="Couverture audit cycle de vie wxPython")
+    session.require_complete()
     counts = Counter(item["kind"] for item in findings)
     kinds = {
         "visual_parent_business_coupling",

--- a/scripts/audit_wx_numeric_arguments.py
+++ b/scripts/audit_wx_numeric_arguments.py
@@ -2,13 +2,19 @@
 """Repère les arguments numériques wxPython susceptibles de devenir flottants.
 
 Cible les appels de taille, position et dimensions contenant une division `/`
-non protégée par une conversion entière. Audit informatif uniquement.
+non protégée par une conversion entière. Les occurrences restent informatives,
+mais un fichier non analysé rend désormais l'audit invalide.
 """
 from __future__ import annotations
 
 import ast
 import sys
 from pathlib import Path
+
+try:
+    from scripts.audit_source_coverage import SourceAuditSession, iter_python_files
+except ModuleNotFoundError:
+    from audit_source_coverage import SourceAuditSession, iter_python_files
 
 ROOT = Path(sys.argv[1] if len(sys.argv) > 1 else "noethys")
 TARGETS = {
@@ -43,11 +49,7 @@ def contains_unprotected_division(node: ast.AST, protected: bool = False) -> boo
     return any(contains_unprotected_division(child, protected) for child in ast.iter_child_nodes(node))
 
 
-def scan(path: Path) -> list[tuple[int, str]]:
-    try:
-        tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"), filename=str(path))
-    except (OSError, SyntaxError):
-        return []
+def scan_tree(tree: ast.AST) -> list[tuple[int, str]]:
     findings = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call) or call_name(node) not in TARGETS:
@@ -62,13 +64,30 @@ def scan(path: Path) -> list[tuple[int, str]]:
     return sorted(set(findings))
 
 
+def scan(path: Path) -> list[tuple[int, str]]:
+    session = SourceAuditSession([path])
+    loaded = session.parse(path)
+    if loaded is None:
+        raise RuntimeError(session.coverage.failures[0].format())
+    _source, tree = loaded
+    return scan_tree(tree)
+
+
 def main() -> int:
+    session = SourceAuditSession(iter_python_files(ROOT))
     total = 0
-    for path in sorted(ROOT.rglob("*.py")):
-        for lineno, message in scan(path):
+    for path in session.paths:
+        loaded = session.parse(path)
+        if loaded is None:
+            continue
+        _source, tree = loaded
+        for lineno, message in scan_tree(tree):
             total += 1
             print(f"{path}:{lineno}: {message}")
     print(f"\n{total} argument(s) wxPython potentiellement flottant(s).")
+    if not session.report():
+        print("Audit incomplet : inventaire wx numérique non exhaustif.")
+        return 2
     return 0
 
 

--- a/scripts/audit_wxphoenix_compat.py
+++ b/scripts/audit_wxphoenix_compat.py
@@ -5,7 +5,7 @@
 Le but n'est pas de réécrire automatiquement l'interface : un nom issu de
 wxPython Classic n'est un problème que s'il n'est plus fourni par le runtime
 Phoenix réellement utilisé. L'audit distingue donc inventaire statique et
-compatibilité runtime.
+compatibilité runtime. La couverture des sources statiques est bloquante.
 
 Usage :
     python scripts/audit_wxphoenix_compat.py
@@ -21,12 +21,15 @@ import json
 from collections import Counter
 from pathlib import Path
 
+try:
+    from scripts.audit_source_coverage import SourceAuditSession
+except ModuleNotFoundError:
+    from audit_source_coverage import SourceAuditSession
+
 ROOT = Path(__file__).resolve().parents[1]
 NOETHYS = ROOT / "noethys"
 THIRD_PARTY_DIRS = {"ObjectListView", "Outils"}
 
-# Un match n'implique pas un bug. ``hooked`` indique qu'un repli existe dans
-# packaging/runtime_wx_compat.py ou dans la couche d'adaptation Noethys.
 PATTERNS = {
     "wx.EmptyBitmap": {"kind": "legacy_alias", "hooked": True, "modern": "wx.Bitmap", "runtime": "wx.EmptyBitmap"},
     "wx.EmptyIcon": {"kind": "legacy_alias", "hooked": True, "modern": "wx.Icon", "runtime": "wx.EmptyIcon"},
@@ -45,20 +48,12 @@ PATTERNS = {
     "wx.InitAllImageHandlers": {"kind": "obsolete_noop", "hooked": False, "modern": "remove / no-op with Phoenix", "runtime": "wx.InitAllImageHandlers"},
     "from wx import gizmos": {"kind": "legacy_import", "hooked": False, "modern": "qualify replacement", "runtime": "module:wx.gizmos"},
     "import wx.gizmos": {"kind": "legacy_import", "hooked": False, "modern": "qualify replacement", "runtime": "module:wx.gizmos"},
-
-    # Interaction : les listes ObjectListView ont désormais un repli central
-    # sous Phoenix/Windows. On garde l'inventaire des écrans qui consomment
-    # l'événement d'activation pour surveiller la couverture du correctif.
     "EVT_LIST_ITEM_ACTIVATED": {
         "kind": "list_activation",
         "hooked": True,
         "modern": "activation native + repli central UTILS_Adaptations",
         "runtime": "wx.EVT_LIST_ITEM_ACTIVATED",
     },
-
-    # Un double-clic brut attaché à la fenêtre interne d'une wx.Grid est un
-    # motif fragile sous Phoenix : préférer EVT_GRID_CELL_LEFT_DCLICK et les
-    # coordonnées ligne/colonne portées par GridEvent.
     "GetGridWindow().Bind(wx.EVT_LEFT_DCLICK": {
         "kind": "raw_grid_double_click",
         "hooked": False,
@@ -73,16 +68,11 @@ def scope_for(path: Path) -> str:
     return "third_party" if rel.parts and rel.parts[0] in THIRD_PARTY_DIRS else "first_party"
 
 
-def scan_file(path: Path) -> list[dict]:
+def scan_text(path: Path, text: str) -> list[dict]:
     findings = []
-    try:
-        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
-    except OSError:
-        return findings
-
     rel = str(path.relative_to(ROOT)).replace("\\", "/")
     scope = scope_for(path)
-    for lineno, raw in enumerate(lines, 1):
+    for lineno, raw in enumerate(text.splitlines(), 1):
         code = raw.split("#", 1)[0]
         if not code.strip():
             continue
@@ -99,12 +89,31 @@ def scan_file(path: Path) -> list[dict]:
     return findings
 
 
-def static_audit() -> list[dict]:
+def scan_file(path: Path) -> list[dict]:
+    session = SourceAuditSession([path])
+    loaded = session.parse(path)
+    session.require_complete()
+    assert loaded is not None
+    text, _tree = loaded
+    return scan_text(path, text)
+
+
+def _static_audit_with_session():
+    paths = [path for path in sorted(NOETHYS.rglob("*.py")) if "__pycache__" not in path.parts]
+    session = SourceAuditSession(paths)
     findings = []
-    for path in sorted(NOETHYS.rglob("*.py")):
-        if "__pycache__" in path.parts:
+    for path in session.paths:
+        loaded = session.parse(path)
+        if loaded is None:
             continue
-        findings.extend(scan_file(path))
+        text, _tree = loaded
+        findings.extend(scan_text(path, text))
+    return findings, session
+
+
+def static_audit() -> list[dict]:
+    findings, session = _static_audit_with_session()
+    session.require_complete()
     return findings
 
 
@@ -192,7 +201,9 @@ def main() -> int:
     parser.add_argument("--json", type=Path, help="écrit le rapport JSON")
     args = parser.parse_args()
 
-    findings = static_audit()
+    findings, session = _static_audit_with_session()
+    session.report(prefix="Couverture audit wxPython Phoenix")
+    session.require_complete()
     runtime = runtime_audit(findings) if args.runtime else None
     payload = {"findings": findings, "runtime": runtime}
 

--- a/tests/test_audit_source_coverage.py
+++ b/tests/test_audit_source_coverage.py
@@ -6,7 +6,7 @@ import unittest
 from pathlib import Path
 
 from scripts import audit_fragile_date_parsing
-from scripts.audit_source_coverage import SourceAuditSession
+from scripts.audit_source_coverage import SourceAuditSession, iter_python_files
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -71,6 +71,18 @@ class SourceCoverageTests(unittest.TestCase):
             self.assertEqual(session.coverage.read, 0)
             self.assertEqual(session.coverage.parsed, 0)
             self.assertEqual(session.coverage.failures[0].stage, "lecture")
+
+    def test_noethys_tree_is_fully_readable_and_parseable(self):
+        paths = tuple(iter_python_files(ROOT / "noethys"))
+        session = SourceAuditSession(paths)
+        for path in session.paths:
+            session.parse(path)
+
+        failures = "\n".join(failure.format() for failure in session.coverage.failures)
+        self.assertTrue(
+            session.coverage.complete,
+            session.coverage.summary() + ("\n" + failures if failures else ""),
+        )
 
     def test_compatibility_inventory_audits_use_the_shared_coverage_contract(self):
         scripts = ROOT / "scripts"

--- a/tests/test_audit_source_coverage.py
+++ b/tests/test_audit_source_coverage.py
@@ -42,6 +42,24 @@ class SourceCoverageTests(unittest.TestCase):
             _source, tree = loaded
             self.assertEqual(len(audit_fragile_date_parsing.scan_tree(tree)), 1)
 
+    def test_ascii_mbcs_source_is_portably_read_and_parsed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "generated_win32com.py"
+            path.write_bytes(
+                b"# -*- coding: mbcs -*-\n"
+                b"library = 'Microsoft Speech Object Library'\n"
+                b"value = 5\n"
+            )
+
+            session = SourceAuditSession([path])
+            loaded = session.parse(path)
+
+            self.assertIsNotNone(loaded)
+            self.assertTrue(session.coverage.complete)
+            self.assertEqual(session.coverage.found, 1)
+            self.assertEqual(session.coverage.read, 1)
+            self.assertEqual(session.coverage.parsed, 1)
+
     def test_syntax_error_is_not_silently_counted_as_zero_findings(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "broken.py"

--- a/tests/test_audit_source_coverage.py
+++ b/tests/test_audit_source_coverage.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import audit_fragile_date_parsing
+from scripts.audit_source_coverage import SourceAuditSession
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HARDENED_AUDITS = (
+    "audit_fragile_date_parsing.py",
+    "audit_wx_numeric_arguments.py",
+    "audit_bytes_text_boundaries.py",
+    "audit_csv_boundaries.py",
+    "audit_utf8_boundaries.py",
+    "audit_dependency_usage.py",
+)
+
+
+class SourceCoverageTests(unittest.TestCase):
+    def test_declared_historical_encoding_is_read_and_parsed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "historique_latin1.py"
+            path.write_bytes(
+                b"# -*- coding: latin-1 -*-\n"
+                b"libelle = 'caf\xe9'\n"
+                b"date_naissance = '01022020'\n"
+                b"jour = int(date_naissance[0:2])\n"
+            )
+
+            session = SourceAuditSession([path])
+            loaded = session.parse(path)
+
+            self.assertIsNotNone(loaded)
+            self.assertTrue(session.coverage.complete)
+            self.assertEqual(session.coverage.found, 1)
+            self.assertEqual(session.coverage.read, 1)
+            self.assertEqual(session.coverage.parsed, 1)
+            _source, tree = loaded
+            self.assertEqual(len(audit_fragile_date_parsing.scan_tree(tree)), 1)
+
+    def test_syntax_error_is_not_silently_counted_as_zero_findings(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "broken.py"
+            path.write_text("def broken(:\n    pass\n", encoding="utf-8")
+
+            session = SourceAuditSession([path])
+            loaded = session.parse(path)
+
+            self.assertIsNone(loaded)
+            self.assertFalse(session.coverage.complete)
+            self.assertEqual(session.coverage.found, 1)
+            self.assertEqual(session.coverage.read, 1)
+            self.assertEqual(session.coverage.parsed, 0)
+            self.assertEqual(session.coverage.failures[0].stage, "parsing")
+
+    def test_undeclared_non_utf8_source_is_an_explicit_read_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "bad_encoding.py"
+            path.write_bytes(b"libelle = 'caf\xe9'\n")
+
+            session = SourceAuditSession([path])
+            loaded = session.parse(path)
+
+            self.assertIsNone(loaded)
+            self.assertFalse(session.coverage.complete)
+            self.assertEqual(session.coverage.found, 1)
+            self.assertEqual(session.coverage.read, 0)
+            self.assertEqual(session.coverage.parsed, 0)
+            self.assertEqual(session.coverage.failures[0].stage, "lecture")
+
+    def test_compatibility_inventory_audits_use_the_shared_coverage_contract(self):
+        scripts = ROOT / "scripts"
+        for filename in HARDENED_AUDITS:
+            with self.subTest(filename=filename):
+                source = (scripts / filename).read_text(encoding="utf-8")
+                self.assertIn("SourceAuditSession", source)
+                self.assertNotIn('errors="replace"', source)
+                self.assertNotIn('errors="ignore"', source)
+                self.assertNotIn("except (OSError, SyntaxError):\n        return []", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problème

Plusieurs inventaires statiques pouvaient lire les sources en UTF-8 avec remplacement puis retourner silencieusement zéro occurrence sur `OSError` / `SyntaxError`. Un fichier historique mal décodé pouvait donc disparaître du périmètre réel de l'audit.

## Correctif

- ajout d'un contrat commun `scripts/audit_source_coverage.py` fondé sur `tokenize.open()` afin de respecter BOM et encodages PEP 263 ;
- comptage explicite `fichiers trouvés = fichiers lus = fichiers parsés` ;
- conservation et affichage de chaque échec de lecture/parsing ;
- code de sortie non nul dès qu'un fichier échappe à l'analyse ;
- migration des inventaires dates fragiles, arguments wx numériques, bytes/texte, CSV, frontières d'encodage et dépendances ;
- tests de non-régression sur source Latin-1 déclarée, source syntaxiquement invalide et source non-UTF-8 non déclarée ;
- garde CI vérifiant que tout `noethys/**/*.py` est effectivement lisible et parsable.

Les occurrences restent informatives. Seule la couverture devient bloquante.

## Suite

Après validation de cette PR, les chiffres des audits historiques doivent être recalculés avant de les considérer comme exhaustifs, puis le peigne fin Noethys peut être relancé sur cette base.