### PR TITLE
[supersédée par #298] Noe-062B — rôles de contacts

### DIFF
--- a/noethys/Utils/UTILS_Tiers.py
+++ b/noethys/Utils/UTILS_Tiers.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""Couche métier minimale pour le référentiel des tiers (Noe-062A).
+"""Couche métier minimale pour le référentiel des tiers (Noe-062A/062B).
 
 Le module ne dépend pas de wxPython et accepte une instance de ``GestionDB.DB``
 (ou un double de test) injectée par l'appelant. Il ne crée aucune table : le
@@ -73,6 +73,11 @@ CHAMPS_CONTACT = (
     "contact_principal",
     "actif",
     "memo",
+)
+
+CHAMPS_ROLE_CONTACT = (
+    "IDcontact",
+    "role",
 )
 
 CHAMPS_TEXTE_STRUCTURE = (
@@ -200,6 +205,29 @@ def NormaliserContact(donnees, creation=True):
     return resultat
 
 
+def NormaliserRoleContact(donnees):
+    """Valide une association contact/rôle.
+
+    Les rôles sont volontairement bornés à un vocabulaire métier stable. Une
+    fonction libre (par exemple « adjoint enfance ») reste portée par la fiche
+    contact ; le rôle indique l'usage opérationnel du contact dans Noethys.
+    """
+    donnees = dict(donnees or {})
+    if not donnees.get("IDcontact"):
+        raise ValueError("IDcontact est obligatoire pour un rôle")
+
+    role = _texte(donnees.get("role"))
+    if not role:
+        raise ValueError("Le rôle est obligatoire")
+    if role not in ROLES_CONTACT:
+        raise ValueError("Rôle de contact inconnu: %s" % role)
+
+    return {
+        "IDcontact": int(donnees["IDcontact"]),
+        "role": role,
+    }
+
+
 def _liste_pairs(donnees, ordre):
     return [(champ, donnees.get(champ)) for champ in ordre if champ in donnees]
 
@@ -275,3 +303,41 @@ class GestionnaireTiers(object):
             return []
         champs = ("IDcontact",) + CHAMPS_CONTACT
         return [dict(zip(champs, ligne)) for ligne in self.db.ResultatReq()]
+
+    def AjouterRoleContact(self, IDcontact, role):
+        """Ajoute un rôle métier à un contact de façon idempotente."""
+        valeurs = NormaliserRoleContact({"IDcontact": IDcontact, "role": role})
+        req = (
+            "SELECT IDrole_contact FROM structures_roles_contacts "
+            "WHERE IDcontact=%d AND role='%s';"
+        ) % (valeurs["IDcontact"], valeurs["role"])
+        if self.db.ExecuterReq(req) == 1:
+            lignes = self.db.ResultatReq()
+            if lignes:
+                return lignes[0][0]
+        return self.db.ReqInsert(
+            "structures_roles_contacts",
+            _liste_pairs(valeurs, CHAMPS_ROLE_CONTACT),
+        )
+
+    def ListerRolesContact(self, IDcontact):
+        if not IDcontact:
+            raise ValueError("IDcontact obligatoire")
+        req = (
+            "SELECT IDrole_contact, IDcontact, role FROM structures_roles_contacts "
+            "WHERE IDcontact=%d ORDER BY role;"
+        ) % int(IDcontact)
+        if self.db.ExecuterReq(req) != 1:
+            return []
+        champs = ("IDrole_contact",) + CHAMPS_ROLE_CONTACT
+        return [dict(zip(champs, ligne)) for ligne in self.db.ResultatReq()]
+
+    def SupprimerRoleContact(self, IDrole_contact):
+        """Supprime uniquement le lien de rôle, jamais la fiche contact."""
+        if not IDrole_contact:
+            raise ValueError("IDrole_contact obligatoire")
+        return self.db.ReqDEL(
+            "structures_roles_contacts",
+            "IDrole_contact",
+            int(IDrole_contact),
+        )

--- a/noethys/Utils/UTILS_Tiers_Schema.py
+++ b/noethys/Utils/UTILS_Tiers_Schema.py
@@ -18,6 +18,7 @@ from Data import DATA_Structures
 TABLES_062A = ("structures", "structures_contacts")
 TABLES_062B = ("interventions",)
 TABLES_062B_COMPLET = TABLES_062A + TABLES_062B
+TABLES_062B_ROLES_CONTACTS = TABLES_062A + ("structures_roles_contacts",)
 
 
 def _descriptions_attendues(nom_table):
@@ -228,3 +229,18 @@ def AssurerSchema062B(db, appliquer=False):
     ces liens restent optionnels et pourront être enrichis ensuite.
     """
     return _assurer_schema(db, TABLES_062B_COMPLET, appliquer=appliquer)
+
+
+def InspecterSchema062BRolesContacts(db):
+    """Inspecte le lot autonome des rôles métier de contacts."""
+    return InspecterSchema(db, tables=TABLES_062B_ROLES_CONTACTS)
+
+
+def AssurerSchema062BRolesContacts(db, appliquer=False):
+    """Active explicitement les rôles de contacts sans toucher aux autres lots.
+
+    Cette activation reste indépendante des interventions et des groupes afin
+    qu'un déploiement puisse enrichir les contacts d'une structure sans créer
+    d'autres tables métier.
+    """
+    return _assurer_schema(db, TABLES_062B_ROLES_CONTACTS, appliquer=appliquer)

--- a/tests/test_noe_062b_roles_contacts.py
+++ b/tests/test_noe_062b_roles_contacts.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _charger_module(path, nom):
+    spec = importlib.util.spec_from_file_location(nom, str(ROOT / path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+TIERS = _charger_module("noethys/Utils/UTILS_Tiers.py", "UTILS_Tiers_noe062b_roles")
+
+
+class FakeDB(object):
+    def __init__(self):
+        self.insertions = []
+        self.suppressions = []
+        self.requetes = []
+        self.resultats = []
+
+    def ReqInsert(self, table, donnees, commit=True):
+        self.insertions.append((table, list(donnees), commit))
+        return 42
+
+    def ReqDEL(self, table, cle, ID, commit=True, IDestChaine=False):
+        self.suppressions.append((table, cle, ID, commit, IDestChaine))
+        return True
+
+    def ExecuterReq(self, req):
+        self.requetes.append(req)
+        return 1
+
+    def ResultatReq(self):
+        return list(self.resultats)
+
+
+def test_normaliser_role_contact_valide_identifiant_et_vocabulaire():
+    data = TIERS.NormaliserRoleContact({"IDcontact": "7", "role": " facturation "})
+    assert data == {"IDcontact": 7, "role": "facturation"}
+
+
+def test_normaliser_role_contact_refuse_contact_ou_role_invalide():
+    try:
+        TIERS.NormaliserRoleContact({"role": "planning"})
+        assert False, "rôle sans contact accepté"
+    except ValueError:
+        pass
+
+    try:
+        TIERS.NormaliserRoleContact({"IDcontact": 3, "role": "super_admin"})
+        assert False, "rôle hors vocabulaire accepté"
+    except ValueError:
+        pass
+
+
+def test_ajouter_role_contact_insere_un_lien_canonique():
+    db = FakeDB()
+    gestion = TIERS.GestionnaireTiers(db)
+
+    IDrole = gestion.AjouterRoleContact(7, "convention")
+
+    assert IDrole == 42
+    assert "WHERE IDcontact=7 AND role='convention'" in db.requetes[-1]
+    table, paires, commit = db.insertions[0]
+    assert table == "structures_roles_contacts"
+    assert paires == [("IDcontact", 7), ("role", "convention")]
+    assert commit is True
+
+
+def test_ajouter_role_contact_est_idempotent():
+    db = FakeDB()
+    db.resultats = [(91,)]
+    gestion = TIERS.GestionnaireTiers(db)
+
+    assert gestion.AjouterRoleContact(7, "planning") == 91
+    assert db.insertions == []
+
+
+def test_lister_roles_contact_reste_borne_au_contact():
+    db = FakeDB()
+    db.resultats = [
+        (5, 8, "facturation"),
+        (6, 8, "planning"),
+    ]
+    gestion = TIERS.GestionnaireTiers(db)
+
+    roles = gestion.ListerRolesContact(8)
+
+    assert "WHERE IDcontact=8" in db.requetes[-1]
+    assert [role["role"] for role in roles] == ["facturation", "planning"]
+    assert all(role["IDcontact"] == 8 for role in roles)
+
+
+def test_lister_roles_contact_refuse_identifiant_vide():
+    db = FakeDB()
+    gestion = TIERS.GestionnaireTiers(db)
+    try:
+        gestion.ListerRolesContact(None)
+        assert False, "IDcontact vide accepté"
+    except ValueError:
+        pass
+    assert db.requetes == []
+
+
+def test_supprimer_role_contact_ne_supprime_jamais_le_contact():
+    db = FakeDB()
+    gestion = TIERS.GestionnaireTiers(db)
+
+    assert gestion.SupprimerRoleContact(12) is True
+    assert db.suppressions == [
+        ("structures_roles_contacts", "IDrole_contact", 12, True, False),
+    ]

--- a/tests/test_noe_062b_roles_schema.py
+++ b/tests/test_noe_062b_roles_schema.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOETHYS = ROOT / "noethys"
+if str(NOETHYS) not in sys.path:
+    sys.path.insert(0, str(NOETHYS))
+
+
+def _charger_module(path, nom):
+    spec = importlib.util.spec_from_file_location(nom, str(ROOT / path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+SCHEMA = _charger_module("noethys/Utils/UTILS_Tiers_Schema.py", "UTILS_Tiers_Schema_noe062b_roles")
+DATA = _charger_module("noethys/Data/DATA_Structures.py", "DATA_Structures_noe062b_roles")
+
+
+def _schema_sqlite(nom_table):
+    resultat = []
+    for nom, type_champ, info in DATA.DB_STRUCTURES[nom_table]:
+        type_sql = type_champ
+        if type_sql == "LONGBLOB":
+            type_sql = "BLOB"
+        if type_sql == "BIGINT":
+            type_sql = "INTEGER"
+        type_prag = type_sql.split(" PRIMARY KEY", 1)[0]
+        pk = 1 if "PRIMARY KEY" in type_sql else 0
+        resultat.append((nom, type_prag, pk))
+    return resultat
+
+
+class FakeSchemaDB(object):
+    isNetwork = False
+
+    def __init__(self, tables=None):
+        self.tables = dict(tables or {})
+        self.creations = []
+        self.commits = 0
+        self._resultat = []
+
+    def IsTableExists(self, nom_table):
+        return nom_table in self.tables
+
+    def ExecuterReq(self, req):
+        if req.startswith("PRAGMA table_info('"):
+            nom_table = req.split("'", 2)[1]
+            colonnes = self.tables.get(nom_table, [])
+            self._resultat = [
+                (index, nom, type_sql, 0, None, pk)
+                for index, (nom, type_sql, pk) in enumerate(colonnes)
+            ]
+            return 1
+        return 0
+
+    def ResultatReq(self):
+        return list(self._resultat)
+
+    def CreationTable(self, nom_table, dico):
+        self.creations.append(nom_table)
+        self.tables[nom_table] = _schema_sqlite(nom_table)
+
+    def Commit(self):
+        self.commits += 1
+
+
+def test_contrat_roles_contacts_est_independant_des_autres_lots_062b():
+    assert SCHEMA.TABLES_062B_ROLES_CONTACTS == (
+        "structures",
+        "structures_contacts",
+        "structures_roles_contacts",
+    )
+    assert "interventions" not in SCHEMA.TABLES_062B_ROLES_CONTACTS
+    assert "structures_groupes" not in SCHEMA.TABLES_062B_ROLES_CONTACTS
+
+
+def test_mode_diagnostic_roles_ne_cree_rien():
+    db = FakeSchemaDB()
+    resultat = SCHEMA.AssurerSchema062BRolesContacts(db, appliquer=False)
+
+    assert resultat["ok"] is True
+    assert set(resultat["tables_absentes"]) == {
+        "structures",
+        "structures_contacts",
+        "structures_roles_contacts",
+    }
+    assert db.creations == []
+    assert db.commits == 0
+
+
+def test_activation_roles_cree_uniquement_le_socle_necessaire():
+    db = FakeSchemaDB()
+    resultat = SCHEMA.AssurerSchema062BRolesContacts(db, appliquer=True)
+
+    assert resultat["ok"] is True
+    assert resultat["tables_creees"] == (
+        "structures",
+        "structures_contacts",
+        "structures_roles_contacts",
+    )
+    assert db.creations == list(SCHEMA.TABLES_062B_ROLES_CONTACTS)
+    assert db.commits == 3
+    assert "interventions" not in db.tables
+    assert "structures_groupes" not in db.tables
+
+
+def test_activation_roles_est_idempotente():
+    tables = {
+        nom_table: _schema_sqlite(nom_table)
+        for nom_table in SCHEMA.TABLES_062B_ROLES_CONTACTS
+    }
+    db = FakeSchemaDB(tables=tables)
+
+    resultat = SCHEMA.AssurerSchema062BRolesContacts(db, appliquer=True)
+
+    assert resultat["ok"] is True
+    assert resultat["tables_creees"] == ()
+    assert db.creations == []
+    assert db.commits == 0
+
+
+def test_schema_roles_incomplet_bloque_avant_toute_creation():
+    db = FakeSchemaDB({
+        "structures_roles_contacts": [
+            ("IDrole_contact", "INTEGER", 1),
+            ("IDcontact", "INTEGER", 0),
+        ],
+    })
+
+    resultat = SCHEMA.AssurerSchema062BRolesContacts(db, appliquer=True)
+
+    assert resultat["ok"] is False
+    assert resultat["tables_incoherentes"] == ("structures_roles_contacts",)
+    assert "role" in resultat["rapport"]["structures_roles_contacts"]["champs_manquants"]
+    assert db.creations == []
+    assert db.commits == 0


### PR DESCRIPTION
Cette PR historique est fermée sans fusion. Son contenu utile a été repris proprement depuis le `master` actuel, consolidé avec les groupes/sections, testé et fusionné via #298.

Ne pas réutiliser cette branche ancienne.