### PR TITLE
Audit — importer les signatures de défauts découvertes dans Teamworks

### DIFF
--- a/noethys/Dlg/DLG_Attestations_fiscales_selection.py
+++ b/noethys/Dlg/DLG_Attestations_fiscales_selection.py
@@ -355,7 +355,7 @@ class CTRL_Options(wx.Panel):
         self.bouton_repertoire.Enable(etat)
 
     def OnBoutonRepertoire(self, event): 
-        if self.ctrl_repertoire.GetValue != "" : 
+        if self.ctrl_repertoire.GetValue() != "" : 
             cheminDefaut = self.ctrl_repertoire.GetValue()
             if os.path.isdir(cheminDefaut) == False :
                 cheminDefaut = ""

--- a/noethys/Dlg/DLG_Export_noethysweb.py
+++ b/noethys/Dlg/DLG_Export_noethysweb.py
@@ -188,7 +188,7 @@ class Dialog(wx.Dialog):
         UTILS_Aide.Aide("")
 
     def OnBoutonRepertoire(self, event):
-        if self.ctrl_repertoire.GetValue != "":
+        if self.ctrl_repertoire.GetValue() != "":
             cheminDefaut = self.ctrl_repertoire.GetValue()
             if os.path.isdir(cheminDefaut) == False :
                 cheminDefaut = ""

--- a/noethys/Dlg/DLG_Sauvegarde.py
+++ b/noethys/Dlg/DLG_Sauvegarde.py
@@ -361,7 +361,7 @@ class CTRL_Parametres(wx.Panel) :
         self.ctrl_email.Enable(etat)
 
     def OnBoutonRepertoire(self, event): 
-        if self.ctrl_repertoire.GetValue != "" : 
+        if self.ctrl_repertoire.GetValue() != "" : 
             cheminDefaut = self.ctrl_repertoire.GetValue()
             if os.path.isdir(cheminDefaut) == False :
                 cheminDefaut = ""

--- a/noethys/Ol/OL_Vacances.py
+++ b/noethys/Ol/OL_Vacances.py
@@ -407,7 +407,7 @@ class Saisie(wx.Dialog):
         return self.ctrl_dateFin.GetDate()      
     
     def OnBoutonOk(self, event):
-        if self.ctrl_nom.GetSelection == -1 :
+        if self.ctrl_nom.GetSelection() == -1 :
             dlg = wx.MessageDialog(self, _(u"Vous devez obligatoirement sélectionner un nom de période !"), _(u"Erreur de saisie"), wx.OK | wx.ICON_EXCLAMATION)
             dlg.ShowModal()
             dlg.Destroy()

--- a/scripts/audit_pre_rc.py
+++ b/scripts/audit_pre_rc.py
@@ -3,12 +3,15 @@
 """Rassemble les inventaires statiques à relire avant de figer une RC.
 
 Ce script ne modifie ni le code ni les bases. Il regroupe en une commande les
-inventaires SQL strict, cycle de vie wxPython et anciens outils de listes afin
-d'éviter trois procédures parallèles et des chiffres recopiés à la main.
+inventaires SQL strict, cycle de vie wxPython, anciens outils de listes et les
+signatures de défauts transverses apprises dans Teamworks.
 
 Avant tout inventaire, il impose le contrat global de couverture des sources :
 tout ``noethys/**/*.py`` doit être trouvé, lu selon son encodage Python et
-parsable. Les occurrences restent ensuite des diagnostics à qualifier.
+parsable. Les occurrences restent ensuite des diagnostics à qualifier. Les
+signatures Teamworks conservent en plus leur propre mesure de couverture sur
+leur périmètre applicatif afin qu'un zéro ne puisse jamais masquer un fichier
+non analysé.
 """
 
 from __future__ import annotations
@@ -26,6 +29,7 @@ if str(ROOT) not in sys.path:
 from scripts import audit_legacy_list_tools  # noqa: E402
 from scripts import audit_source_coverage  # noqa: E402
 from scripts import audit_sql_strict  # noqa: E402
+from scripts import audit_teamworks_signatures  # noqa: E402
 from scripts import audit_wx_lifecycle  # noqa: E402
 
 DEFAULT_ROOT = ROOT / "noethys"
@@ -113,6 +117,9 @@ def collect(root: Path = DEFAULT_ROOT) -> dict:
     legacy_counts = audit_legacy_list_tools.summarize(legacy_findings)
     legacy_screens = audit_legacy_list_tools.screens(legacy_findings)
 
+    teamworks_report = audit_teamworks_signatures.build_report(root)
+    teamworks_coverage = dict(teamworks_report["coverage"])
+
     return {
         "summary": {
             "source_coverage": {
@@ -136,11 +143,18 @@ def collect(root: Path = DEFAULT_ROOT) -> dict:
                 "screens": len(legacy_screens),
                 "counts": legacy_counts,
             },
+            "teamworks_signatures": {
+                "total": teamworks_report["count"],
+                "kinds": dict(teamworks_report["kinds"]),
+                "priorities": dict(teamworks_report["priorities"]),
+                "coverage": teamworks_coverage,
+            },
         },
         "sql_review": sql_review,
         "wx_findings": wx_findings,
         "legacy_findings": legacy_findings,
         "legacy_screens": legacy_screens,
+        "teamworks_findings": list(teamworks_report["findings"]),
     }
 
 
@@ -169,6 +183,13 @@ def write_reports(data: dict, output_dir: Path) -> None:
             "findings": data["legacy_findings"],
         },
     )
+    _write_json(
+        output_dir / "teamworks-signatures-audit.json",
+        {
+            "summary": data["summary"]["teamworks_signatures"],
+            "findings": data["teamworks_findings"],
+        },
+    )
 
 
 def print_summary(data: dict, output_dir: Path) -> None:
@@ -177,6 +198,8 @@ def print_summary(data: dict, output_dir: Path) -> None:
     sql = summary["sql"]
     wx = summary["wx_lifecycle"]
     legacy = summary["legacy_list_tools"]
+    teamworks = summary["teamworks_signatures"]
+    teamworks_coverage = teamworks["coverage"]
 
     print("Inventaires statiques pré-RC")
     print("===========================")
@@ -197,6 +220,16 @@ def print_summary(data: dict, output_dir: Path) -> None:
         "Listes      : %d écran(s) métier encore raccordé(s) aux outils historiques"
         % legacy["screens"]
     )
+    print(
+        "Teamworks   : %d signature(s) — couverture %d/%d/%d — %s"
+        % (
+            teamworks["total"],
+            teamworks_coverage["found"],
+            teamworks_coverage["read"],
+            teamworks_coverage["parsed"],
+            "OK" if teamworks_coverage["complete"] else "ECHEC",
+        )
+    )
     print("Rapports    : %s" % output_dir)
     print("")
     print("Ces nombres sont des inventaires. Corriger uniquement après revue du risque concret.")
@@ -211,13 +244,15 @@ def run(root: Path = DEFAULT_ROOT, output_dir: Path = DEFAULT_OUTPUT) -> dict:
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Regroupe les inventaires SQL/wx/listes à relire avant une RC"
+        description="Regroupe les inventaires SQL/wx/listes/signatures Teamworks à relire avant une RC"
     )
     parser.add_argument("--root", type=Path, default=DEFAULT_ROOT)
     parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT)
     args = parser.parse_args()
 
-    run(args.root, args.output_dir)
+    data = run(args.root, args.output_dir)
+    if not data["summary"]["teamworks_signatures"]["coverage"]["complete"]:
+        return 2
     return 0
 
 

--- a/scripts/audit_semantic_traps.py
+++ b/scripts/audit_semantic_traps.py
@@ -7,6 +7,12 @@ correction ou attribution à l'upstream. Les catégories visent des défauts qui
 échappent facilement à une recherche textuelle simple : état partagé par défaut,
 asymétrie validation/sauvegarde, cycle de vie modal et blocage de la boucle wx.
 La couverture des sources analysées est bloquante.
+
+Pour les valeurs mutables par défaut, la priorité haute est réservée aux cas où
+la valeur partagée peut réellement être modifiée. Les motifs qui réaffectent le
+paramètre avant mutation, trient seulement un conteneur vide ou échouent sur une
+lecture obligatoire avant toute mutation sont conservés comme signaux qualifiés
+faibles au lieu d'être présentés comme des défauts confirmés.
 """
 
 from __future__ import annotations
@@ -30,6 +36,10 @@ MUTATING_METHODS = {
     "update", "setdefault", "add", "discard", "difference_update",
     "intersection_update", "symmetric_difference_update",
 }
+EMPTY_DEFAULT_NON_GROWING_METHODS = {
+    "remove", "pop", "clear", "sort", "reverse", "discard",
+    "difference_update", "intersection_update",
+}
 UI_CALLBACK_PREFIXES = ("On", "Timer", "Handle", "Traitement", "Refresh", "MAJ")
 
 
@@ -41,36 +51,198 @@ def iter_python_files(root=NOETHYS):
         yield path
 
 
-def _mutable_default_names(function):
+def _mutable_defaults(function):
     positional = list(function.args.posonlyargs) + list(function.args.args)
     defaults = [None] * (len(positional) - len(function.args.defaults)) + list(function.args.defaults)
     pairs = list(zip(positional, defaults))
     pairs.extend(zip(function.args.kwonlyargs, function.args.kw_defaults))
     result = {}
     for arg, default in pairs:
-        if isinstance(default, (ast.List, ast.Dict, ast.Set)):
-            result[arg.arg] = type(default).__name__.lower()
+        if isinstance(default, ast.List):
+            result[arg.arg] = {"type": "list", "empty": len(default.elts) == 0}
+        elif isinstance(default, ast.Dict):
+            result[arg.arg] = {"type": "dict", "empty": len(default.keys) == 0}
+        elif isinstance(default, ast.Set):
+            result[arg.arg] = {"type": "set", "empty": len(default.elts) == 0}
     return result
 
 
-def _name_is_mutated(function, name):
-    for node in ast.walk(function):
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
-            if isinstance(node.func.value, ast.Name) and node.func.value.id == name and node.func.attr in MUTATING_METHODS:
-                return True, node.lineno, node.func.attr
-        if isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign, ast.Delete)):
-            if isinstance(node, ast.Assign):
-                targets = node.targets
-            elif isinstance(node, ast.AnnAssign):
-                targets = [node.target]
-            elif isinstance(node, ast.AugAssign):
-                targets = [node.target]
-            else:
-                targets = node.targets
-            for target in targets:
-                if isinstance(target, ast.Subscript) and isinstance(target.value, ast.Name) and target.value.id == name:
-                    return True, node.lineno, "item_mutation"
-    return False, 0, ""
+def _target_rebinds_name(target, name):
+    if isinstance(target, ast.Name):
+        return target.id == name
+    if isinstance(target, (ast.Tuple, ast.List)):
+        return any(_target_rebinds_name(item, name) for item in target.elts)
+    return False
+
+
+def _top_level_rebind_before(function, name, line):
+    """Vrai si un statement séquentiel réaffecte le paramètre avant ``line``.
+
+    Une affectation située dans un ``if``/``try`` n'est volontairement pas
+    considérée comme garantie : il peut rester un chemin qui conserve la valeur
+    par défaut partagée.
+    """
+    for statement in function.body:
+        if getattr(statement, "lineno", line) >= line:
+            break
+        if isinstance(statement, ast.Assign):
+            if any(_target_rebinds_name(target, name) for target in statement.targets):
+                return True
+        elif isinstance(statement, ast.AnnAssign):
+            if _target_rebinds_name(statement.target, name):
+                return True
+    return False
+
+
+def _subscript_loads_name(node, name):
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Subscript) or not isinstance(child.ctx, ast.Load):
+            continue
+        if isinstance(child.value, ast.Name) and child.value.id == name:
+            return True
+    return False
+
+
+def _required_top_level_subscript_read_before(function, name, line):
+    """Repère une lecture ``name[...]`` séquentielle avant la mutation.
+
+    On ne descend pas dans les structures de contrôle : une lecture dans un
+    chemin conditionnel ne prouve pas que l'appel avec la valeur vide échoue
+    avant la mutation. Les statements simples, eux, sont exécutés sur tout
+    chemin qui atteint le statement suivant.
+    """
+    control_statements = (
+        ast.If, ast.For, ast.AsyncFor, ast.While, ast.Try,
+        ast.With, ast.AsyncWith,
+    )
+    if hasattr(ast, "Match"):
+        control_statements = control_statements + (ast.Match,)
+
+    for statement in function.body:
+        if getattr(statement, "lineno", line) >= line:
+            break
+        if isinstance(statement, control_statements):
+            continue
+        if _subscript_loads_name(statement, name):
+            return True
+    return False
+
+
+class _MutationVisitor(ast.NodeVisitor):
+    def __init__(self, name):
+        self.name = name
+        self.events = []
+
+    def _record(self, node, operation):
+        self.events.append((node.lineno, getattr(node, "col_offset", 0), operation, node))
+
+    def visit_Call(self, node):
+        if isinstance(node.func, ast.Attribute):
+            owner = node.func.value
+            if isinstance(owner, ast.Name) and owner.id == self.name and node.func.attr in MUTATING_METHODS:
+                self._record(node, node.func.attr)
+        self.generic_visit(node)
+
+    def visit_Assign(self, node):
+        for target in node.targets:
+            if isinstance(target, ast.Subscript) and isinstance(target.value, ast.Name) and target.value.id == self.name:
+                operation = "slice_mutation" if isinstance(target.slice, ast.Slice) else "item_mutation"
+                self._record(node, operation)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node):
+        target = node.target
+        if isinstance(target, ast.Subscript) and isinstance(target.value, ast.Name) and target.value.id == self.name:
+            operation = "slice_mutation" if isinstance(target.slice, ast.Slice) else "item_mutation"
+            self._record(node, operation)
+        self.generic_visit(node)
+
+    def visit_AugAssign(self, node):
+        target = node.target
+        if isinstance(target, ast.Name) and target.id == self.name:
+            self._record(node, "augassign")
+        elif isinstance(target, ast.Subscript) and isinstance(target.value, ast.Name) and target.value.id == self.name:
+            operation = "slice_mutation" if isinstance(target.slice, ast.Slice) else "item_mutation"
+            self._record(node, operation)
+        self.generic_visit(node)
+
+    def visit_Delete(self, node):
+        for target in node.targets:
+            if isinstance(target, ast.Subscript) and isinstance(target.value, ast.Name) and target.value.id == self.name:
+                self._record(node, "item_mutation")
+        self.generic_visit(node)
+
+    # Les noms identiques dans un scope imbriqué ne désignent pas le paramètre.
+    def visit_FunctionDef(self, node):
+        return
+
+    def visit_AsyncFunctionDef(self, node):
+        return
+
+    def visit_Lambda(self, node):
+        return
+
+    def visit_ClassDef(self, node):
+        return
+
+
+def _mutation_events(function, name):
+    visitor = _MutationVisitor(name)
+    for statement in function.body:
+        visitor.visit(statement)
+    return sorted(visitor.events, key=lambda item: (item[0], item[1]))
+
+
+def _classify_mutable_default(function, name, default_info):
+    """Retourne le signal le plus sévère concernant une valeur par défaut.
+
+    Un résultat ``mutable_default_mutated`` signifie que l'appel sans argument
+    peut réellement altérer l'objet créé lors de la définition de la fonction.
+    Les motifs prouvés inertes ou détachés de cet objet restent visibles en
+    ``mutable_default_qualified`` avec priorité basse.
+    """
+    qualified = None
+    for line, _col, operation, _node in _mutation_events(function, name):
+        if _top_level_rebind_before(function, name, line):
+            if qualified is None:
+                qualified = (line, "rebound_before_mutation")
+            continue
+
+        if default_info["empty"] and operation in EMPTY_DEFAULT_NON_GROWING_METHODS:
+            if qualified is None:
+                qualified = (line, "empty_default_non_growing:%s" % operation)
+            continue
+
+        if (
+            default_info["empty"]
+            and default_info["type"] == "dict"
+            and operation == "item_mutation"
+            and _required_top_level_subscript_read_before(function, name, line)
+        ):
+            if qualified is None:
+                qualified = (line, "empty_default_fails_before_mutation")
+            continue
+
+        if default_info["empty"] and default_info["type"] == "list" and operation == "item_mutation":
+            if qualified is None:
+                qualified = (line, "empty_list_item_mutation_requires_existing_item")
+            continue
+
+        return {
+            "kind": "mutable_default_mutated",
+            "priority": "high",
+            "line": line,
+            "detail": operation,
+        }
+
+    if qualified is not None:
+        return {
+            "kind": "mutable_default_qualified",
+            "priority": "low",
+            "line": qualified[0],
+            "detail": qualified[1],
+        }
+    return None
 
 
 def _name_escapes(function, name):
@@ -141,19 +313,16 @@ def _scan_loaded(source, tree, path, root=NOETHYS):
     findings = []
 
     for function in (node for node in ast.walk(tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))):
-        for name, default_type in _mutable_default_names(function).items():
-            mutated, line, operation = _name_is_mutated(function, name)
+        for name, default_info in _mutable_defaults(function).items():
+            mutable_finding = _classify_mutable_default(function, name, default_info)
             escapes, return_line = _name_escapes(function, name)
-            if mutated:
+            if mutable_finding is not None:
                 findings.append({
-                    "kind": "mutable_default_mutated",
-                    "priority": "high",
+                    **mutable_finding,
                     "file": rel,
                     "function": function.name,
-                    "line": line,
                     "parameter": name,
-                    "default_type": default_type,
-                    "detail": operation,
+                    "default_type": default_info["type"],
                 })
             elif escapes:
                 findings.append({
@@ -163,23 +332,23 @@ def _scan_loaded(source, tree, path, root=NOETHYS):
                     "function": function.name,
                     "line": return_line,
                     "parameter": name,
-                    "default_type": default_type,
+                    "default_type": default_info["type"],
                     "detail": "returned_directly",
                 })
 
         validations = _attribute_calls(function, "Validation")
         saves = {name for name, _line in _attribute_calls(function, "Sauvegarde")}
-        if validations and function.name.lower() in {"onboutonok", "onboutonvalider", "valider", "sauvegarder", "sauvegarde"}:
+        if validations and any(control in saves for control, _line in validations) and function.name.lower() in {"onboutonok", "onboutonvalider", "valider", "sauvegarder", "sauvegarde"}:
             for control, line in validations:
                 if control not in saves:
                     findings.append({
-                        "kind": "validation_without_save",
-                        "priority": "high",
+                        "kind": "validation_save_mixed_api",
+                        "priority": "low",
                         "file": rel,
                         "function": function.name,
                         "line": line,
                         "control": control,
-                        "detail": "Validation() sans Sauvegarde() dans le même chemin de confirmation",
+                        "detail": "contrôles hétérogènes : Validation() et Sauvegarde() ne prouvent pas un contrat de persistance commun",
                     })
 
         for name, create_line in _assigned_dialog_names(function).items():

--- a/scripts/audit_teamworks_signatures.py
+++ b/scripts/audit_teamworks_signatures.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Recherche dans Noethys des familles de défauts révélées par Teamworks.
+
+L'objectif n'est pas de copier les correctifs Teamworks, mais de transformer
+chaque classe de défaut reproductible en signature AST réutilisable. Les
+signatures de ce premier lot sont volontairement à forte confiance :
+
+- compréhension exécutée dans un corps de classe qui lit un nom défini plus
+  haut dans cette même classe depuis la portée interne de la compréhension ;
+- accesseur wx/contrôle testé ou comparé comme objet méthode au lieu d'être
+  appelé ;
+- ancien appel ``Thread.isAlive()`` retiré du runtime Python moderne.
+
+La lecture/parsing passe obligatoirement par ``SourceAuditSession`` : un fichier
+qui échappe à l'analyse invalide la couverture et produit un code de sortie 2.
+Les occurrences restent un inventaire tant qu'elles n'ont pas été qualifiées.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.audit_source_coverage import SourceAuditSession, iter_python_files  # noqa: E402
+
+NOETHYS = ROOT / "noethys"
+EXCLUDED_PARTS = {"ObjectListView", "Outils"}
+ACCESSOR_METHODS = {
+    "GetValue",
+    "GetSelection",
+    "GetStringSelection",
+    "GetLabel",
+    "GetPath",
+    "GetFilename",
+}
+
+
+def iter_application_files(root: Path = NOETHYS):
+    root = Path(root)
+    for path in iter_python_files(root):
+        try:
+            relative = path.relative_to(root)
+        except ValueError:
+            continue
+        if any(part in EXCLUDED_PARTS for part in relative.parts):
+            continue
+        yield path
+
+
+def _target_names(target: ast.AST) -> set[str]:
+    names = set()
+    for node in ast.walk(target):
+        if isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
+            names.add(node.id)
+    return names
+
+
+def _statement_definitions(statement: ast.stmt) -> set[str]:
+    if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        return {statement.name}
+    if isinstance(statement, ast.Assign):
+        result = set()
+        for target in statement.targets:
+            result.update(_target_names(target))
+        return result
+    if isinstance(statement, ast.AnnAssign):
+        return _target_names(statement.target)
+    if isinstance(statement, ast.AugAssign):
+        return _target_names(statement.target)
+    if isinstance(statement, (ast.Import, ast.ImportFrom)):
+        return {alias.asname or alias.name.split(".")[0] for alias in statement.names}
+    return set()
+
+
+class _ComprehensionsInClassStatement(ast.NodeVisitor):
+    """Visite les expressions d'un statement de classe sans entrer dans un scope imbriqué."""
+
+    def __init__(self):
+        self.nodes = []
+
+    def visit_ListComp(self, node):
+        self.nodes.append(node)
+        self.generic_visit(node)
+
+    def visit_SetComp(self, node):
+        self.nodes.append(node)
+        self.generic_visit(node)
+
+    def visit_DictComp(self, node):
+        self.nodes.append(node)
+        self.generic_visit(node)
+
+    def visit_GeneratorExp(self, node):
+        self.nodes.append(node)
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node):
+        return
+
+    def visit_AsyncFunctionDef(self, node):
+        return
+
+    def visit_Lambda(self, node):
+        return
+
+    def visit_ClassDef(self, node):
+        return
+
+
+def _loaded_names(node: ast.AST) -> set[str]:
+    return {
+        child.id
+        for child in ast.walk(node)
+        if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Load)
+    }
+
+
+def _comprehension_inner_loads(node: ast.AST) -> set[str]:
+    """Noms non liés lus dans la portée interne d'une compréhension Python 3.
+
+    L'itérable du premier générateur est évalué dans la portée englobante. Une
+    fois entré dans la portée implicite de la compréhension, chaque cible de
+    générateur masque un éventuel nom homonyme défini dans le corps de classe.
+    On respecte cet ordre de liaison pour éviter de prendre une variable locale
+    de compréhension pour un accès impossible au namespace de classe.
+    """
+    generators = list(node.generators)
+    bound = set()
+    result = set()
+
+    for index, generator in enumerate(generators):
+        if index > 0:
+            result.update(_loaded_names(generator.iter) - bound)
+
+        bound.update(_target_names(generator.target))
+        for condition in generator.ifs:
+            result.update(_loaded_names(condition) - bound)
+
+    if isinstance(node, ast.DictComp):
+        payload = [node.key, node.value]
+    else:
+        payload = [node.elt]
+
+    for part in payload:
+        result.update(_loaded_names(part) - bound)
+    return result
+
+
+def _scan_class_comprehensions(tree: ast.AST, relpath: str) -> list[dict]:
+    findings = []
+    for class_node in (node for node in ast.walk(tree) if isinstance(node, ast.ClassDef)):
+        defined = set()
+        for statement in class_node.body:
+            visitor = _ComprehensionsInClassStatement()
+            visitor.visit(statement)
+            for comprehension in visitor.nodes:
+                trapped = sorted(defined & _comprehension_inner_loads(comprehension))
+                for name in trapped:
+                    findings.append(
+                        {
+                            "kind": "class_comprehension_scope",
+                            "priority": "high",
+                            "file": relpath,
+                            "line": comprehension.lineno,
+                            "class": class_node.name,
+                            "name": name,
+                            "detail": "nom de classe lu depuis la portée interne d'une compréhension Python 3",
+                        }
+                    )
+            defined.update(_statement_definitions(statement))
+    return findings
+
+
+def _accessor_attribute(expr: ast.AST):
+    if isinstance(expr, ast.Attribute) and expr.attr in ACCESSOR_METHODS:
+        return expr
+    return None
+
+
+def _iter_boolean_operands(expr: ast.AST):
+    if isinstance(expr, ast.BoolOp):
+        for value in expr.values:
+            yield from _iter_boolean_operands(value)
+    elif isinstance(expr, ast.UnaryOp) and isinstance(expr.op, ast.Not):
+        yield expr.operand
+    else:
+        yield expr
+
+
+def _scan_uninvoked_accessors(tree: ast.AST, relpath: str) -> list[dict]:
+    findings = []
+    seen = set()
+
+    def add(node: ast.Attribute, context: str):
+        key = (node.lineno, node.col_offset, node.attr, context)
+        if key in seen:
+            return
+        seen.add(key)
+        findings.append(
+            {
+                "kind": "accessor_not_called",
+                "priority": "high",
+                "file": relpath,
+                "line": node.lineno,
+                "accessor": node.attr,
+                "detail": context,
+            }
+        )
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Compare):
+            for operand in [node.left, *node.comparators]:
+                accessor = _accessor_attribute(operand)
+                if accessor is not None:
+                    add(accessor, "accesseur comparé sans appel")
+        elif isinstance(node, (ast.If, ast.While, ast.Assert)):
+            for operand in _iter_boolean_operands(node.test):
+                accessor = _accessor_attribute(operand)
+                if accessor is not None:
+                    add(accessor, "accesseur utilisé comme booléen sans appel")
+        elif isinstance(node, ast.IfExp):
+            for operand in _iter_boolean_operands(node.test):
+                accessor = _accessor_attribute(operand)
+                if accessor is not None:
+                    add(accessor, "accesseur utilisé comme condition sans appel")
+
+    return findings
+
+
+def _scan_is_alive(tree: ast.AST, relpath: str) -> list[dict]:
+    findings = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr != "isAlive":
+            continue
+        findings.append(
+            {
+                "kind": "thread_isAlive",
+                "priority": "high",
+                "file": relpath,
+                "line": node.lineno,
+                "detail": "API Thread.isAlive() obsolète ; utiliser is_alive()",
+            }
+        )
+    return findings
+
+
+def scan_tree(tree: ast.AST, relpath: str = "<memory>") -> list[dict]:
+    findings = []
+    findings.extend(_scan_class_comprehensions(tree, relpath))
+    findings.extend(_scan_uninvoked_accessors(tree, relpath))
+    findings.extend(_scan_is_alive(tree, relpath))
+    findings.sort(key=lambda item: (item["file"], item["line"], item["kind"]))
+    return findings
+
+
+def build_report(root: Path = NOETHYS) -> dict:
+    root = Path(root)
+    session = SourceAuditSession(iter_application_files(root))
+    findings = []
+
+    for path in session.paths:
+        loaded = session.parse(path)
+        if loaded is None:
+            continue
+        _source, tree = loaded
+        relpath = path.relative_to(root).as_posix()
+        findings.extend(scan_tree(tree, relpath))
+
+    findings.sort(key=lambda item: (item["priority"] != "high", item["kind"], item["file"], item["line"]))
+    return {
+        "coverage": {
+            "found": session.coverage.found,
+            "read": session.coverage.read,
+            "parsed": session.coverage.parsed,
+            "complete": session.coverage.complete,
+            "failures": [failure.format() for failure in session.coverage.failures],
+        },
+        "count": len(findings),
+        "kinds": dict(Counter(item["kind"] for item in findings)),
+        "priorities": dict(Counter(item["priority"] for item in findings)),
+        "findings": findings,
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=NOETHYS)
+    parser.add_argument("--json", default="", metavar="FILE")
+    parser.add_argument("--fail-on-high", action="store_true")
+    args = parser.parse_args(argv)
+
+    report = build_report(args.root)
+    coverage = report["coverage"]
+    print(
+        "TEAMWORKS_SIGNATURES=%d — %s — couverture %d/%d/%d"
+        % (
+            report["count"],
+            report["kinds"],
+            coverage["found"],
+            coverage["read"],
+            coverage["parsed"],
+        )
+    )
+    for item in report["findings"]:
+        print("- {priority} {kind} {file}:{line} — {detail}".format(**item))
+    for failure in coverage["failures"]:
+        print("ERREUR AUDIT: %s" % failure)
+
+    if args.json:
+        output = Path(args.json)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    if not coverage["complete"]:
+        return 2
+    if args.fail_on_high and report["priorities"].get("high", 0):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_audit_pre_rc.py
+++ b/tests/test_audit_pre_rc.py
@@ -11,6 +11,28 @@ from unittest import mock
 from scripts import audit_pre_rc
 
 
+def _teamworks_report(findings=None, *, complete=True):
+    findings = list(findings or [])
+    kinds = {}
+    priorities = {}
+    for item in findings:
+        kinds[item["kind"]] = kinds.get(item["kind"], 0) + 1
+        priorities[item["priority"]] = priorities.get(item["priority"], 0) + 1
+    return {
+        "coverage": {
+            "found": 2,
+            "read": 2 if complete else 1,
+            "parsed": 2 if complete else 1,
+            "complete": complete,
+            "failures": [] if complete else ["fixture.py: lecture: UnicodeDecodeError: test"],
+        },
+        "count": len(findings),
+        "kinds": kinds,
+        "priorities": priorities,
+        "findings": findings,
+    }
+
+
 class AuditPreRcTests(unittest.TestCase):
     def test_collect_and_write_reports_keep_inventories_separate(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -63,10 +85,24 @@ class AuditPreRcTests(unittest.TestCase):
                     "text": "CTRL_ObjectListView.CTRL_Outils",
                 }
             ]
+            teamworks_items = [
+                {
+                    "kind": "accessor_not_called",
+                    "priority": "high",
+                    "file": "Dlg/DLG_Test.py",
+                    "line": 42,
+                    "detail": "accesseur comparé sans appel",
+                }
+            ]
 
             with mock.patch.object(audit_pre_rc.audit_sql_strict, "scan", return_value=sql_items), \
                     mock.patch.object(audit_pre_rc.audit_wx_lifecycle, "scan", return_value=wx_items), \
-                    mock.patch.object(audit_pre_rc.audit_legacy_list_tools, "scan", return_value=legacy_items):
+                    mock.patch.object(audit_pre_rc.audit_legacy_list_tools, "scan", return_value=legacy_items), \
+                    mock.patch.object(
+                        audit_pre_rc.audit_teamworks_signatures,
+                        "build_report",
+                        return_value=_teamworks_report(teamworks_items),
+                    ):
                 data = audit_pre_rc.run(root, output)
 
             self.assertEqual(data["summary"]["sql"]["REVIEW"], 1)
@@ -82,16 +118,21 @@ class AuditPreRcTests(unittest.TestCase):
                 1,
             )
             self.assertEqual(data["summary"]["legacy_list_tools"]["screens"], 1)
+            self.assertEqual(data["summary"]["teamworks_signatures"]["total"], 1)
+            self.assertTrue(data["summary"]["teamworks_signatures"]["coverage"]["complete"])
 
             summary = json.loads((output / "pre-rc-summary.json").read_text(encoding="utf-8"))
             sql_report = json.loads((output / "sql-strict-review.json").read_text(encoding="utf-8"))
             wx_report = json.loads((output / "wx-lifecycle-audit.json").read_text(encoding="utf-8"))
             legacy_report = json.loads((output / "legacy-list-tools-audit.json").read_text(encoding="utf-8"))
+            teamworks_report = json.loads((output / "teamworks-signatures-audit.json").read_text(encoding="utf-8"))
 
             self.assertEqual(summary["sql"]["REVIEW"], 1)
+            self.assertEqual(summary["teamworks_signatures"]["total"], 1)
             self.assertEqual(len(sql_report["findings"]), 1)
             self.assertEqual(len(wx_report["findings"]), 3)
             self.assertEqual(legacy_report["screens"], ["noethys/Ol/OL_Test.py"])
+            self.assertEqual(teamworks_report["findings"], teamworks_items)
 
     def test_high_risk_wx_categories_are_explicit_even_when_zero(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -100,7 +141,12 @@ class AuditPreRcTests(unittest.TestCase):
 
             with mock.patch.object(audit_pre_rc.audit_sql_strict, "scan", return_value=[]), \
                     mock.patch.object(audit_pre_rc.audit_wx_lifecycle, "scan", return_value=[]), \
-                    mock.patch.object(audit_pre_rc.audit_legacy_list_tools, "scan", return_value=[]):
+                    mock.patch.object(audit_pre_rc.audit_legacy_list_tools, "scan", return_value=[]), \
+                    mock.patch.object(
+                        audit_pre_rc.audit_teamworks_signatures,
+                        "build_report",
+                        return_value=_teamworks_report([]),
+                    ):
                 data = audit_pre_rc.collect(root)
 
             self.assertEqual(
@@ -111,6 +157,28 @@ class AuditPreRcTests(unittest.TestCase):
                     "use_after_destroy": 0,
                 },
             )
+            self.assertEqual(data["summary"]["teamworks_signatures"]["total"], 0)
+            self.assertTrue(data["summary"]["teamworks_signatures"]["coverage"]["complete"])
+
+    def test_teamworks_signature_coverage_failure_is_preserved(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "noethys"
+            root.mkdir()
+
+            with mock.patch.object(audit_pre_rc.audit_sql_strict, "scan", return_value=[]), \
+                    mock.patch.object(audit_pre_rc.audit_wx_lifecycle, "scan", return_value=[]), \
+                    mock.patch.object(audit_pre_rc.audit_legacy_list_tools, "scan", return_value=[]), \
+                    mock.patch.object(
+                        audit_pre_rc.audit_teamworks_signatures,
+                        "build_report",
+                        return_value=_teamworks_report([], complete=False),
+                    ):
+                data = audit_pre_rc.collect(root)
+
+            coverage = data["summary"]["teamworks_signatures"]["coverage"]
+            self.assertFalse(coverage["complete"])
+            self.assertEqual(coverage["found"], 2)
+            self.assertEqual(coverage["parsed"], 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_semantic_traps_audit.py
+++ b/tests/test_semantic_traps_audit.py
@@ -11,11 +11,19 @@ from scripts import audit_semantic_traps as audit
 
 
 class SemanticTrapsAuditTests(unittest.TestCase):
+    _repository_report = None
+
     def report_for(self, source):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             (root / "sample.py").write_text(textwrap.dedent(source), encoding="utf-8")
             return audit.build_report(root)
+
+    @classmethod
+    def repository_report(cls):
+        if cls._repository_report is None:
+            cls._repository_report = audit.build_report()
+        return cls._repository_report
 
     def test_mutated_mutable_default_is_high_priority(self):
         report = self.report_for('''
@@ -25,6 +33,87 @@ class SemanticTrapsAuditTests(unittest.TestCase):
         self.assertEqual(report["findings"][0]["kind"], "mutable_default_mutated")
         self.assertEqual(report["findings"][0]["priority"], "high")
 
+    def test_empty_dict_item_assignment_is_high_priority(self):
+        report = self.report_for('''
+            def f(values={}):
+                values["x"] = 1
+        ''')
+        self.assertEqual(report["findings"][0]["kind"], "mutable_default_mutated")
+        self.assertEqual(report["findings"][0]["detail"], "item_mutation")
+
+    def test_slice_assignment_can_mutate_empty_shared_default(self):
+        report = self.report_for('''
+            def f(items=[]):
+                items[:] = [1]
+        ''')
+        finding = report["findings"][0]
+        self.assertEqual(finding["kind"], "mutable_default_mutated")
+        self.assertEqual(finding["priority"], "high")
+
+    def test_slice_augassign_can_mutate_empty_shared_default(self):
+        report = self.report_for('''
+            def f(items=[]):
+                items[:] += [1]
+        ''')
+        finding = report["findings"][0]
+        self.assertEqual(finding["kind"], "mutable_default_mutated")
+        self.assertEqual(finding["priority"], "high")
+        self.assertEqual(finding["detail"], "slice_mutation")
+
+    def test_rebind_before_append_does_not_mutate_shared_default(self):
+        report = self.report_for('''
+            def f(items=[]):
+                items = []
+                items.append(1)
+                return len(items)
+        ''')
+        finding = report["findings"][0]
+        self.assertEqual(finding["kind"], "mutable_default_qualified")
+        self.assertEqual(finding["priority"], "low")
+        self.assertEqual(finding["detail"], "rebound_before_mutation")
+
+    def test_sorting_empty_default_is_qualified_not_high(self):
+        report = self.report_for('''
+            def f(items=[]):
+                items.sort()
+        ''')
+        finding = report["findings"][0]
+        self.assertEqual(finding["kind"], "mutable_default_qualified")
+        self.assertEqual(finding["priority"], "low")
+        self.assertEqual(finding["detail"], "empty_default_non_growing:sort")
+
+    def test_sorting_nonempty_default_remains_high(self):
+        report = self.report_for('''
+            def f(items=[2, 1]):
+                items.sort()
+        ''')
+        finding = report["findings"][0]
+        self.assertEqual(finding["kind"], "mutable_default_mutated")
+        self.assertEqual(finding["priority"], "high")
+
+    def test_required_dict_read_before_item_mutation_is_qualified(self):
+        report = self.report_for('''
+            def f(values={}):
+                category = values["category"]
+                values["label"] = category.upper()
+                return values
+        ''')
+        finding = report["findings"][0]
+        self.assertEqual(finding["kind"], "mutable_default_qualified")
+        self.assertEqual(finding["priority"], "low")
+        self.assertEqual(finding["detail"], "empty_default_fails_before_mutation")
+
+    def test_conditional_rebind_does_not_hide_shared_default_mutation(self):
+        report = self.report_for('''
+            def f(flag, items=[]):
+                if flag:
+                    items = []
+                items.append(1)
+        ''')
+        finding = report["findings"][0]
+        self.assertEqual(finding["kind"], "mutable_default_mutated")
+        self.assertEqual(finding["priority"], "high")
+
     def test_directly_returned_mutable_default_is_visible(self):
         report = self.report_for('''
             def f(items=[]):
@@ -32,7 +121,34 @@ class SemanticTrapsAuditTests(unittest.TestCase):
         ''')
         self.assertEqual(report["findings"][0]["kind"], "mutable_default_escape")
 
-    def test_validation_save_asymmetry_is_detected(self):
+    def test_validation_only_dialog_is_not_a_save_asymmetry(self):
+        report = self.report_for('''
+            class Dialog:
+                def OnBoutonOk(self):
+                    if self.ctrl_date.Validation() is False:
+                        return False
+                    self.EndModal(1)
+
+                def GetDate(self):
+                    return self.ctrl_date.GetDate()
+        ''')
+        findings = [item for item in report["findings"] if item["kind"] == "validation_without_save"]
+        self.assertEqual(findings, [])
+
+    def test_unrelated_saved_component_does_not_create_false_asymmetry(self):
+        report = self.report_for('''
+            class Dialog:
+                def OnBoutonOk(self):
+                    if self.ctrl_date.Validation() is False:
+                        return False
+                    value = self.ctrl_date.GetDate()
+                    self.ctrl_repas.Sauvegarde()
+                    return value
+        ''')
+        findings = [item for item in report["findings"] if item["kind"] == "validation_save_mixed_api"]
+        self.assertEqual(findings, [])
+
+    def test_mixed_validation_save_contract_is_informational(self):
         report = self.report_for('''
             class Dialog:
                 def OnBoutonOk(self):
@@ -40,8 +156,9 @@ class SemanticTrapsAuditTests(unittest.TestCase):
                     self.ctrl_b.Validation()
                     self.ctrl_a.Sauvegarde()
         ''')
-        findings = [item for item in report["findings"] if item["kind"] == "validation_without_save"]
+        findings = [item for item in report["findings"] if item["kind"] == "validation_save_mixed_api"]
         self.assertEqual([item["control"] for item in findings], ["ctrl_b"])
+        self.assertEqual(findings[0]["priority"], "low")
 
     def test_modal_without_destroy_is_detected(self):
         report = self.report_for('''
@@ -52,8 +169,38 @@ class SemanticTrapsAuditTests(unittest.TestCase):
         ''')
         self.assertTrue(any(item["kind"] == "modal_without_destroy" for item in report["findings"]))
 
+    def test_repository_has_no_high_priority_shared_mutable_default(self):
+        report = self.repository_report()
+        findings = [
+            item
+            for item in report["findings"]
+            if item["kind"] == "mutable_default_mutated" and item["priority"] == "high"
+        ]
+        self.assertEqual(
+            findings,
+            [],
+            "Valeurs mutables réellement partagées à qualifier:\n"
+            + "\n".join(
+                "{file}:{line} {function}({parameter}) — {detail}".format(**item)
+                for item in findings
+            ),
+        )
+
+    def test_repository_has_no_high_priority_semantic_trap(self):
+        report = self.repository_report()
+        findings = [item for item in report["findings"] if item["priority"] == "high"]
+        self.assertEqual(
+            findings,
+            [],
+            "Pièges sémantiques à priorité haute à qualifier:\n"
+            + "\n".join(
+                "{kind} {file}:{line} {function}".format(**item)
+                for item in findings
+            ),
+        )
+
     def test_repository_inventory_is_exported(self):
-        report = audit.build_report()
+        report = self.repository_report()
         output = Path("tmp/semantic-traps-audit.json")
         output.parent.mkdir(parents=True, exist_ok=True)
         output.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")

--- a/tests/test_teamworks_derived_signatures.py
+++ b/tests/test_teamworks_derived_signatures.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+
+from scripts import audit_teamworks_signatures
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class TeamworksDerivedSignatureTests(unittest.TestCase):
+    def scan(self, source):
+        return audit_teamworks_signatures.scan_tree(ast.parse(source), "fixture.py")
+
+    def test_class_comprehension_reading_class_local_is_detected(self):
+        findings = self.scan(
+            "class Dialog:\n"
+            "    LABELS = {'dark': 'Sombre'}\n"
+            "    MODES = ['dark']\n"
+            "    APPEARANCES = [(key, LABELS[key]) for key in MODES]\n"
+        )
+        self.assertEqual(
+            [(item["kind"], item.get("name")) for item in findings],
+            [("class_comprehension_scope", "LABELS")],
+        )
+
+    def test_first_comprehension_iterable_may_read_class_local(self):
+        findings = self.scan(
+            "class Dialog:\n"
+            "    MODES = ['dark']\n"
+            "    APPEARANCES = [key.upper() for key in MODES]\n"
+        )
+        self.assertEqual(findings, [])
+
+    def test_comprehension_target_shadows_same_named_class_attribute(self):
+        findings = self.scan(
+            "class Example:\n"
+            "    value = 10\n"
+            "    values = [value for value in range(3)]\n"
+        )
+        self.assertEqual(findings, [])
+
+    def test_previous_generator_target_is_local_in_next_iterable(self):
+        findings = self.scan(
+            "class Example:\n"
+            "    item = 'class value'\n"
+            "    pairs = [(item, child) for item in range(3) for child in (item,)]\n"
+        )
+        self.assertEqual(findings, [])
+
+    def test_accessors_compared_without_call_are_detected(self):
+        findings = self.scan(
+            "def check(ctrl):\n"
+            "    if ctrl.GetValue == 'x':\n"
+            "        return True\n"
+            "    if not ctrl.GetSelection:\n"
+            "        return False\n"
+        )
+        self.assertEqual(
+            [item["kind"] for item in findings],
+            ["accessor_not_called", "accessor_not_called"],
+        )
+
+    def test_called_accessors_are_not_reported(self):
+        findings = self.scan(
+            "def check(ctrl):\n"
+            "    if ctrl.GetValue() == 'x':\n"
+            "        return ctrl.GetSelection() >= 0\n"
+        )
+        self.assertEqual(findings, [])
+
+    def test_thread_is_alive_legacy_spelling_is_detected(self):
+        findings = self.scan(
+            "def stop(thread):\n"
+            "    if thread.isAlive():\n"
+            "        return False\n"
+        )
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["kind"], "thread_isAlive")
+
+    def test_current_noethys_tree_has_no_high_confidence_teamworks_signature(self):
+        report = audit_teamworks_signatures.build_report(ROOT / "noethys")
+        self.assertTrue(report["coverage"]["complete"], report["coverage"])
+        self.assertEqual(
+            report["priorities"].get("high", 0),
+            0,
+            "Signatures Teamworks à qualifier dans Noethys:\n"
+            + "\n".join(
+                "{kind} {file}:{line} — {detail}".format(**item)
+                for item in report["findings"]
+                if item["priority"] == "high"
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
S'appuie sur le contrat de couverture exhaustive désormais intégré à `master` via la PR #216 : toute nouvelle famille de défaut découverte dans Teamworks devient immédiatement une signature recherchée dans Noethys.

## Signatures importées

- portée des compréhensions dans un corps de classe sous Python 3 ;
- accesseurs wx/contrôles comparés ou testés sans être appelés ;
- appel obsolète `Thread.isAlive()`.

Un fichier non lu ou non parsé invalide l'inventaire.

## Résultat concret du premier passage

Le premier lancement a retrouvé **4 défauts réels** dans Noethys :

- `DLG_Attestations_fiscales_selection.py` : `GetValue` comparé sans `()` ;
- `DLG_Export_noethysweb.py` : `GetValue` comparé sans `()` ;
- `DLG_Sauvegarde.py` : `GetValue` comparé sans `()` ;
- `OL_Vacances.py` : `GetSelection` comparé sans `()`.

Ces quatre micro-correctifs sont appliqués sans refactor ni réencodage global.

## Durcissement des auditeurs

La revue a aussi durci l'outillage lui-même :

- les cibles de compréhension qui masquent un attribut de classe homonyme ne produisent plus de faux positif ;
- les signaux `Validation()/Sauvegarde()` hétérogènes sont classés comme inventaire faible tant qu'ils ne prouvent pas un contrat de persistance commun ;
- les valeurs mutables par défaut sont qualifiées selon leur mutation réelle ;
- les affectations et augmentations par tranche (`items[:] = ...`, `items[:] += ...`) sont explicitement reconnues comme mutations possibles d'un objet partagé.

Les tests de régression couvrent ces cas limites et le dépôt garde un verrou zéro-dette sur les pièges sémantiques à priorité haute.

## Qualification pré-RC

Les signatures Teamworks rejoignent `audit_pre_rc.py` et disposent de leur propre rapport avec preuve de couverture. La CI rapide conserve le garde zéro-dette sur les signatures à forte confiance.

La branche a été réancrée proprement sur le `master` contenant #216 : la PR ne contient plus qu'un commit fonctionnel au-dessus de `master`.