### PR TITLE
Noe-062B : consolider groupes/sections et rôles de contacts

### DIFF
--- a/noethys/Utils/UTILS_Tiers.py
+++ b/noethys/Utils/UTILS_Tiers.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""Couche métier minimale pour le référentiel des tiers (Noe-062A).
+"""Couche métier minimale pour le référentiel des tiers (Noe-062A/062B).
 
 Le module ne dépend pas de wxPython et accepte une instance de ``GestionDB.DB``
 (ou un double de test) injectée par l'appelant. Il ne crée aucune table : le
@@ -75,6 +75,18 @@ CHAMPS_CONTACT = (
     "memo",
 )
 
+CHAMPS_GROUPE = (
+    "IDstructure",
+    "nom",
+    "actif",
+    "memo",
+)
+
+CHAMPS_ROLE_CONTACT = (
+    "IDcontact",
+    "role",
+)
+
 CHAMPS_TEXTE_STRUCTURE = (
     "nom", "nom_court", "nom_officiel", "rue", "cp", "ville", "tel",
     "mail", "site_web", "rna", "siren", "siret", "ape", "memo",
@@ -82,6 +94,10 @@ CHAMPS_TEXTE_STRUCTURE = (
 
 CHAMPS_TEXTE_CONTACT = (
     "nom", "prenom", "fonction", "tel", "mobile", "mail", "memo",
+)
+
+CHAMPS_TEXTE_GROUPE = (
+    "nom", "memo",
 )
 
 
@@ -163,7 +179,6 @@ def NormaliserStructure(donnees, date=None, creation=False):
         resultat["uid"] = _texte(donnees.get("uid")) or GenererUIDStructure()
         resultat["date_creation"] = _date_iso(donnees.get("date_creation") or date)
     else:
-        # L'UID et la date de création sont immuables par le CRUD standard.
         resultat.pop("uid", None)
         resultat.pop("date_creation", None)
 
@@ -200,6 +215,65 @@ def NormaliserContact(donnees, creation=True):
     return resultat
 
 
+def NormaliserGroupe(donnees, creation=True):
+    """Valide un groupe libre rattaché à une structure."""
+    donnees = dict(donnees or {})
+
+    if creation and not donnees.get("IDstructure"):
+        raise ValueError("IDstructure est obligatoire pour un groupe")
+    if "IDstructure" in donnees and not donnees.get("IDstructure"):
+        raise ValueError("IDstructure ne peut pas être vide")
+
+    if creation:
+        nom = _texte(donnees.get("nom"))
+        if not nom:
+            raise ValueError("Le nom du groupe est obligatoire")
+    else:
+        nom = None
+        if "nom" in donnees:
+            nom = _texte(donnees.get("nom"))
+            if not nom:
+                raise ValueError("Le nom du groupe ne peut pas être vide")
+        if not donnees:
+            raise ValueError("Aucune donnée à modifier")
+
+    resultat = {}
+    for champ in CHAMPS_GROUPE:
+        if champ in donnees:
+            resultat[champ] = donnees[champ]
+
+    if creation or "nom" in donnees:
+        resultat["nom"] = nom
+
+    for champ in CHAMPS_TEXTE_GROUPE:
+        if champ == "nom":
+            continue
+        if creation or champ in donnees:
+            resultat[champ] = _texte(donnees.get(champ))
+
+    if creation or "actif" in donnees:
+        resultat["actif"] = 1 if donnees.get("actif", 1) not in (0, False, "0") else 0
+    return resultat
+
+
+def NormaliserRoleContact(donnees):
+    """Valide une association contact/rôle structurée."""
+    donnees = dict(donnees or {})
+    if not donnees.get("IDcontact"):
+        raise ValueError("IDcontact est obligatoire pour un rôle")
+
+    role = _texte(donnees.get("role"))
+    if not role:
+        raise ValueError("Le rôle est obligatoire")
+    if role not in ROLES_CONTACT:
+        raise ValueError("Rôle de contact inconnu: %s" % role)
+
+    return {
+        "IDcontact": int(donnees["IDcontact"]),
+        "role": role,
+    }
+
+
 def _liste_pairs(donnees, ordre):
     return [(champ, donnees.get(champ)) for champ in ordre if champ in donnees]
 
@@ -226,7 +300,6 @@ class GestionnaireTiers(object):
         )
 
     def ArchiverStructure(self, IDstructure, date=None):
-        """Archive sans supprimer ni réécrire les autres données du tiers."""
         return self.ModifierStructure(IDstructure, {"actif": 0}, date=date)
 
     def LireStructure(self, IDstructure):
@@ -275,3 +348,81 @@ class GestionnaireTiers(object):
             return []
         champs = ("IDcontact",) + CHAMPS_CONTACT
         return [dict(zip(champs, ligne)) for ligne in self.db.ResultatReq()]
+
+    def CreerGroupe(self, donnees):
+        valeurs = NormaliserGroupe(donnees, creation=True)
+        return self.db.ReqInsert("structures_groupes", _liste_pairs(valeurs, CHAMPS_GROUPE))
+
+    def ModifierGroupe(self, IDgroupe_structure, donnees):
+        if not IDgroupe_structure:
+            raise ValueError("IDgroupe_structure obligatoire")
+        valeurs = NormaliserGroupe(donnees, creation=False)
+        return self.db.ReqMAJ(
+            "structures_groupes",
+            _liste_pairs(valeurs, CHAMPS_GROUPE),
+            "IDgroupe_structure",
+            int(IDgroupe_structure),
+        )
+
+    def ArchiverGroupe(self, IDgroupe_structure):
+        return self.ModifierGroupe(IDgroupe_structure, {"actif": 0})
+
+    def LireGroupe(self, IDgroupe_structure):
+        req = "SELECT IDgroupe_structure, %s FROM structures_groupes WHERE IDgroupe_structure=%d;" % (
+            ", ".join(CHAMPS_GROUPE), int(IDgroupe_structure))
+        if self.db.ExecuterReq(req) != 1:
+            return None
+        lignes = self.db.ResultatReq()
+        if not lignes:
+            return None
+        champs = ("IDgroupe_structure",) + CHAMPS_GROUPE
+        return dict(zip(champs, lignes[0]))
+
+    def ListerGroupes(self, IDstructure, actifs_seulement=True):
+        if not IDstructure:
+            raise ValueError("IDstructure obligatoire")
+        condition_actif = " AND actif=1" if actifs_seulement else ""
+        req = "SELECT IDgroupe_structure, %s FROM structures_groupes WHERE IDstructure=%d%s ORDER BY nom;" % (
+            ", ".join(CHAMPS_GROUPE), int(IDstructure), condition_actif)
+        if self.db.ExecuterReq(req) != 1:
+            return []
+        champs = ("IDgroupe_structure",) + CHAMPS_GROUPE
+        return [dict(zip(champs, ligne)) for ligne in self.db.ResultatReq()]
+
+    def AjouterRoleContact(self, IDcontact, role):
+        """Ajoute un rôle métier à un contact de façon idempotente."""
+        valeurs = NormaliserRoleContact({"IDcontact": IDcontact, "role": role})
+        req = (
+            "SELECT IDrole_contact FROM structures_roles_contacts "
+            "WHERE IDcontact=%d AND role='%s';"
+        ) % (valeurs["IDcontact"], valeurs["role"])
+        if self.db.ExecuterReq(req) == 1:
+            lignes = self.db.ResultatReq()
+            if lignes:
+                return lignes[0][0]
+        return self.db.ReqInsert(
+            "structures_roles_contacts",
+            _liste_pairs(valeurs, CHAMPS_ROLE_CONTACT),
+        )
+
+    def ListerRolesContact(self, IDcontact):
+        if not IDcontact:
+            raise ValueError("IDcontact obligatoire")
+        req = (
+            "SELECT IDrole_contact, IDcontact, role FROM structures_roles_contacts "
+            "WHERE IDcontact=%d ORDER BY role;"
+        ) % int(IDcontact)
+        if self.db.ExecuterReq(req) != 1:
+            return []
+        champs = ("IDrole_contact",) + CHAMPS_ROLE_CONTACT
+        return [dict(zip(champs, ligne)) for ligne in self.db.ResultatReq()]
+
+    def SupprimerRoleContact(self, IDrole_contact):
+        """Supprime uniquement le lien de rôle, jamais la fiche contact."""
+        if not IDrole_contact:
+            raise ValueError("IDrole_contact obligatoire")
+        return self.db.ReqDEL(
+            "structures_roles_contacts",
+            "IDrole_contact",
+            int(IDrole_contact),
+        )

--- a/noethys/Utils/UTILS_Tiers_Schema.py
+++ b/noethys/Utils/UTILS_Tiers_Schema.py
@@ -19,6 +19,17 @@ TABLES_062A = ("structures", "structures_contacts")
 TABLES_062B = ("interventions",)
 TABLES_062B_COMPLET = TABLES_062A + TABLES_062B
 
+# Contrats indépendants : ils permettent d'enrichir le référentiel sans changer
+# le comportement historique d'AssurerSchema062B(), déjà utilisé pour les
+# premières interventions.
+TABLES_062B_GROUPES = ("structures_groupes",)
+TABLES_062B_GROUPES_COMPLET = TABLES_062A + TABLES_062B_GROUPES
+TABLES_062B_ROLES_CONTACTS = TABLES_062A + ("structures_roles_contacts",)
+TABLES_062B_REFERENTIEL = TABLES_062A + (
+    "structures_groupes",
+    "structures_roles_contacts",
+)
+
 
 def _descriptions_attendues(nom_table):
     return tuple(DATA_Structures.DB_STRUCTURES[nom_table])
@@ -93,9 +104,6 @@ def _metadata_table(db, nom_table):
             colonnes[nom] = {
                 "type": type_sql,
                 "pk": bool(pk),
-                # En SQLite, INTEGER PRIMARY KEY est l'alias du rowid ;
-                # AUTOINCREMENT n'est pas nécessaire à l'identité du champ mais
-                # le contrat Noethys le déclare pour éviter la réutilisation.
                 "auto": bool(pk) and _categorie_type(type_sql) == "integer",
             }
     else:
@@ -228,3 +236,33 @@ def AssurerSchema062B(db, appliquer=False):
     ces liens restent optionnels et pourront être enrichis ensuite.
     """
     return _assurer_schema(db, TABLES_062B_COMPLET, appliquer=appliquer)
+
+
+def InspecterSchema062BGroupes(db):
+    """Inspecte structures, contacts et groupes libres sans écrire en base."""
+    return InspecterSchema(db, tables=TABLES_062B_GROUPES_COMPLET)
+
+
+def AssurerSchema062BGroupes(db, appliquer=False):
+    """Active explicitement les groupes libres des tiers."""
+    return _assurer_schema(db, TABLES_062B_GROUPES_COMPLET, appliquer=appliquer)
+
+
+def InspecterSchema062BRolesContacts(db):
+    """Inspecte le lot autonome des rôles métier de contacts."""
+    return InspecterSchema(db, tables=TABLES_062B_ROLES_CONTACTS)
+
+
+def AssurerSchema062BRolesContacts(db, appliquer=False):
+    """Active explicitement les rôles de contacts sans toucher aux autres lots."""
+    return _assurer_schema(db, TABLES_062B_ROLES_CONTACTS, appliquer=appliquer)
+
+
+def InspecterSchema062BReferentiel(db):
+    """Inspecte le référentiel 062B consolidé : tiers, groupes et rôles."""
+    return InspecterSchema(db, tables=TABLES_062B_REFERENTIEL)
+
+
+def AssurerSchema062BReferentiel(db, appliquer=False):
+    """Active en une passe les groupes et rôles sur un socle tiers conforme."""
+    return _assurer_schema(db, TABLES_062B_REFERENTIEL, appliquer=appliquer)

--- a/tests/test_noe_062b_referentiel_groupes_roles.py
+++ b/tests/test_noe_062b_referentiel_groupes_roles.py
@@ -1,0 +1,206 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import sqlite3
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOETHYS = ROOT / "noethys"
+if str(NOETHYS) not in sys.path:
+    sys.path.insert(0, str(NOETHYS))
+
+
+def _charger_module(path, nom):
+    spec = importlib.util.spec_from_file_location(nom, str(ROOT / path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+SCHEMA = _charger_module("noethys/Utils/UTILS_Tiers_Schema.py", "UTILS_Tiers_Schema_062b_ref")
+TIERS = _charger_module("noethys/Utils/UTILS_Tiers.py", "UTILS_Tiers_062b_ref")
+
+
+class SQLiteDB(object):
+    isNetwork = False
+
+    def __init__(self):
+        self.connexion = sqlite3.connect(":memory:")
+        self.cursor = self.connexion.cursor()
+        self.creations = []
+        self.commits = 0
+
+    def Close(self):
+        self.connexion.close()
+
+    def IsTableExists(self, nom_table):
+        self.cursor.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+            (nom_table,),
+        )
+        return self.cursor.fetchone() is not None
+
+    def ExecuterReq(self, req):
+        try:
+            self.cursor.execute(req)
+            return 1
+        except Exception:
+            return 0
+
+    def ResultatReq(self):
+        return self.cursor.fetchall()
+
+    def CreationTable(self, nom_table, dico):
+        champs = []
+        for nom, type_champ, info in dico[nom_table]:
+            if type_champ == "LONGBLOB":
+                type_champ = "BLOB"
+            if type_champ == "BIGINT":
+                type_champ = "INTEGER"
+            champs.append("%s %s" % (nom, type_champ))
+        self.cursor.execute("CREATE TABLE %s (%s)" % (nom_table, ", ".join(champs)))
+        self.creations.append(nom_table)
+
+    def Commit(self):
+        self.connexion.commit()
+        self.commits += 1
+
+    def ReqInsert(self, nom_table, liste_donnees, commit=True):
+        noms = [nom for nom, valeur in liste_donnees]
+        valeurs = [valeur for nom, valeur in liste_donnees]
+        marqueurs = ", ".join("?" for nom in noms)
+        self.cursor.execute(
+            "INSERT INTO %s (%s) VALUES (%s)" % (
+                nom_table,
+                ", ".join(noms),
+                marqueurs,
+            ),
+            tuple(valeurs),
+        )
+        if commit:
+            self.connexion.commit()
+        return self.cursor.lastrowid
+
+    def ReqMAJ(self, nom_table, liste_donnees, nom_champ_id, ID, IDestChaine=False, commit=True):
+        clauses = ["%s=?" % nom for nom, valeur in liste_donnees]
+        valeurs = [valeur for nom, valeur in liste_donnees]
+        valeurs.append(ID)
+        self.cursor.execute(
+            "UPDATE %s SET %s WHERE %s=?" % (
+                nom_table,
+                ", ".join(clauses),
+                nom_champ_id,
+            ),
+            tuple(valeurs),
+        )
+        if commit:
+            self.connexion.commit()
+        return True
+
+    def ReqDEL(self, nom_table, nom_champ_id, ID, commit=True, IDestChaine=False):
+        self.cursor.execute(
+            "DELETE FROM %s WHERE %s=?" % (nom_table, nom_champ_id),
+            (ID,),
+        )
+        if commit:
+            self.connexion.commit()
+        return True
+
+
+class Noe062BReferentielTests(unittest.TestCase):
+
+    def test_contrat_historique_062b_reste_inchange(self):
+        self.assertEqual(("interventions",), SCHEMA.TABLES_062B)
+        self.assertNotIn("structures_groupes", SCHEMA.TABLES_062B_COMPLET)
+        self.assertNotIn("structures_roles_contacts", SCHEMA.TABLES_062B_COMPLET)
+
+    def test_activation_referentiel_est_additive_et_idempotente(self):
+        db = SQLiteDB()
+        try:
+            resultat_a = SCHEMA.AssurerSchema(db, appliquer=True)
+            self.assertTrue(resultat_a["ok"])
+            self.assertEqual(("structures", "structures_contacts"), resultat_a["tables_creees"])
+
+            resultat = SCHEMA.AssurerSchema062BReferentiel(db, appliquer=True)
+            self.assertTrue(resultat["ok"])
+            self.assertEqual(
+                ("structures_groupes", "structures_roles_contacts"),
+                resultat["tables_creees"],
+            )
+            self.assertFalse(db.IsTableExists("interventions"))
+
+            resultat2 = SCHEMA.AssurerSchema062BReferentiel(db, appliquer=True)
+            self.assertTrue(resultat2["ok"])
+            self.assertEqual((), resultat2["tables_creees"])
+        finally:
+            db.Close()
+
+    def test_groupe_libre_est_rattache_archive_sans_suppression(self):
+        db = SQLiteDB()
+        try:
+            SCHEMA.AssurerSchema062BReferentiel(db, appliquer=True)
+            gestion = TIERS.GestionnaireTiers(db)
+            IDstructure = gestion.CreerStructure({
+                "type_structure": "association",
+                "nom": "Club test",
+            })
+            IDgroupe = gestion.CreerGroupe({
+                "IDstructure": IDstructure,
+                "nom": " Section badminton ",
+                "memo": " Mardi ",
+            })
+
+            groupe = gestion.LireGroupe(IDgroupe)
+            self.assertEqual(IDstructure, groupe["IDstructure"])
+            self.assertEqual("Section badminton", groupe["nom"])
+            self.assertEqual("Mardi", groupe["memo"])
+            self.assertEqual(1, groupe["actif"])
+
+            gestion.ArchiverGroupe(IDgroupe)
+            archive = gestion.LireGroupe(IDgroupe)
+            self.assertEqual(0, archive["actif"])
+            self.assertEqual("Section badminton", archive["nom"])
+            self.assertEqual([], gestion.ListerGroupes(IDstructure))
+            self.assertEqual(1, len(gestion.ListerGroupes(IDstructure, actifs_seulement=False)))
+        finally:
+            db.Close()
+
+    def test_contact_peut_cumuler_plusieurs_roles_et_rejeu_est_idempotent(self):
+        db = SQLiteDB()
+        try:
+            SCHEMA.AssurerSchema062BReferentiel(db, appliquer=True)
+            gestion = TIERS.GestionnaireTiers(db)
+            IDstructure = gestion.CreerStructure({"nom": "École test", "type_structure": "ecole"})
+            IDcontact = gestion.CreerContact({
+                "IDstructure": IDstructure,
+                "nom": "Martin",
+                "fonction": "Direction",
+            })
+
+            IDplanning = gestion.AjouterRoleContact(IDcontact, "planning")
+            IDplanning2 = gestion.AjouterRoleContact(IDcontact, "planning")
+            IDfacturation = gestion.AjouterRoleContact(IDcontact, "facturation")
+
+            self.assertEqual(IDplanning, IDplanning2)
+            self.assertNotEqual(IDplanning, IDfacturation)
+            roles = gestion.ListerRolesContact(IDcontact)
+            self.assertEqual(["facturation", "planning"], [item["role"] for item in roles])
+
+            gestion.SupprimerRoleContact(IDplanning)
+            roles_apres = gestion.ListerRolesContact(IDcontact)
+            self.assertEqual(["facturation"], [item["role"] for item in roles_apres])
+            self.assertEqual(1, len(gestion.ListerContacts(IDstructure)))
+        finally:
+            db.Close()
+
+    def test_vocabulaire_role_est_borne_et_groupe_exige_un_nom(self):
+        with self.assertRaises(ValueError):
+            TIERS.NormaliserRoleContact({"IDcontact": 1, "role": "super_admin"})
+        with self.assertRaises(ValueError):
+            TIERS.NormaliserGroupe({"IDstructure": 1, "nom": "   "}, creation=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Objectif

Reprendre proprement sur le `master` actuel les deux sous-lots Noe-062B restés en drafts anciens (#220 et #221), sans réutiliser leurs branches devenues obsolètes.

## Contenu

- CRUD des groupes libres `structures_groupes` : section, classe, cycle, service ou autre libellé métier ;
- archivage logique des groupes sans suppression d'historique ;
- rôles multiples structurés pour les contacts : planning, facturation, convention, urgence, etc. ;
- ajout de rôle idempotent et suppression du seul lien de rôle ;
- activations de schéma indépendantes pour groupes et rôles ;
- activation consolidée `AssurerSchema062BReferentiel()` pour tiers + groupes + rôles ;
- maintien strict du contrat historique `AssurerSchema062B()` : les interventions restent indépendantes.

## Compatibilité

- aucune modification des tables historiques familles/individus ;
- aucune activation automatique ;
- aucun changement du contrat Connecthys vanilla ;
- aucune dépendance wxPython ;
- uniquement des tables déjà déclarées dans `DATA_Structures.py`.

## Tests

Tests SQLite en mémoire couvrant :

- activation additive puis idempotente ;
- absence de création implicite d'`interventions` ;
- création, lecture, archivage et filtrage d'un groupe ;
- cumul de plusieurs rôles sur un contact ;
- idempotence du rejeu d'un rôle ;
- suppression du lien de rôle sans suppression du contact ;
- validation du vocabulaire de rôles et des groupes.

Supersède #220 et #221 après validation et fusion.

Relates #60.