### PR TITLE
Noe-062 : conventions versionnées et avenants figés

### DIFF
--- a/noethys/Data/DATA_Conventions_Structures.py
+++ b/noethys/Data/DATA_Conventions_Structures.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Schéma additif des conventions/avenants liés aux relations Noe-062."""
+from __future__ import unicode_literals
+
+
+DB_CONVENTIONS_STRUCTURES = {
+    "structures_conventions": [
+        ("IDconvention_structure", "INTEGER PRIMARY KEY AUTOINCREMENT", u"ID local de la convention ou de l'avenant"),
+        ("uid", "VARCHAR(64)", u"Identifiant stable inter-applications"),
+        ("IDrelation_structure", "INTEGER", u"Relation contractuelle concernée"),
+        ("IDconvention_parent", "INTEGER", u"Convention/version parente pour un avenant"),
+        ("reference", "VARCHAR(200)", u"Référence documentaire libre"),
+        ("version", "INTEGER", u"Numéro de version dans la chaîne contractuelle"),
+        ("statut", "VARCHAR(50)", u"brouillon, validee, signee, terminee, annulee"),
+        ("date_debut", "DATE", u"Début d'effet de cette version"),
+        ("date_fin", "DATE", u"Fin d'effet éventuelle"),
+        ("objet", "VARCHAR(500)", u"Objet ou intitulé documentaire optionnel"),
+        ("notes", "VARCHAR(2000)", u"Notes internes"),
+        ("snapshot_contractuel", "LONGBLOB", u"Instantané JSON figé à la validation"),
+        ("empreinte_sha256", "VARCHAR(64)", u"Empreinte de l'instantané contractuel"),
+        ("date_validation", "DATE", u"Date de validation de la version"),
+        ("date_signature", "DATE", u"Date de signature constatée"),
+        ("actif", "INTEGER", u"Version active dans l'historique 0/1"),
+        ("date_creation", "DATE", u"Date de création"),
+        ("date_modification", "DATE", u"Date de dernière modification"),
+    ],
+}
+
+
+def GetChamps(nom_table="structures_conventions"):
+    return tuple(champ[0] for champ in DB_CONVENTIONS_STRUCTURES[nom_table])

--- a/noethys/Utils/UTILS_Conventions_Structures.py
+++ b/noethys/Utils/UTILS_Conventions_Structures.py
@@ -1,0 +1,577 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Service métier des conventions et avenants Noe-062.
+
+La relation contractuelle reste la source des règles commerciales. Une
+convention référence cette relation et fige, lors de sa validation, un snapshot
+JSON canonique + une empreinte SHA-256. Une version validée/signée n'est jamais
+réécrite comme un brouillon : les changements contractuels passent par un
+avenant/version suivante.
+"""
+from __future__ import unicode_literals
+
+import datetime
+import hashlib
+import json
+import uuid
+
+from Utils import UTILS_Relations_Structures
+
+
+STATUT_BROUILLON = "brouillon"
+STATUT_VALIDEE = "validee"
+STATUT_SIGNEE = "signee"
+STATUT_TERMINEE = "terminee"
+STATUT_ANNULEE = "annulee"
+
+STATUTS = (
+    STATUT_BROUILLON,
+    STATUT_VALIDEE,
+    STATUT_SIGNEE,
+    STATUT_TERMINEE,
+    STATUT_ANNULEE,
+)
+
+STATUTS_PARENT_AVENANT = (
+    STATUT_VALIDEE,
+    STATUT_SIGNEE,
+    STATUT_TERMINEE,
+)
+
+CHAMPS_CONVENTION = (
+    "uid",
+    "IDrelation_structure",
+    "IDconvention_parent",
+    "reference",
+    "version",
+    "statut",
+    "date_debut",
+    "date_fin",
+    "objet",
+    "notes",
+    "snapshot_contractuel",
+    "empreinte_sha256",
+    "date_validation",
+    "date_signature",
+    "actif",
+    "date_creation",
+    "date_modification",
+)
+
+CHAMPS_TEXTE = (
+    "reference",
+    "objet",
+    "notes",
+)
+
+CHAMPS_RELATION_SNAPSHOT = (
+    "uid",
+    "IDstructure",
+    "IDgroupe_structure",
+    "IDactivite",
+    "type_relation",
+    "libelle",
+    "saison",
+    "fonction_intervenant",
+    "IDintervenant_externe",
+    "nom_intervenant",
+    "date_debut",
+    "date_fin",
+    "tarif",
+    "unite_tarif",
+    "regle_adhesion",
+    "mode_facturation",
+    "jour_facturation",
+    "memo",
+)
+
+CHAMPS_PAYEUR_SNAPSHOT = (
+    "IDpayeur_structure",
+    "type_payeur",
+    "IDfamille",
+    "IDstructure_payeur",
+    "libelle_payeur",
+    "taux_prise_en_charge",
+    "montant_plafond",
+    "date_debut",
+    "date_fin",
+    "reference",
+    "implicite",
+)
+
+
+def _texte(valeur):
+    if valeur is None:
+        return u""
+    try:
+        return valeur.strip()
+    except Exception:
+        return valeur
+
+
+def _date_iso(valeur, nom_champ, obligatoire=False):
+    if valeur in (None, ""):
+        if obligatoire:
+            raise ValueError("%s est obligatoire" % nom_champ)
+        return None
+    if isinstance(valeur, datetime.datetime):
+        valeur = valeur.date()
+    if isinstance(valeur, datetime.date):
+        return valeur.isoformat()
+    valeur = _texte(valeur)
+    try:
+        return datetime.datetime.strptime(valeur, "%Y-%m-%d").date().isoformat()
+    except (TypeError, ValueError):
+        raise ValueError("%s doit être une date ISO YYYY-MM-DD" % nom_champ)
+
+
+def _date_maintenant(date=None):
+    if date is None:
+        return datetime.date.today().isoformat()
+    return _date_iso(date, "date", obligatoire=True)
+
+
+def _entier_positif(valeur, nom_champ, obligatoire=False):
+    if valeur in (None, "", 0, "0"):
+        if obligatoire:
+            raise ValueError("%s est obligatoire" % nom_champ)
+        return None
+    try:
+        valeur = int(valeur)
+    except (TypeError, ValueError):
+        raise ValueError("%s doit être un entier" % nom_champ)
+    if valeur <= 0:
+        raise ValueError("%s doit être positif" % nom_champ)
+    return valeur
+
+
+def _uid_convention(valeur=None, generer=True):
+    valeur = _texte(valeur)
+    if not valeur:
+        if not generer:
+            raise ValueError("UID de convention obligatoire")
+        return "CONV-%s" % uuid.uuid4().hex
+    if len(valeur) > 64 or not all(ch.isalnum() or ch in "-_" for ch in valeur):
+        raise ValueError("UID de convention invalide")
+    return valeur
+
+
+def _verifier_periode(date_debut, date_fin):
+    if date_debut and date_fin and date_fin < date_debut:
+        raise ValueError("date_fin ne peut pas précéder date_debut")
+
+
+def _liste_pairs(donnees, ordre):
+    return [(champ, donnees.get(champ)) for champ in ordre if champ in donnees]
+
+
+def _normaliser_json(valeur):
+    """Produit une structure JSON stable sans objets métier implicites."""
+    if valeur is None or isinstance(valeur, (bool, int, float, str)):
+        return valeur
+    if isinstance(valeur, bytes):
+        return valeur.decode("utf-8")
+    if isinstance(valeur, datetime.datetime):
+        return valeur.isoformat()
+    if isinstance(valeur, datetime.date):
+        return valeur.isoformat()
+    if isinstance(valeur, (list, tuple)):
+        return [_normaliser_json(item) for item in valeur]
+    if isinstance(valeur, dict):
+        return dict((str(cle), _normaliser_json(item)) for cle, item in valeur.items())
+    raise ValueError("Valeur non sérialisable dans le snapshot: %r" % (valeur,))
+
+
+def _serialiser_snapshot(snapshot):
+    normalise = _normaliser_json(snapshot)
+    texte = json.dumps(
+        normalise,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return texte.encode("utf-8")
+
+
+def _empreinte(contenu):
+    if isinstance(contenu, str):
+        contenu = contenu.encode("utf-8")
+    return hashlib.sha256(contenu).hexdigest()
+
+
+def _decoder_snapshot(contenu):
+    if contenu in (None, b"", ""):
+        return None
+    if isinstance(contenu, bytes):
+        contenu = contenu.decode("utf-8")
+    return json.loads(contenu)
+
+
+def NormaliserConvention(donnees, creation=True, date=None):
+    donnees = dict(donnees or {})
+    if not donnees:
+        raise ValueError("Aucune donnée de convention")
+
+    resultat = {}
+    if creation:
+        resultat["uid"] = _uid_convention(donnees.get("uid"), generer=True)
+        resultat["IDrelation_structure"] = _entier_positif(
+            donnees.get("IDrelation_structure"), "IDrelation_structure", obligatoire=True
+        )
+        resultat["IDconvention_parent"] = _entier_positif(
+            donnees.get("IDconvention_parent"), "IDconvention_parent"
+        )
+        try:
+            version = int(donnees.get("version", 1))
+        except (TypeError, ValueError):
+            raise ValueError("version doit être un entier")
+        if version < 1:
+            raise ValueError("version doit être supérieure ou égale à 1")
+        resultat["version"] = version
+        statut = _texte(donnees.get("statut")) or STATUT_BROUILLON
+        if statut != STATUT_BROUILLON:
+            raise ValueError("Une convention doit être créée en brouillon")
+        resultat["statut"] = statut
+    else:
+        # Identité, relation, parent, version et statut sont gérés par le workflow.
+        interdits = (
+            "uid",
+            "IDrelation_structure",
+            "IDconvention_parent",
+            "version",
+            "statut",
+            "snapshot_contractuel",
+            "empreinte_sha256",
+            "date_validation",
+            "date_signature",
+            "date_creation",
+        )
+        if any(champ in donnees for champ in interdits):
+            raise ValueError("Modification directe d'un champ contractuel protégé")
+
+    for champ in CHAMPS_TEXTE:
+        if creation or champ in donnees:
+            resultat[champ] = _texte(donnees.get(champ))
+
+    date_debut = None
+    date_fin = None
+    if creation or "date_debut" in donnees:
+        date_debut = _date_iso(
+            donnees.get("date_debut"), "date_debut", obligatoire=creation
+        )
+        resultat["date_debut"] = date_debut
+    if creation or "date_fin" in donnees:
+        date_fin = _date_iso(donnees.get("date_fin"), "date_fin")
+        resultat["date_fin"] = date_fin
+    if creation:
+        _verifier_periode(date_debut, date_fin)
+
+    if creation:
+        resultat["snapshot_contractuel"] = None
+        resultat["empreinte_sha256"] = ""
+        resultat["date_validation"] = None
+        resultat["date_signature"] = None
+    if creation or "actif" in donnees:
+        resultat["actif"] = 1 if donnees.get("actif", 1) not in (0, False, "0") else 0
+
+    resultat["date_modification"] = _date_maintenant(date)
+    if creation:
+        resultat["date_creation"] = _date_iso(
+            donnees.get("date_creation") or date or datetime.date.today(),
+            "date_creation",
+            obligatoire=True,
+        )
+    return resultat
+
+
+class GestionnaireConventionsStructures(object):
+    def __init__(self, db):
+        self.db = db
+        self.relations = UTILS_Relations_Structures.GestionnaireRelationsStructures(db)
+
+    def LireConvention(self, IDconvention_structure):
+        IDconvention_structure = _entier_positif(
+            IDconvention_structure, "IDconvention_structure", obligatoire=True
+        )
+        req = "SELECT IDconvention_structure, %s FROM structures_conventions WHERE IDconvention_structure=%d;" % (
+            ", ".join(CHAMPS_CONVENTION), IDconvention_structure
+        )
+        if self.db.ExecuterReq(req) != 1:
+            return None
+        lignes = self.db.ResultatReq() or []
+        if not lignes:
+            return None
+        return dict(zip(("IDconvention_structure",) + CHAMPS_CONVENTION, lignes[0]))
+
+    def LireConventionParUID(self, uid):
+        uid = _uid_convention(uid, generer=False)
+        req = "SELECT IDconvention_structure, %s FROM structures_conventions WHERE uid='%s';" % (
+            ", ".join(CHAMPS_CONVENTION), uid
+        )
+        if self.db.ExecuterReq(req) != 1:
+            return None
+        lignes = self.db.ResultatReq() or []
+        if not lignes:
+            return None
+        if len(lignes) > 1:
+            raise RuntimeError("UID de convention dupliqué")
+        return dict(zip(("IDconvention_structure",) + CHAMPS_CONVENTION, lignes[0]))
+
+    def ListerConventions(self, IDrelation_structure=None, actifs_seulement=True):
+        conditions = []
+        if IDrelation_structure:
+            conditions.append("IDrelation_structure=%d" % int(IDrelation_structure))
+        if actifs_seulement:
+            conditions.append("actif=1")
+        req = "SELECT IDconvention_structure, %s FROM structures_conventions" % ", ".join(CHAMPS_CONVENTION)
+        if conditions:
+            req += " WHERE " + " AND ".join(conditions)
+        req += " ORDER BY IDrelation_structure, version, IDconvention_structure;"
+        if self.db.ExecuterReq(req) != 1:
+            return []
+        return [
+            dict(zip(("IDconvention_structure",) + CHAMPS_CONVENTION, ligne))
+            for ligne in (self.db.ResultatReq() or [])
+        ]
+
+    def _version_existe(self, IDrelation_structure, version):
+        req = (
+            "SELECT IDconvention_structure FROM structures_conventions "
+            "WHERE IDrelation_structure=%d AND version=%d;"
+        ) % (int(IDrelation_structure), int(version))
+        if self.db.ExecuterReq(req) != 1:
+            return False
+        return bool(self.db.ResultatReq() or [])
+
+    def _verifier_periode_relation(self, relation, date_debut, date_fin):
+        debut_relation = relation.get("date_debut")
+        fin_relation = relation.get("date_fin")
+        if debut_relation and date_debut and date_debut < debut_relation:
+            raise ValueError("La convention débute avant la relation contractuelle")
+        if fin_relation and date_fin and date_fin > fin_relation:
+            raise ValueError("La convention se termine après la relation contractuelle")
+        if fin_relation and not date_fin:
+            raise ValueError("Une relation bornée exige une date_fin de convention")
+
+    def CreerConvention(self, donnees, date=None):
+        valeurs = NormaliserConvention(donnees, creation=True, date=date)
+        if valeurs.get("IDconvention_parent"):
+            raise ValueError("Utiliser CreerAvenant pour créer une version dérivée")
+        if valeurs["version"] != 1:
+            raise ValueError("Une convention initiale doit être en version 1")
+        relation = self.relations.LireRelation(valeurs["IDrelation_structure"])
+        if not relation:
+            raise ValueError("Relation contractuelle introuvable")
+        if self.LireConventionParUID(valeurs["uid"]):
+            raise ValueError("UID de convention déjà utilisé")
+        if self._version_existe(valeurs["IDrelation_structure"], 1):
+            raise ValueError("Une convention initiale existe déjà pour cette relation")
+        self._verifier_periode_relation(
+            relation, valeurs.get("date_debut"), valeurs.get("date_fin")
+        )
+        return self.db.ReqInsert(
+            "structures_conventions", _liste_pairs(valeurs, CHAMPS_CONVENTION)
+        )
+
+    def CreerAvenant(self, IDconvention_parent, donnees=None, date=None):
+        parent = self.LireConvention(IDconvention_parent)
+        if not parent:
+            raise ValueError("Convention parente introuvable")
+        if parent["statut"] not in STATUTS_PARENT_AVENANT:
+            raise ValueError("Le parent doit être validé, signé ou terminé")
+        donnees = dict(donnees or {})
+        donnees["IDrelation_structure"] = parent["IDrelation_structure"]
+        donnees["IDconvention_parent"] = parent["IDconvention_structure"]
+        donnees["version"] = int(parent["version"]) + 1
+        donnees["statut"] = STATUT_BROUILLON
+        donnees.setdefault("date_debut", parent["date_debut"])
+        donnees.setdefault("date_fin", parent["date_fin"])
+        valeurs = NormaliserConvention(donnees, creation=True, date=date)
+        if self._version_existe(valeurs["IDrelation_structure"], valeurs["version"]):
+            raise ValueError("Cette version existe déjà pour la relation")
+        relation = self.relations.LireRelation(valeurs["IDrelation_structure"])
+        if not relation:
+            raise ValueError("Relation contractuelle introuvable")
+        if self.LireConventionParUID(valeurs["uid"]):
+            raise ValueError("UID de convention déjà utilisé")
+        self._verifier_periode_relation(
+            relation, valeurs.get("date_debut"), valeurs.get("date_fin")
+        )
+        return self.db.ReqInsert(
+            "structures_conventions", _liste_pairs(valeurs, CHAMPS_CONVENTION)
+        )
+
+    def ModifierConvention(self, IDconvention_structure, donnees, date=None):
+        courant = self.LireConvention(IDconvention_structure)
+        if not courant:
+            raise ValueError("Convention introuvable")
+        if courant["statut"] != STATUT_BROUILLON:
+            raise ValueError("Une version figée ne peut plus être modifiée")
+        changements = NormaliserConvention(donnees, creation=False, date=date)
+        date_debut = changements.get("date_debut", courant.get("date_debut"))
+        date_fin = changements.get("date_fin", courant.get("date_fin"))
+        _verifier_periode(date_debut, date_fin)
+        relation = self.relations.LireRelation(courant["IDrelation_structure"])
+        if not relation:
+            raise ValueError("Relation contractuelle introuvable")
+        self._verifier_periode_relation(relation, date_debut, date_fin)
+        return self.db.ReqMAJ(
+            "structures_conventions",
+            _liste_pairs(changements, CHAMPS_CONVENTION),
+            "IDconvention_structure",
+            int(IDconvention_structure),
+        )
+
+    def ConstruireSnapshotContractuel(self, IDconvention_structure, complements=None):
+        convention = self.LireConvention(IDconvention_structure)
+        if not convention:
+            raise ValueError("Convention introuvable")
+        relation = self.relations.LireRelation(convention["IDrelation_structure"])
+        if not relation:
+            raise ValueError("Relation contractuelle introuvable")
+        payeurs = self.relations.ListerPayeursEffectifs(convention["IDrelation_structure"])
+
+        convention_snapshot = {
+            "uid": convention["uid"],
+            "IDconvention_parent": convention.get("IDconvention_parent"),
+            "reference": convention.get("reference") or "",
+            "version": int(convention["version"]),
+            "date_debut": convention.get("date_debut"),
+            "date_fin": convention.get("date_fin"),
+            "objet": convention.get("objet") or "",
+        }
+        relation_snapshot = dict(
+            (champ, relation.get(champ)) for champ in CHAMPS_RELATION_SNAPSHOT
+        )
+        payeurs_snapshot = [
+            dict((champ, payeur.get(champ)) for champ in CHAMPS_PAYEUR_SNAPSHOT)
+            for payeur in payeurs
+        ]
+        snapshot = {
+            "schema": "noe-062-convention-v1",
+            "convention": convention_snapshot,
+            "relation": relation_snapshot,
+            "payeurs": payeurs_snapshot,
+        }
+        if complements not in (None, {}):
+            snapshot["complements"] = _normaliser_json(complements)
+        return _normaliser_json(snapshot)
+
+    def ValiderConvention(self, IDconvention_structure, complements=None, date=None):
+        convention = self.LireConvention(IDconvention_structure)
+        if not convention:
+            raise ValueError("Convention introuvable")
+        if convention["statut"] != STATUT_BROUILLON:
+            raise ValueError("Seul un brouillon peut être validé")
+        snapshot = self.ConstruireSnapshotContractuel(
+            IDconvention_structure, complements=complements
+        )
+        contenu = _serialiser_snapshot(snapshot)
+        valeurs = {
+            "statut": STATUT_VALIDEE,
+            "snapshot_contractuel": contenu,
+            "empreinte_sha256": _empreinte(contenu),
+            "date_validation": _date_maintenant(date),
+            "date_modification": _date_maintenant(date),
+        }
+        return self.db.ReqMAJ(
+            "structures_conventions",
+            _liste_pairs(valeurs, CHAMPS_CONVENTION),
+            "IDconvention_structure",
+            int(IDconvention_structure),
+        )
+
+    def VerifierIntegrite(self, IDconvention_structure):
+        convention = self.LireConvention(IDconvention_structure)
+        if not convention:
+            raise ValueError("Convention introuvable")
+        contenu = convention.get("snapshot_contractuel")
+        empreinte = _texte(convention.get("empreinte_sha256"))
+        if contenu in (None, b"", "") or not empreinte:
+            return False
+        return _empreinte(contenu) == empreinte
+
+    def LireSnapshot(self, IDconvention_structure):
+        convention = self.LireConvention(IDconvention_structure)
+        if not convention:
+            raise ValueError("Convention introuvable")
+        if not self.VerifierIntegrite(IDconvention_structure):
+            raise ValueError("Intégrité du snapshot contractuel invalide")
+        return _decoder_snapshot(convention.get("snapshot_contractuel"))
+
+    def SignerConvention(self, IDconvention_structure, date=None):
+        convention = self.LireConvention(IDconvention_structure)
+        if not convention:
+            raise ValueError("Convention introuvable")
+        if convention["statut"] == STATUT_SIGNEE:
+            return True
+        if convention["statut"] != STATUT_VALIDEE:
+            raise ValueError("Seule une convention validée peut être signée")
+        if not self.VerifierIntegrite(IDconvention_structure):
+            raise ValueError("Snapshot contractuel absent ou altéré")
+        valeurs = {
+            "statut": STATUT_SIGNEE,
+            "date_signature": _date_maintenant(date),
+            "date_modification": _date_maintenant(date),
+        }
+        return self.db.ReqMAJ(
+            "structures_conventions",
+            _liste_pairs(valeurs, CHAMPS_CONVENTION),
+            "IDconvention_structure",
+            int(IDconvention_structure),
+        )
+
+    def TerminerConvention(self, IDconvention_structure, date=None):
+        convention = self.LireConvention(IDconvention_structure)
+        if not convention:
+            raise ValueError("Convention introuvable")
+        if convention["statut"] == STATUT_TERMINEE:
+            return True
+        if convention["statut"] not in (STATUT_VALIDEE, STATUT_SIGNEE):
+            raise ValueError("Convention non terminable dans son état actuel")
+        if not self.VerifierIntegrite(IDconvention_structure):
+            raise ValueError("Snapshot contractuel absent ou altéré")
+        valeurs = {
+            "statut": STATUT_TERMINEE,
+            "date_modification": _date_maintenant(date),
+        }
+        return self.db.ReqMAJ(
+            "structures_conventions",
+            _liste_pairs(valeurs, CHAMPS_CONVENTION),
+            "IDconvention_structure",
+            int(IDconvention_structure),
+        )
+
+    def AnnulerConvention(self, IDconvention_structure, date=None):
+        convention = self.LireConvention(IDconvention_structure)
+        if not convention:
+            raise ValueError("Convention introuvable")
+        if convention["statut"] == STATUT_ANNULEE:
+            return True
+        valeurs = {
+            "statut": STATUT_ANNULEE,
+            "date_modification": _date_maintenant(date),
+        }
+        return self.db.ReqMAJ(
+            "structures_conventions",
+            _liste_pairs(valeurs, CHAMPS_CONVENTION),
+            "IDconvention_structure",
+            int(IDconvention_structure),
+        )
+
+    def ArchiverConvention(self, IDconvention_structure, date=None):
+        convention = self.LireConvention(IDconvention_structure)
+        if not convention:
+            raise ValueError("Convention introuvable")
+        if convention["statut"] not in (STATUT_TERMINEE, STATUT_ANNULEE):
+            raise ValueError("Seule une version terminée ou annulée peut être archivée")
+        valeurs = {
+            "actif": 0,
+            "date_modification": _date_maintenant(date),
+        }
+        return self.db.ReqMAJ(
+            "structures_conventions",
+            _liste_pairs(valeurs, CHAMPS_CONVENTION),
+            "IDconvention_structure",
+            int(IDconvention_structure),
+        )

--- a/noethys/Utils/UTILS_Conventions_Structures_Schema.py
+++ b/noethys/Utils/UTILS_Conventions_Structures_Schema.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Activation additive contrôlée du schéma conventions Noe-062.
+
+La table ``structures_relations`` est un prérequis : ce module ne la crée pas
+implicitement. Seule ``structures_conventions`` peut être créée par
+``AssurerSchemaConventions(..., appliquer=True)`` après un préflight complet.
+"""
+from __future__ import unicode_literals
+
+import re
+
+from Data import DATA_Conventions_Structures
+from Data import DATA_Structures
+
+
+TABLE_RELATIONS = "structures_relations"
+TABLE_CONVENTIONS = "structures_conventions"
+
+
+def _description(nom_table):
+    if nom_table == TABLE_CONVENTIONS:
+        return tuple(DATA_Conventions_Structures.DB_CONVENTIONS_STRUCTURES[nom_table])
+    return tuple(DATA_Structures.DB_STRUCTURES[nom_table])
+
+
+def _dictionnaire_creation(nom_table):
+    if nom_table == TABLE_CONVENTIONS:
+        return DATA_Conventions_Structures.DB_CONVENTIONS_STRUCTURES
+    return DATA_Structures.DB_STRUCTURES
+
+
+def _chaine(valeur):
+    if isinstance(valeur, bytes):
+        return valeur.decode("ascii", "ignore")
+    return str(valeur)
+
+
+def _type_attendu(type_decl, is_network):
+    type_decl = type_decl.upper().strip()
+    if not is_network:
+        if type_decl == "LONGBLOB":
+            return "BLOB"
+        if type_decl == "BIGINT":
+            return "INTEGER"
+        return type_decl
+    if type_decl == "INTEGER PRIMARY KEY AUTOINCREMENT":
+        return "INTEGER PRIMARY KEY AUTO_INCREMENT"
+    if type_decl == "FLOAT":
+        return "REAL"
+    if type_decl == "DATE":
+        return "VARCHAR(10)"
+    if type_decl.startswith("VARCHAR"):
+        match = re.search(r"\((\d+)\)", type_decl)
+        if match:
+            taille = int(match.group(1))
+            if taille > 20000:
+                return "MEDIUMTEXT"
+            if taille > 255:
+                return "TEXT(%d)" % taille
+    return type_decl
+
+
+def _categorie_type(type_sql):
+    if type_sql is None:
+        return ""
+    valeur = _chaine(type_sql).strip().lower()
+    base = valeur.split("(", 1)[0].strip()
+    if "int" in base:
+        return "integer"
+    if base in ("float", "real", "double", "decimal", "numeric"):
+        return "real"
+    if base in ("char", "varchar", "text", "tinytext", "mediumtext", "longtext"):
+        return "text"
+    if base in ("blob", "tinyblob", "mediumblob", "longblob"):
+        return "blob"
+    if base in ("date", "datetime", "timestamp"):
+        return "date"
+    return base
+
+
+def _metadata_table(db, nom_table):
+    is_network = bool(getattr(db, "isNetwork", False))
+    colonnes = {}
+    if not is_network:
+        if db.ExecuterReq("PRAGMA table_info('%s');" % nom_table) != 1:
+            return None
+        for cid, nom, type_sql, notnull, valeur_defaut, pk in db.ResultatReq():
+            nom = _chaine(nom)
+            colonnes[nom] = {
+                "type": type_sql,
+                "pk": bool(pk),
+                "auto": bool(pk) and _categorie_type(type_sql) == "integer",
+            }
+    else:
+        if db.ExecuterReq("SHOW COLUMNS FROM %s;" % nom_table) != 1:
+            return None
+        for valeurs in db.ResultatReq():
+            nom = _chaine(valeurs[0])
+            colonnes[nom] = {
+                "type": valeurs[1],
+                "pk": _chaine(valeurs[3] if len(valeurs) > 3 else "").upper() == "PRI",
+                "auto": "auto_increment" in _chaine(valeurs[5] if len(valeurs) > 5 else "").lower(),
+            }
+    return colonnes
+
+
+def _inspecter_table(db, nom_table):
+    existe = bool(db.IsTableExists(nom_table))
+    description = _description(nom_table)
+    champs_attendus = tuple(champ[0] for champ in description)
+    rapport = {
+        "existe": existe,
+        "champs_attendus": champs_attendus,
+        "champs_presents": (),
+        "champs_manquants": champs_attendus,
+        "champs_incompatibles": (),
+        "metadata_ok": False,
+        "conforme": False,
+    }
+    if not existe:
+        return rapport
+
+    metadata = _metadata_table(db, nom_table)
+    if metadata is None:
+        return rapport
+
+    rapport["metadata_ok"] = True
+    rapport["champs_presents"] = tuple(metadata.keys())
+    rapport["champs_manquants"] = tuple(
+        champ for champ in champs_attendus if champ not in metadata
+    )
+    incompatibles = []
+    is_network = bool(getattr(db, "isNetwork", False))
+    for nom_champ, type_decl, info in description:
+        if nom_champ not in metadata:
+            continue
+        attendu = _type_attendu(type_decl, is_network)
+        present = metadata[nom_champ]
+        if _categorie_type(attendu) != _categorie_type(present["type"]):
+            incompatibles.append(nom_champ)
+            continue
+        if "PRIMARY KEY" in attendu and not present["pk"]:
+            incompatibles.append(nom_champ)
+            continue
+        if "AUTO_INCREMENT" in attendu and not present["auto"]:
+            incompatibles.append(nom_champ)
+    rapport["champs_incompatibles"] = tuple(incompatibles)
+    rapport["conforme"] = (
+        rapport["metadata_ok"]
+        and not rapport["champs_manquants"]
+        and not rapport["champs_incompatibles"]
+    )
+    return rapport
+
+
+def InspecterSchemaConventions(db):
+    """Inspecte la dépendance relation et la table conventions sans écrire."""
+    return {
+        TABLE_RELATIONS: _inspecter_table(db, TABLE_RELATIONS),
+        TABLE_CONVENTIONS: _inspecter_table(db, TABLE_CONVENTIONS),
+    }
+
+
+def AssurerSchemaConventions(db, appliquer=False):
+    """Crée uniquement ``structures_conventions`` après préflight complet.
+
+    Une relation absente ou incohérente bloque l'activation. Une table
+    conventions existante mais incompatible bloque également toute écriture.
+    """
+    avant = InspecterSchemaConventions(db)
+    relation = avant[TABLE_RELATIONS]
+    convention = avant[TABLE_CONVENTIONS]
+
+    incoherentes = tuple(
+        nom for nom, rapport in avant.items()
+        if rapport["existe"] and not rapport["conforme"]
+    )
+    if not relation["existe"] or not relation["conforme"] or incoherentes:
+        return {
+            "ok": False,
+            "appliquer": bool(appliquer),
+            "tables_creees": (),
+            "tables_absentes": tuple(
+                nom for nom, rapport in avant.items() if not rapport["existe"]
+            ),
+            "tables_incoherentes": incoherentes,
+            "prerequis_absents": () if relation["existe"] else (TABLE_RELATIONS,),
+            "rapport": avant,
+        }
+
+    creees = []
+    if appliquer and not convention["existe"]:
+        db.CreationTable(TABLE_CONVENTIONS, _dictionnaire_creation(TABLE_CONVENTIONS))
+        db.Commit()
+        creees.append(TABLE_CONVENTIONS)
+
+    apres = InspecterSchemaConventions(db)
+    absentes = tuple(
+        nom for nom, rapport in apres.items() if not rapport["existe"]
+    )
+    incoherentes = tuple(
+        nom for nom, rapport in apres.items()
+        if rapport["existe"] and not rapport["conforme"]
+    )
+    return {
+        "ok": not incoherentes and (not appliquer or not absentes),
+        "appliquer": bool(appliquer),
+        "tables_creees": tuple(creees),
+        "tables_absentes": absentes,
+        "tables_incoherentes": incoherentes,
+        "prerequis_absents": (),
+        "rapport": apres,
+    }

--- a/tests/test_noe_062_conventions_avenants.py
+++ b/tests/test_noe_062_conventions_avenants.py
@@ -1,0 +1,443 @@
+# -*- coding: utf-8 -*-
+import hashlib
+import importlib.util
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOETHYS = ROOT / "noethys"
+if str(NOETHYS) not in sys.path:
+    sys.path.insert(0, str(NOETHYS))
+
+
+def _charger(path, nom):
+    spec = importlib.util.spec_from_file_location(nom, str(ROOT / path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+DATA = _charger("noethys/Data/DATA_Structures.py", "DATA_Structures_noe062_conv")
+DATA_CONV = _charger(
+    "noethys/Data/DATA_Conventions_Structures.py", "DATA_Conventions_noe062_conv"
+)
+SCHEMA = _charger(
+    "noethys/Utils/UTILS_Conventions_Structures_Schema.py",
+    "UTILS_Conventions_Schema_noe062_conv",
+)
+CONV = _charger(
+    "noethys/Utils/UTILS_Conventions_Structures.py",
+    "UTILS_Conventions_noe062_conv",
+)
+REL = _charger(
+    "noethys/Utils/UTILS_Relations_Structures.py",
+    "UTILS_Relations_noe062_conv",
+)
+
+
+class SQLiteDB(object):
+    isNetwork = False
+
+    def __init__(self):
+        self.conn = sqlite3.connect(":memory:")
+        self._resultat = []
+        self.creations = []
+        self.commits = 0
+
+    def IsTableExists(self, nom_table):
+        cur = self.conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (nom_table,)
+        )
+        return cur.fetchone() is not None
+
+    def ExecuterReq(self, req):
+        try:
+            cur = self.conn.execute(req)
+            self._resultat = cur.fetchall()
+            return 1
+        except sqlite3.Error:
+            self._resultat = []
+            return 0
+
+    def ResultatReq(self):
+        return list(self._resultat)
+
+    def CreationTable(self, nom_table, dico):
+        champs = []
+        for nom, type_sql, info in dico[nom_table]:
+            if type_sql == "LONGBLOB":
+                type_sql = "BLOB"
+            elif type_sql == "BIGINT":
+                type_sql = "INTEGER"
+            champs.append("%s %s" % (nom, type_sql))
+        self.conn.execute("CREATE TABLE %s (%s)" % (nom_table, ", ".join(champs)))
+        self.creations.append(nom_table)
+
+    def Commit(self):
+        self.conn.commit()
+        self.commits += 1
+
+    def ReqInsert(self, table, donnees, commit=True):
+        donnees = list(donnees)
+        champs = [champ for champ, valeur in donnees]
+        valeurs = [valeur for champ, valeur in donnees]
+        req = "INSERT INTO %s (%s) VALUES (%s)" % (
+            table,
+            ", ".join(champs),
+            ", ".join(["?"] * len(champs)),
+        )
+        cur = self.conn.execute(req, valeurs)
+        if commit:
+            self.conn.commit()
+        return cur.lastrowid
+
+    def ReqMAJ(self, table, donnees, cle, ID, IDestChaine=False, commit=True):
+        donnees = list(donnees)
+        champs = [champ for champ, valeur in donnees]
+        valeurs = [valeur for champ, valeur in donnees]
+        req = "UPDATE %s SET %s WHERE %s=?" % (
+            table,
+            ", ".join("%s=?" % champ for champ in champs),
+            cle,
+        )
+        self.conn.execute(req, valeurs + [ID])
+        if commit:
+            self.conn.commit()
+        return True
+
+
+def _creer_table(db, nom_table):
+    db.CreationTable(nom_table, DATA.DB_STRUCTURES)
+    db.Commit()
+
+
+def _preparer_base(avec_conventions=True):
+    db = SQLiteDB()
+    for table in (
+        "structures",
+        "structures_groupes",
+        "structures_relations",
+        "structures_payeurs",
+    ):
+        _creer_table(db, table)
+    if avec_conventions:
+        db.CreationTable("structures_conventions", DATA_CONV.DB_CONVENTIONS_STRUCTURES)
+        db.Commit()
+    db.ReqInsert(
+        "structures",
+        [
+            ("uid", "STR-benef"),
+            ("type_structure", "association"),
+            ("nom", "Association bénéficiaire"),
+            ("actif", 1),
+            ("date_creation", "2026-09-01"),
+            ("date_modification", "2026-09-01"),
+        ],
+    )
+    return db
+
+
+def _creer_relation(db, date_fin="2027-08-31"):
+    gestion = REL.GestionnaireRelationsStructures(db)
+    return gestion.CreerRelation(
+        {
+            "uid": "REL-2026-001",
+            "IDstructure": 1,
+            "type_relation": "mise_disposition",
+            "libelle": "Encadrement sportif saison 2026-2027",
+            "saison": "2026-2027",
+            "date_debut": "2026-09-01",
+            "date_fin": date_fin,
+            "tarif": 44,
+            "unite_tarif": "heure",
+            "regle_adhesion": "requise",
+            "mode_facturation": "mensuel",
+        },
+        date="2026-09-01",
+    )
+
+
+def _creer_convention_brouillon(db):
+    IDrelation = _creer_relation(db)
+    gestion = CONV.GestionnaireConventionsStructures(db)
+    IDconv = gestion.CreerConvention(
+        {
+            "uid": "CONV-2026-001",
+            "IDrelation_structure": IDrelation,
+            "reference": "MAD-2026-001",
+            "date_debut": "2026-09-01",
+            "date_fin": "2027-08-31",
+            "objet": "Mise à disposition d'un éducateur sportif",
+        },
+        date="2026-09-01",
+    )
+    return gestion, IDrelation, IDconv
+
+
+def test_schema_declare_snapshot_et_versionnement():
+    champs = DATA_CONV.GetChamps()
+    assert champs[0] == "IDconvention_structure"
+    for champ in (
+        "uid",
+        "IDrelation_structure",
+        "IDconvention_parent",
+        "version",
+        "statut",
+        "snapshot_contractuel",
+        "empreinte_sha256",
+        "date_validation",
+        "date_signature",
+    ):
+        assert champ in champs
+
+
+def test_activation_refuse_relation_absente_sans_ecriture():
+    db = SQLiteDB()
+    resultat = SCHEMA.AssurerSchemaConventions(db, appliquer=True)
+    assert resultat["ok"] is False
+    assert resultat["prerequis_absents"] == ("structures_relations",)
+    assert db.creations == []
+
+
+def test_activation_cree_uniquement_conventions_et_est_idempotente():
+    db = SQLiteDB()
+    _creer_table(db, "structures_relations")
+    avant = list(db.creations)
+    resultat = SCHEMA.AssurerSchemaConventions(db, appliquer=True)
+    assert resultat["ok"] is True
+    assert resultat["tables_creees"] == ("structures_conventions",)
+    assert db.creations == avant + ["structures_conventions"]
+
+    resultat2 = SCHEMA.AssurerSchemaConventions(db, appliquer=True)
+    assert resultat2["ok"] is True
+    assert resultat2["tables_creees"] == ()
+    assert db.creations == avant + ["structures_conventions"]
+
+
+def test_schema_conventions_incomplet_bloque_sans_reparation_silencieuse():
+    db = SQLiteDB()
+    _creer_table(db, "structures_relations")
+    db.conn.execute(
+        "CREATE TABLE structures_conventions (IDconvention_structure INTEGER PRIMARY KEY AUTOINCREMENT, uid VARCHAR(64))"
+    )
+    db.conn.commit()
+    creations = list(db.creations)
+    resultat = SCHEMA.AssurerSchemaConventions(db, appliquer=True)
+    assert resultat["ok"] is False
+    assert resultat["tables_incoherentes"] == ("structures_conventions",)
+    assert "IDrelation_structure" in resultat["rapport"]["structures_conventions"]["champs_manquants"]
+    assert db.creations == creations
+
+
+def test_creation_initiale_est_version_1_et_liee_a_la_relation():
+    db = _preparer_base()
+    gestion, IDrelation, IDconv = _creer_convention_brouillon(db)
+    conv = gestion.LireConvention(IDconv)
+    assert conv["uid"] == "CONV-2026-001"
+    assert conv["IDrelation_structure"] == IDrelation
+    assert conv["IDconvention_parent"] is None
+    assert conv["version"] == 1
+    assert conv["statut"] == CONV.STATUT_BROUILLON
+    assert conv["snapshot_contractuel"] is None
+
+
+def test_une_seule_version_1_par_relation():
+    db = _preparer_base()
+    gestion, IDrelation, IDconv = _creer_convention_brouillon(db)
+    try:
+        gestion.CreerConvention(
+            {
+                "IDrelation_structure": IDrelation,
+                "date_debut": "2026-09-01",
+                "date_fin": "2027-08-31",
+            }
+        )
+        assert False, "deuxième version 1 acceptée"
+    except ValueError as err:
+        assert "initiale existe déjà" in str(err)
+
+
+def test_brouillon_est_modifiable_sans_changer_son_identite():
+    db = _preparer_base()
+    gestion, IDrelation, IDconv = _creer_convention_brouillon(db)
+    gestion.ModifierConvention(
+        IDconv,
+        {"objet": "Objet corrigé", "notes": "Préparation bureau"},
+        date="2026-09-02",
+    )
+    conv = gestion.LireConvention(IDconv)
+    assert conv["uid"] == "CONV-2026-001"
+    assert conv["version"] == 1
+    assert conv["objet"] == "Objet corrigé"
+
+    try:
+        gestion.ModifierConvention(IDconv, {"version": 8})
+        assert False, "version modifiée directement"
+    except ValueError:
+        pass
+
+
+def test_validation_fige_relation_payeur_et_sha256():
+    db = _preparer_base()
+    gestion, IDrelation, IDconv = _creer_convention_brouillon(db)
+    assert gestion.ValiderConvention(
+        IDconv,
+        complements={"contact_convention": {"nom": "Martin", "role": "président"}},
+        date="2026-09-03",
+    ) is True
+
+    conv = gestion.LireConvention(IDconv)
+    assert conv["statut"] == CONV.STATUT_VALIDEE
+    assert conv["date_validation"] == "2026-09-03"
+    assert conv["empreinte_sha256"] == hashlib.sha256(conv["snapshot_contractuel"]).hexdigest()
+    assert gestion.VerifierIntegrite(IDconv) is True
+
+    snapshot = gestion.LireSnapshot(IDconv)
+    assert snapshot["schema"] == "noe-062-convention-v1"
+    assert snapshot["relation"]["uid"] == "REL-2026-001"
+    assert snapshot["relation"]["regle_adhesion"] == "requise"
+    assert snapshot["payeurs"][0]["implicite"] is True
+    assert snapshot["payeurs"][0]["IDstructure_payeur"] == 1
+    assert snapshot["complements"]["contact_convention"]["nom"] == "Martin"
+
+
+def test_version_validee_ne_peut_plus_etre_modifiee():
+    db = _preparer_base()
+    gestion, IDrelation, IDconv = _creer_convention_brouillon(db)
+    gestion.ValiderConvention(IDconv, date="2026-09-03")
+    try:
+        gestion.ModifierConvention(IDconv, {"objet": "Réécriture interdite"})
+        assert False, "version validée modifiée"
+    except ValueError as err:
+        assert "figée" in str(err)
+
+
+def test_snapshot_altere_bloque_signature():
+    db = _preparer_base()
+    gestion, IDrelation, IDconv = _creer_convention_brouillon(db)
+    gestion.ValiderConvention(IDconv, date="2026-09-03")
+    db.conn.execute(
+        "UPDATE structures_conventions SET snapshot_contractuel=? WHERE IDconvention_structure=?",
+        (b'{"altération":true}', IDconv),
+    )
+    db.conn.commit()
+    assert gestion.VerifierIntegrite(IDconv) is False
+    try:
+        gestion.SignerConvention(IDconv, date="2026-09-04")
+        assert False, "signature d'un snapshot altéré acceptée"
+    except ValueError as err:
+        assert "altéré" in str(err)
+
+
+def test_signature_preserve_snapshot_et_permet_avenant_v2():
+    db = _preparer_base()
+    gestion, IDrelation, IDconv = _creer_convention_brouillon(db)
+    gestion.ValiderConvention(IDconv, date="2026-09-03")
+    avant = gestion.LireConvention(IDconv)["snapshot_contractuel"]
+    assert gestion.SignerConvention(IDconv, date="2026-09-05") is True
+    parent = gestion.LireConvention(IDconv)
+    assert parent["statut"] == CONV.STATUT_SIGNEE
+    assert parent["date_signature"] == "2026-09-05"
+    assert parent["snapshot_contractuel"] == avant
+
+    IDavenant = gestion.CreerAvenant(
+        IDconv,
+        {
+            "uid": "CONV-2026-001-A1",
+            "reference": "MAD-2026-001-A1",
+            "date_debut": "2027-01-01",
+            "date_fin": "2027-08-31",
+            "objet": "Avenant horaires",
+        },
+        date="2026-12-15",
+    )
+    avenant = gestion.LireConvention(IDavenant)
+    assert avenant["version"] == 2
+    assert avenant["IDconvention_parent"] == IDconv
+    assert avenant["IDrelation_structure"] == IDrelation
+    assert avenant["statut"] == CONV.STATUT_BROUILLON
+    assert avenant["snapshot_contractuel"] is None
+
+
+def test_avenant_refuse_parent_brouillon_ou_annule():
+    db = _preparer_base()
+    gestion, IDrelation, IDconv = _creer_convention_brouillon(db)
+    try:
+        gestion.CreerAvenant(IDconv, {"date_debut": "2027-01-01"})
+        assert False, "avenant depuis brouillon accepté"
+    except ValueError:
+        pass
+    gestion.AnnulerConvention(IDconv)
+    try:
+        gestion.CreerAvenant(IDconv, {"date_debut": "2027-01-01"})
+        assert False, "avenant depuis convention annulée accepté"
+    except ValueError:
+        pass
+
+
+def test_periode_convention_ne_depasse_pas_relation():
+    db = _preparer_base()
+    IDrelation = _creer_relation(db, date_fin="2027-06-30")
+    gestion = CONV.GestionnaireConventionsStructures(db)
+    try:
+        gestion.CreerConvention(
+            {
+                "IDrelation_structure": IDrelation,
+                "date_debut": "2026-09-01",
+                "date_fin": "2027-08-31",
+            }
+        )
+        assert False, "convention hors relation acceptée"
+    except ValueError as err:
+        assert "après la relation" in str(err)
+
+
+def test_snapshot_prend_en_compte_payeur_structure_explicite():
+    db = _preparer_base()
+    gestion, IDrelation, IDconv = _creer_convention_brouillon(db)
+    db.ReqInsert(
+        "structures",
+        [
+            ("uid", "STR-payeur"),
+            ("type_structure", "mairie_collectivite"),
+            ("nom", "Mairie payeuse"),
+            ("actif", 1),
+            ("date_creation", "2026-09-01"),
+            ("date_modification", "2026-09-01"),
+        ],
+    )
+    relations = REL.GestionnaireRelationsStructures(db)
+    relations.CreerPayeur(
+        {
+            "IDrelation_structure": IDrelation,
+            "type_payeur": "structure",
+            "IDstructure_payeur": 2,
+            "taux_prise_en_charge": 75,
+            "reference": "BC-2026-17",
+        },
+        date="2026-09-02",
+    )
+    gestion.ValiderConvention(IDconv, date="2026-09-03")
+    snapshot = gestion.LireSnapshot(IDconv)
+    assert len(snapshot["payeurs"]) == 1
+    assert snapshot["payeurs"][0]["implicite"] is False
+    assert snapshot["payeurs"][0]["IDstructure_payeur"] == 2
+    assert snapshot["payeurs"][0]["taux_prise_en_charge"] == 75.0
+
+
+def test_archivage_preserve_historique_et_exige_etat_final():
+    db = _preparer_base()
+    gestion, IDrelation, IDconv = _creer_convention_brouillon(db)
+    try:
+        gestion.ArchiverConvention(IDconv)
+        assert False, "brouillon archivé"
+    except ValueError:
+        pass
+    gestion.AnnulerConvention(IDconv, date="2026-09-04")
+    assert gestion.ArchiverConvention(IDconv, date="2026-09-05") is True
+    conv = gestion.LireConvention(IDconv)
+    assert conv["actif"] == 0
+    assert conv["statut"] == CONV.STATUT_ANNULEE

--- a/tests/test_noe_062_conventions_avenants.py
+++ b/tests/test_noe_062_conventions_avenants.py
@@ -321,7 +321,7 @@ def test_snapshot_altere_bloque_signature():
     gestion.ValiderConvention(IDconv, date="2026-09-03")
     db.conn.execute(
         "UPDATE structures_conventions SET snapshot_contractuel=? WHERE IDconvention_structure=?",
-        (b'{"altération":true}', IDconv),
+        (b'{"alteration":true}', IDconv),
     )
     db.conn.commit()
     assert gestion.VerifierIntegrite(IDconv) is False


### PR DESCRIPTION
## Objectif

Ajouter la couche contractuelle persistée au-dessus des relations Noe-062 sans dupliquer les règles commerciales déjà portées par `structures_relations`.

## Modèle

Nouvelle table additive `structures_conventions` :
- UID stable ;
- relation contractuelle de référence ;
- version et parent d'avenant ;
- statut `brouillon`, `validee`, `signee`, `terminee`, `annulee` ;
- période d'effet ;
- référence, objet et notes ;
- snapshot contractuel JSON figé ;
- empreinte SHA-256 ;
- dates de validation/signature ;
- archivage logique.

## Workflow

- une convention initiale est créée en version 1 et en brouillon ;
- seule une version brouillon est modifiable ;
- la validation reconstruit côté serveur un snapshot canonique de la convention + relation + payeurs effectifs, puis le fige avec SHA-256 ;
- une version validée/signée n'est plus réécrite ;
- les changements contractuels passent par `CreerAvenant`, qui crée une nouvelle version liée au parent ;
- la signature exige un snapshot intact ;
- une version terminée/annulée peut être archivée sans suppression d'historique.

## Activation

`AssurerSchemaConventions(..., appliquer=True)` :
- exige `structures_relations` déjà présente et conforme ;
- ne crée jamais implicitement les relations ;
- crée uniquement `structures_conventions` ;
- bloque une table expérimentale incohérente au lieu de la réparer silencieusement ;
- activation idempotente.

## Garde-fous

- aucune table historique famille/individu modifiée ;
- aucune modification de `DATA_Tables.py` ;
- aucun moteur de facture/prestation/document dupliqué ;
- la relation reste source du tarif, adhésion, bénéficiaire et payeurs ;
- période de convention bornée par la relation ;
- UID/version/parent/statut/snapshot protégés des modifications directes ;
- Teamworks/PMSL-Équipe restent hors du stockage contractuel Noethys.

## Tests

Recette SQLite réelle : activation et idempotence, prérequis absent, schéma incohérent, création v1, unicité de version, modification de brouillon, validation + snapshot + SHA-256, altération détectée, signature, création d'avenant v2, refus d'avenant depuis brouillon/annulé, période hors relation, payeur explicite/implicite et archivage.

Relates #60.