### PR TITLE
Fix — généraliser le placement des groupes de filiation

### DIFF
--- a/.github/workflows/tmp-composition-filiation-layout.yml
+++ b/.github/workflows/tmp-composition-filiation-layout.yml
@@ -1,16 +1,17 @@
 name: Temp composition filiation layout
 
 on:
-  push:
+  pull_request:
     branches:
-      - fix/composition-filiation-layout
+      - master
+    types: [opened, reopened, synchronize]
 
 permissions:
   contents: write
 
 jobs:
   patch-and-test:
-    if: github.actor != 'github-actions[bot]'
+    if: github.head_ref == 'fix/composition-filiation-layout' && github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/tmp-composition-filiation-layout.yml
+++ b/.github/workflows/tmp-composition-filiation-layout.yml
@@ -1,0 +1,174 @@
+name: Temp composition filiation layout
+
+on:
+  push:
+    branches:
+      - fix/composition-filiation-layout
+
+permissions:
+  contents: write
+
+jobs:
+  patch-and-test:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: fix/composition-filiation-layout
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.10'
+
+      - name: Appliquer le correctif et les tests
+        shell: bash
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          path = Path('noethys/Ctrl/CTRL_Composition.py')
+          source = path.read_text(encoding='utf-8')
+
+          cursor_block = """if 'phoenix' in wx.PlatformInfo:\n    CURSOR = wx.Cursor\nelse :\n    CURSOR = wx.StockCursor\n"""
+          helper = """
+
+
+def GetPositionsLiensFiliation(posSeparation, nbreLiensFiliation):
+    \"\"\"Retourne les positions horizontales des groupes de filiation.\"\"\"
+    if nbreLiensFiliation <= 0:
+        return []
+    decalageDepart = -2 * (nbreLiensFiliation - 1)
+    return [
+        posSeparation + decalageDepart + 4 * index
+        for index in range(nbreLiensFiliation)
+    ]
+"""
+          if 'def GetPositionsLiensFiliation(' not in source:
+              if cursor_block not in source:
+                  raise SystemExit('bloc CURSOR introuvable')
+              source = source.replace(cursor_block, cursor_block + helper, 1)
+
+          old = """            if nbreLiensFiliation == 1 : posCentrale = [self.posSeparationCol1,]\n            if nbreLiensFiliation == 2 : posCentrale = [self.posSeparationCol1-2, self.posSeparationCol1+2]\n            if nbreLiensFiliation == 3 : posCentrale = [self.posSeparationCol1-4, self.posSeparationCol1, self.posSeparationCol1+4]\n            if nbreLiensFiliation == 4 : posCentrale = [self.posSeparationCol1-6, self.posSeparationCol1-2, self.posSeparationCol1+2, self.posSeparationCol1+6]\n            if nbreLiensFiliation == 5 : posCentrale = [self.posSeparationCol1-8, self.posSeparationCol1-4, self.posSeparationCol1, self.posSeparationCol1+4, self.posSeparationCol1+8]\n"""
+          new = """            posCentrale = GetPositionsLiensFiliation(self.posSeparationCol1, nbreLiensFiliation)\n"""
+          if old not in source:
+              raise SystemExit('bloc historique posCentrale introuvable')
+          source = source.replace(old, new, 1)
+          path.write_text(source, encoding='utf-8')
+
+          test = Path('tests/test_composition_filiation_layout.py')
+          test.write_text('''#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import ast
+import unittest
+from pathlib import Path
+
+from scripts import audit_branch_assignment_gaps
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_ROOT = ROOT / "noethys"
+SOURCE_PATH = SOURCE_ROOT / "Ctrl" / "CTRL_Composition.py"
+
+
+def load_positions_helper():
+    source = SOURCE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    functions = [
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "GetPositionsLiensFiliation"
+    ]
+    if len(functions) != 1:
+        raise AssertionError(functions)
+    module = ast.Module(body=functions, type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = {}
+    exec(compile(module, str(SOURCE_PATH), "exec"), namespace)
+    return namespace["GetPositionsLiensFiliation"]
+
+
+class CompositionFiliationLayoutTests(unittest.TestCase):
+    def test_historical_positions_one_to_five_are_preserved(self):
+        positions = load_positions_helper()
+        centre = 100
+        expected = {
+            1: [100],
+            2: [98, 102],
+            3: [96, 100, 104],
+            4: [94, 98, 102, 106],
+            5: [92, 96, 100, 104, 108],
+        }
+        for count, values in expected.items():
+            with self.subTest(count=count):
+                self.assertEqual(positions(centre, count), values)
+
+    def test_ten_filiation_groups_are_supported(self):
+        positions = load_positions_helper()
+        self.assertEqual(
+            positions(100, 10),
+            [82, 86, 90, 94, 98, 102, 106, 110, 114, 118],
+        )
+
+    def test_zero_groups_returns_no_position(self):
+        positions = load_positions_helper()
+        self.assertEqual(positions(100, 0), [])
+
+    def test_positions_remain_regular_and_centered(self):
+        positions = load_positions_helper()
+        for count in (1, 2, 5, 10, 17):
+            values = positions(240, count)
+            self.assertEqual(len(values), count)
+            if count > 1:
+                self.assertEqual(
+                    [b - a for a, b in zip(values, values[1:])],
+                    [4] * (count - 1),
+                )
+            self.assertEqual(values[0] + values[-1], 480)
+
+    def test_draw_liens_poscentrale_branch_gap_is_gone(self):
+        findings = audit_branch_assignment_gaps.scan_file(SOURCE_PATH, SOURCE_ROOT)
+        targeted = [
+            item for item in findings
+            if item.get("function") == "DrawLiens"
+            and item.get("name") == "posCentrale"
+        ]
+        self.assertEqual(targeted, [], targeted)
+
+
+if __name__ == "__main__":
+    unittest.main()
+''', encoding='utf-8')
+          PY
+
+          python -m py_compile noethys/Ctrl/CTRL_Composition.py tests/test_composition_filiation_layout.py
+          python -m unittest tests.test_composition_filiation_layout -v
+          python scripts/audit_branch_assignment_gaps.py --json /tmp/branch-gaps.json
+          python - <<'PY'
+          import json
+          data = json.load(open('/tmp/branch-gaps.json', encoding='utf-8'))
+          findings = data.get('findings', data if isinstance(data, list) else [])
+          targeted = [x for x in findings if x.get('file') == 'Ctrl/CTRL_Composition.py' and x.get('function') == 'DrawLiens' and x.get('name') == 'posCentrale']
+          print('TARGETED_POSCENTRALE_FINDINGS=', targeted)
+          print('BRANCH_ASSIGNMENT_GAPS=', len(findings))
+          if targeted:
+              raise SystemExit(1)
+          PY
+
+      - name: Commit du correctif
+        shell: bash
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add noethys/Ctrl/CTRL_Composition.py tests/test_composition_filiation_layout.py
+          git commit -m 'Fix — généraliser le placement des filiations'
+          git push origin HEAD:fix/composition-filiation-layout
+
+      - name: Retirer le workflow temporaire
+        shell: bash
+        run: |
+          git rm .github/workflows/tmp-composition-filiation-layout.yml
+          git commit -m 'CI temporaire — retirer la validation des filiations'
+          git push origin HEAD:fix/composition-filiation-layout


### PR DESCRIPTION
Corrige le plantage potentiel de `CTRL_Composition.DrawLiens` lorsque la composition familiale comporte plus de cinq groupes de filiation distincts.

Le correctif remplace les cinq cas codés en dur par une formule générale qui conserve exactement les positions historiques pour 1 à 5 groupes et supporte sans limite artificielle les cas plus complexes, notamment 10 groupes.

Tests prévus : conservation stricte des positions 1–5, cas explicite à 10 groupes, régularité/centrage, et disparition du signal `branch_assignment_gap` sur `posCentrale`.