### PR TITLE
Noe-062E : programmation annuelle, occurrences et annexe

### DIFF
--- a/noethys/Data/DATA_Programmations_Structures.py
+++ b/noethys/Data/DATA_Programmations_Structures.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Schéma additif des programmations annuelles Noe-062E.
+
+La programmation décrit les créneaux prévisionnels d'une relation contractuelle.
+Elle ne remplace ni le moteur historique de récurrence, ni les séances
+``interventions`` : les occurrences sont calculées à partir de ces créneaux puis
+matérialisées dans une étape distincte.
+"""
+from __future__ import unicode_literals
+
+
+DB_PROGRAMMATIONS_STRUCTURES = {
+    "structures_programmations": [
+        ("IDprogrammation_structure", "INTEGER PRIMARY KEY AUTOINCREMENT", u"ID local de la programmation"),
+        ("uid", "VARCHAR(64)", u"Identifiant stable inter-applications"),
+        ("IDrelation_structure", "INTEGER", u"Relation contractuelle concernée"),
+        ("IDprogrammation_source", "INTEGER", u"Programmation N-1 source optionnelle"),
+        ("saison", "VARCHAR(50)", u"Saison / exercice"),
+        ("statut", "VARCHAR(30)", u"brouillon, soumise, validee, annulee"),
+        ("date_debut", "DATE", u"Début de la programmation"),
+        ("date_fin", "DATE", u"Fin de la programmation"),
+        ("notes", "VARCHAR(2000)", u"Notes de programmation"),
+        ("actif", "INTEGER", u"Programmation active 0/1"),
+        ("date_creation", "DATE", u"Date de création"),
+        ("date_modification", "DATE", u"Date de modification"),
+    ],
+    "structures_programmations_creneaux": [
+        ("IDcreneau_programmation", "INTEGER PRIMARY KEY AUTOINCREMENT", u"ID local du créneau"),
+        ("uid", "VARCHAR(64)", u"Identifiant stable du créneau"),
+        ("IDprogrammation_structure", "INTEGER", u"Programmation parente"),
+        ("IDcreneau_source", "INTEGER", u"Créneau N-1 source optionnel"),
+        ("jour_semaine", "INTEGER", u"Jour 0=lundi à 6=dimanche"),
+        ("heure_debut", "VARCHAR(5)", u"Heure HH:MM"),
+        ("heure_fin", "VARCHAR(5)", u"Heure HH:MM"),
+        ("date_debut", "DATE", u"Borne spécifique optionnelle"),
+        ("date_fin", "DATE", u"Borne spécifique optionnelle"),
+        ("IDgroupe_structure", "INTEGER", u"Section/classe/groupe optionnel"),
+        ("IDlieu", "INTEGER", u"Lieu habituel optionnel"),
+        ("nature", "VARCHAR(50)", u"sport, animation, autre"),
+        ("libelle", "VARCHAR(300)", u"Libellé prévisionnel de la séance"),
+        ("appliquer_scolaire", "INTEGER", u"Inclure périodes scolaires 0/1"),
+        ("appliquer_vacances", "INTEGER", u"Inclure vacances 0/1"),
+        ("inclure_feries", "INTEGER", u"Inclure jours fériés 0/1"),
+        ("frequence", "INTEGER", u"Code fréquence historique 1 à 6"),
+        ("etat_renouvellement", "VARCHAR(30)", u"inchange, modifie, supprime, ajoute"),
+        ("observations", "VARCHAR(2000)", u"Observations"),
+        ("actif", "INTEGER", u"Créneau actif 0/1"),
+        ("date_creation", "DATE", u"Date de création"),
+        ("date_modification", "DATE", u"Date de modification"),
+    ],
+}
+
+
+def GetNomsTables():
+    return tuple(DB_PROGRAMMATIONS_STRUCTURES.keys())
+
+
+def GetChamps(nom_table):
+    return tuple(champ[0] for champ in DB_PROGRAMMATIONS_STRUCTURES[nom_table])

--- a/noethys/Utils/UTILS_Programmations_Structures.py
+++ b/noethys/Utils/UTILS_Programmations_Structures.py
@@ -1,0 +1,628 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Programmations annuelles et aperçu d'occurrences Noe-062E.
+
+Le service persiste les programmations et créneaux. Il ne recode pas le moteur
+historique vacances/fériés/récurrences : ``GenererApercuOccurrences`` exige un
+calculateur injecté acceptant le contrat historique de
+``DLG_Saisie_location.Calcule_occurences``.
+"""
+from __future__ import unicode_literals
+
+import datetime
+import hashlib
+import uuid
+
+from Utils import UTILS_Relations_Structures
+
+
+STATUT_BROUILLON = "brouillon"
+STATUT_SOUMISE = "soumise"
+STATUT_VALIDEE = "validee"
+STATUT_ANNULEE = "annulee"
+STATUTS_PROGRAMMATION = (
+    STATUT_BROUILLON,
+    STATUT_SOUMISE,
+    STATUT_VALIDEE,
+    STATUT_ANNULEE,
+)
+
+RENOUVELLEMENT_INCHANGE = "inchange"
+RENOUVELLEMENT_MODIFIE = "modifie"
+RENOUVELLEMENT_SUPPRIME = "supprime"
+RENOUVELLEMENT_AJOUTE = "ajoute"
+ETATS_RENOUVELLEMENT = (
+    RENOUVELLEMENT_INCHANGE,
+    RENOUVELLEMENT_MODIFIE,
+    RENOUVELLEMENT_SUPPRIME,
+    RENOUVELLEMENT_AJOUTE,
+)
+
+FREQUENCES_HISTORIQUES = (1, 2, 3, 4, 5, 6)
+NATURES = ("sport", "animation", "autre")
+JOURS = ("lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi", "dimanche")
+
+CHAMPS_PROGRAMMATION = (
+    "uid",
+    "IDrelation_structure",
+    "IDprogrammation_source",
+    "saison",
+    "statut",
+    "date_debut",
+    "date_fin",
+    "notes",
+    "actif",
+    "date_creation",
+    "date_modification",
+)
+
+CHAMPS_CRENEAU = (
+    "uid",
+    "IDprogrammation_structure",
+    "IDcreneau_source",
+    "jour_semaine",
+    "heure_debut",
+    "heure_fin",
+    "date_debut",
+    "date_fin",
+    "IDgroupe_structure",
+    "IDlieu",
+    "nature",
+    "libelle",
+    "appliquer_scolaire",
+    "appliquer_vacances",
+    "inclure_feries",
+    "frequence",
+    "etat_renouvellement",
+    "observations",
+    "actif",
+    "date_creation",
+    "date_modification",
+)
+
+
+def _texte(valeur):
+    if valeur is None:
+        return u""
+    try:
+        return valeur.strip()
+    except Exception:
+        return valeur
+
+
+def _date_iso(valeur, nom_champ, obligatoire=False):
+    if valeur in (None, ""):
+        if obligatoire:
+            raise ValueError("%s est obligatoire" % nom_champ)
+        return None
+    if isinstance(valeur, datetime.datetime):
+        valeur = valeur.date()
+    if isinstance(valeur, datetime.date):
+        return valeur.isoformat()
+    valeur = _texte(valeur)
+    try:
+        return datetime.datetime.strptime(valeur, "%Y-%m-%d").date().isoformat()
+    except (TypeError, ValueError):
+        raise ValueError("%s doit être une date ISO YYYY-MM-DD" % nom_champ)
+
+
+def _date_obj(valeur, nom_champ):
+    iso = _date_iso(valeur, nom_champ, obligatoire=True)
+    return datetime.datetime.strptime(iso, "%Y-%m-%d").date()
+
+
+def _heure(valeur, nom_champ):
+    texte = _texte(valeur)
+    try:
+        return datetime.datetime.strptime(texte, "%H:%M").strftime("%H:%M")
+    except (TypeError, ValueError):
+        raise ValueError("%s doit être une heure HH:MM" % nom_champ)
+
+
+def _duree_minutes(debut, fin):
+    d = datetime.datetime.strptime(_heure(debut, "heure_debut"), "%H:%M")
+    f = datetime.datetime.strptime(_heure(fin, "heure_fin"), "%H:%M")
+    minutes = int((f - d).total_seconds() // 60)
+    if minutes <= 0:
+        raise ValueError("heure_fin doit être postérieure à heure_debut")
+    return minutes
+
+
+def _entier(valeur, nom_champ, obligatoire=False):
+    if valeur in (None, "", 0, "0"):
+        if obligatoire:
+            raise ValueError("%s est obligatoire" % nom_champ)
+        return None
+    try:
+        valeur = int(valeur)
+    except (TypeError, ValueError):
+        raise ValueError("%s doit être un entier" % nom_champ)
+    if valeur <= 0:
+        raise ValueError("%s doit être positif" % nom_champ)
+    return valeur
+
+
+def _bool01(valeur, defaut=False):
+    if valeur is None:
+        valeur = defaut
+    return 0 if valeur in (0, False, "0", "false", "False") else 1
+
+
+def _uid(prefixe, valeur=None, generer=True):
+    valeur = _texte(valeur)
+    if not valeur:
+        if not generer:
+            raise ValueError("UID obligatoire")
+        return "%s-%s" % (prefixe, uuid.uuid4().hex)
+    if len(valeur) > 64 or not all(c.isalnum() or c in "-_" for c in valeur):
+        raise ValueError("UID invalide")
+    return valeur
+
+
+def _liste_pairs(donnees, ordre):
+    return [(champ, donnees.get(champ)) for champ in ordre if champ in donnees]
+
+
+def _maintenant(date=None):
+    return _date_iso(date or datetime.date.today(), "date", obligatoire=True)
+
+
+def NormaliserProgrammation(donnees, creation=True, date=None):
+    donnees = dict(donnees or {})
+    if not donnees:
+        raise ValueError("Aucune donnée de programmation")
+    resultat = {}
+    if creation:
+        resultat["uid"] = _uid("PROG", donnees.get("uid"))
+        resultat["IDrelation_structure"] = _entier(
+            donnees.get("IDrelation_structure"), "IDrelation_structure", obligatoire=True
+        )
+        resultat["IDprogrammation_source"] = _entier(
+            donnees.get("IDprogrammation_source"), "IDprogrammation_source"
+        )
+        saison = _texte(donnees.get("saison"))
+        if not saison:
+            raise ValueError("saison obligatoire")
+        resultat["saison"] = saison
+        statut = _texte(donnees.get("statut")) or STATUT_BROUILLON
+        if statut != STATUT_BROUILLON:
+            raise ValueError("Une programmation est créée en brouillon")
+        resultat["statut"] = statut
+    else:
+        interdits = ("uid", "IDrelation_structure", "IDprogrammation_source", "statut", "date_creation")
+        if any(champ in donnees for champ in interdits):
+            raise ValueError("Modification directe d'un champ protégé")
+        if "saison" in donnees:
+            saison = _texte(donnees.get("saison"))
+            if not saison:
+                raise ValueError("saison ne peut pas être vide")
+            resultat["saison"] = saison
+
+    debut = None
+    fin = None
+    if creation or "date_debut" in donnees:
+        debut = _date_iso(donnees.get("date_debut"), "date_debut", obligatoire=creation)
+        resultat["date_debut"] = debut
+    if creation or "date_fin" in donnees:
+        fin = _date_iso(donnees.get("date_fin"), "date_fin", obligatoire=creation)
+        resultat["date_fin"] = fin
+    if creation and fin < debut:
+        raise ValueError("date_fin ne peut pas précéder date_debut")
+    if creation or "notes" in donnees:
+        resultat["notes"] = _texte(donnees.get("notes"))
+    if creation or "actif" in donnees:
+        resultat["actif"] = _bool01(donnees.get("actif"), True)
+    resultat["date_modification"] = _maintenant(date)
+    if creation:
+        resultat["date_creation"] = _maintenant(donnees.get("date_creation") or date)
+    return resultat
+
+
+def NormaliserCreneau(donnees, creation=True, date=None):
+    donnees = dict(donnees or {})
+    if not donnees:
+        raise ValueError("Aucune donnée de créneau")
+    resultat = {}
+    if creation:
+        resultat["uid"] = _uid("CRN", donnees.get("uid"))
+        resultat["IDprogrammation_structure"] = _entier(
+            donnees.get("IDprogrammation_structure"), "IDprogrammation_structure", obligatoire=True
+        )
+        resultat["IDcreneau_source"] = _entier(donnees.get("IDcreneau_source"), "IDcreneau_source")
+    else:
+        interdits = ("uid", "IDprogrammation_structure", "IDcreneau_source", "date_creation")
+        if any(champ in donnees for champ in interdits):
+            raise ValueError("Modification directe d'un champ protégé")
+
+    if creation or "jour_semaine" in donnees:
+        try:
+            jour = int(donnees.get("jour_semaine"))
+        except (TypeError, ValueError):
+            raise ValueError("jour_semaine doit être compris entre 0 et 6")
+        if not 0 <= jour <= 6:
+            raise ValueError("jour_semaine doit être compris entre 0 et 6")
+        resultat["jour_semaine"] = jour
+
+    debut_h = fin_h = None
+    if creation or "heure_debut" in donnees:
+        debut_h = _heure(donnees.get("heure_debut"), "heure_debut")
+        resultat["heure_debut"] = debut_h
+    if creation or "heure_fin" in donnees:
+        fin_h = _heure(donnees.get("heure_fin"), "heure_fin")
+        resultat["heure_fin"] = fin_h
+    if creation:
+        _duree_minutes(debut_h, fin_h)
+
+    debut = fin = None
+    if creation or "date_debut" in donnees:
+        debut = _date_iso(donnees.get("date_debut"), "date_debut")
+        resultat["date_debut"] = debut
+    if creation or "date_fin" in donnees:
+        fin = _date_iso(donnees.get("date_fin"), "date_fin")
+        resultat["date_fin"] = fin
+    if creation and debut and fin and fin < debut:
+        raise ValueError("date_fin ne peut pas précéder date_debut")
+
+    for champ in ("IDgroupe_structure", "IDlieu"):
+        if creation or champ in donnees:
+            resultat[champ] = _entier(donnees.get(champ), champ)
+
+    if creation or "nature" in donnees:
+        nature = _texte(donnees.get("nature")) or "autre"
+        if nature not in NATURES:
+            raise ValueError("nature inconnue: %s" % nature)
+        resultat["nature"] = nature
+    if creation or "libelle" in donnees:
+        resultat["libelle"] = _texte(donnees.get("libelle")) or u"Séance"
+
+    for champ, defaut in (
+        ("appliquer_scolaire", True),
+        ("appliquer_vacances", False),
+        ("inclure_feries", False),
+    ):
+        if creation or champ in donnees:
+            resultat[champ] = _bool01(donnees.get(champ), defaut)
+    if creation and not resultat["appliquer_scolaire"] and not resultat["appliquer_vacances"]:
+        raise ValueError("Le créneau doit s'appliquer au scolaire, aux vacances ou aux deux")
+
+    if creation or "frequence" in donnees:
+        try:
+            frequence = int(donnees.get("frequence", 1))
+        except (TypeError, ValueError):
+            raise ValueError("fréquence historique invalide")
+        if frequence not in FREQUENCES_HISTORIQUES:
+            raise ValueError("fréquence historique inconnue: %s" % frequence)
+        resultat["frequence"] = frequence
+
+    if creation or "etat_renouvellement" in donnees:
+        etat = _texte(donnees.get("etat_renouvellement")) or RENOUVELLEMENT_AJOUTE
+        if etat not in ETATS_RENOUVELLEMENT:
+            raise ValueError("état de renouvellement inconnu: %s" % etat)
+        resultat["etat_renouvellement"] = etat
+    if creation or "observations" in donnees:
+        resultat["observations"] = _texte(donnees.get("observations"))
+    if creation or "actif" in donnees:
+        resultat["actif"] = _bool01(donnees.get("actif"), True)
+    resultat["date_modification"] = _maintenant(date)
+    if creation:
+        resultat["date_creation"] = _maintenant(donnees.get("date_creation") or date)
+    return resultat
+
+
+class GestionnaireProgrammationsStructures(object):
+    def __init__(self, db):
+        self.db = db
+        self.relations = UTILS_Relations_Structures.GestionnaireRelationsStructures(db)
+
+    def _lire(self, table, cle, ID, champs):
+        req = "SELECT %s, %s FROM %s WHERE %s=%d;" % (cle, ", ".join(champs), table, cle, int(ID))
+        if self.db.ExecuterReq(req) != 1:
+            return None
+        lignes = self.db.ResultatReq() or []
+        if not lignes:
+            return None
+        return dict(zip((cle,) + champs, lignes[0]))
+
+    def LireProgrammation(self, IDprogrammation_structure):
+        return self._lire(
+            "structures_programmations", "IDprogrammation_structure",
+            IDprogrammation_structure, CHAMPS_PROGRAMMATION
+        )
+
+    def LireCreneau(self, IDcreneau_programmation):
+        return self._lire(
+            "structures_programmations_creneaux", "IDcreneau_programmation",
+            IDcreneau_programmation, CHAMPS_CRENEAU
+        )
+
+    def _uid_existe(self, table, uid):
+        req = "SELECT 1 FROM %s WHERE uid='%s';" % (table, uid)
+        return self.db.ExecuterReq(req) == 1 and bool(self.db.ResultatReq() or [])
+
+    def _verifier_relation(self, IDrelation_structure):
+        relation = self.relations.LireRelation(IDrelation_structure)
+        if not relation:
+            raise ValueError("Relation contractuelle introuvable")
+        if relation.get("actif") in (0, False, "0"):
+            raise ValueError("Relation contractuelle archivée")
+        return relation
+
+    def _verifier_programmation_brouillon(self, IDprogrammation_structure):
+        programmation = self.LireProgrammation(IDprogrammation_structure)
+        if not programmation:
+            raise ValueError("Programmation introuvable")
+        if programmation["statut"] != STATUT_BROUILLON:
+            raise ValueError("Seule une programmation brouillon est modifiable")
+        return programmation
+
+    def CreerProgrammation(self, donnees, date=None):
+        valeurs = NormaliserProgrammation(donnees, creation=True, date=date)
+        relation = self._verifier_relation(valeurs["IDrelation_structure"])
+        if self._uid_existe("structures_programmations", valeurs["uid"]):
+            raise ValueError("UID de programmation déjà utilisé")
+        req = (
+            "SELECT IDprogrammation_structure FROM structures_programmations "
+            "WHERE IDrelation_structure=%d AND saison='%s' AND actif=1;"
+        ) % (valeurs["IDrelation_structure"], valeurs["saison"])
+        if self.db.ExecuterReq(req) == 1 and (self.db.ResultatReq() or []):
+            raise ValueError("Une programmation active existe déjà pour cette relation et cette saison")
+        debut_relation = relation.get("date_debut")
+        fin_relation = relation.get("date_fin")
+        if debut_relation and valeurs["date_debut"] < debut_relation:
+            raise ValueError("La programmation débute avant la relation")
+        if fin_relation and valeurs["date_fin"] > fin_relation:
+            raise ValueError("La programmation se termine après la relation")
+        return self.db.ReqInsert(
+            "structures_programmations", _liste_pairs(valeurs, CHAMPS_PROGRAMMATION)
+        )
+
+    def ModifierProgrammation(self, IDprogrammation_structure, donnees, date=None):
+        courant = self._verifier_programmation_brouillon(IDprogrammation_structure)
+        valeurs = NormaliserProgrammation(donnees, creation=False, date=date)
+        debut = valeurs.get("date_debut", courant["date_debut"])
+        fin = valeurs.get("date_fin", courant["date_fin"])
+        if fin < debut:
+            raise ValueError("date_fin ne peut pas précéder date_debut")
+        relation = self._verifier_relation(courant["IDrelation_structure"])
+        if relation.get("date_debut") and debut < relation["date_debut"]:
+            raise ValueError("La programmation débute avant la relation")
+        if relation.get("date_fin") and fin > relation["date_fin"]:
+            raise ValueError("La programmation se termine après la relation")
+        return self.db.ReqMAJ(
+            "structures_programmations", _liste_pairs(valeurs, CHAMPS_PROGRAMMATION),
+            "IDprogrammation_structure", int(IDprogrammation_structure)
+        )
+
+    def ListerCreneaux(self, IDprogrammation_structure, actifs_seulement=True, conserves_seulement=False):
+        conditions = ["IDprogrammation_structure=%d" % int(IDprogrammation_structure)]
+        if actifs_seulement:
+            conditions.append("actif=1")
+        if conserves_seulement:
+            conditions.append("etat_renouvellement<>'supprime'")
+        req = "SELECT IDcreneau_programmation, %s FROM structures_programmations_creneaux WHERE %s ORDER BY jour_semaine, heure_debut, IDcreneau_programmation;" % (
+            ", ".join(CHAMPS_CRENEAU), " AND ".join(conditions)
+        )
+        if self.db.ExecuterReq(req) != 1:
+            return []
+        return [
+            dict(zip(("IDcreneau_programmation",) + CHAMPS_CRENEAU, ligne))
+            for ligne in (self.db.ResultatReq() or [])
+        ]
+
+    def _verifier_groupe_et_lieu(self, programmation, IDgroupe_structure=None, IDlieu=None):
+        relation = self._verifier_relation(programmation["IDrelation_structure"])
+        if IDgroupe_structure:
+            req = "SELECT IDstructure FROM structures_groupes WHERE IDgroupe_structure=%d AND actif=1;" % int(IDgroupe_structure)
+            if self.db.ExecuterReq(req) != 1 or not (self.db.ResultatReq() or []):
+                raise ValueError("Groupe introuvable ou archivé")
+            if int(self.db.ResultatReq()[0][0]) != int(relation["IDstructure"]):
+                raise ValueError("Le groupe n'appartient pas au bénéficiaire de la relation")
+        if IDlieu:
+            req = "SELECT IDlieu FROM lieux WHERE IDlieu=%d AND actif=1;" % int(IDlieu)
+            if self.db.ExecuterReq(req) != 1 or not (self.db.ResultatReq() or []):
+                raise ValueError("Lieu introuvable ou archivé")
+
+    def CreerCreneau(self, IDprogrammation_structure, donnees, date=None):
+        programmation = self._verifier_programmation_brouillon(IDprogrammation_structure)
+        donnees = dict(donnees or {})
+        donnees["IDprogrammation_structure"] = int(IDprogrammation_structure)
+        valeurs = NormaliserCreneau(donnees, creation=True, date=date)
+        if self._uid_existe("structures_programmations_creneaux", valeurs["uid"]):
+            raise ValueError("UID de créneau déjà utilisé")
+        self._verifier_groupe_et_lieu(
+            programmation, valeurs.get("IDgroupe_structure"), valeurs.get("IDlieu")
+        )
+        debut = valeurs.get("date_debut") or programmation["date_debut"]
+        fin = valeurs.get("date_fin") or programmation["date_fin"]
+        if fin < debut or debut < programmation["date_debut"] or fin > programmation["date_fin"]:
+            raise ValueError("La période du créneau doit rester dans la programmation")
+        return self.db.ReqInsert(
+            "structures_programmations_creneaux", _liste_pairs(valeurs, CHAMPS_CRENEAU)
+        )
+
+    def ModifierCreneau(self, IDcreneau_programmation, donnees, date=None):
+        courant = self.LireCreneau(IDcreneau_programmation)
+        if not courant:
+            raise ValueError("Créneau introuvable")
+        programmation = self._verifier_programmation_brouillon(courant["IDprogrammation_structure"])
+        valeurs = NormaliserCreneau(donnees, creation=False, date=date)
+        groupe = valeurs.get("IDgroupe_structure", courant.get("IDgroupe_structure"))
+        lieu = valeurs.get("IDlieu", courant.get("IDlieu"))
+        self._verifier_groupe_et_lieu(programmation, groupe, lieu)
+        debut_h = valeurs.get("heure_debut", courant["heure_debut"])
+        fin_h = valeurs.get("heure_fin", courant["heure_fin"])
+        _duree_minutes(debut_h, fin_h)
+        debut = valeurs.get("date_debut", courant.get("date_debut")) or programmation["date_debut"]
+        fin = valeurs.get("date_fin", courant.get("date_fin")) or programmation["date_fin"]
+        if fin < debut or debut < programmation["date_debut"] or fin > programmation["date_fin"]:
+            raise ValueError("La période du créneau doit rester dans la programmation")
+        if courant.get("IDcreneau_source") and courant.get("etat_renouvellement") == RENOUVELLEMENT_INCHANGE:
+            valeurs["etat_renouvellement"] = RENOUVELLEMENT_MODIFIE
+        return self.db.ReqMAJ(
+            "structures_programmations_creneaux", _liste_pairs(valeurs, CHAMPS_CRENEAU),
+            "IDcreneau_programmation", int(IDcreneau_programmation)
+        )
+
+    def SupprimerCreneau(self, IDcreneau_programmation, date=None):
+        courant = self.LireCreneau(IDcreneau_programmation)
+        if not courant:
+            raise ValueError("Créneau introuvable")
+        self._verifier_programmation_brouillon(courant["IDprogrammation_structure"])
+        if courant.get("IDcreneau_source"):
+            valeurs = {"etat_renouvellement": RENOUVELLEMENT_SUPPRIME, "date_modification": _maintenant(date)}
+        else:
+            valeurs = {"actif": 0, "date_modification": _maintenant(date)}
+        return self.db.ReqMAJ(
+            "structures_programmations_creneaux", _liste_pairs(valeurs, CHAMPS_CRENEAU),
+            "IDcreneau_programmation", int(IDcreneau_programmation)
+        )
+
+    def ChangerStatut(self, IDprogrammation_structure, nouveau_statut, date=None):
+        programmation = self.LireProgrammation(IDprogrammation_structure)
+        if not programmation:
+            raise ValueError("Programmation introuvable")
+        nouveau_statut = _texte(nouveau_statut)
+        transitions = {
+            STATUT_BROUILLON: (STATUT_SOUMISE, STATUT_VALIDEE, STATUT_ANNULEE),
+            STATUT_SOUMISE: (STATUT_BROUILLON, STATUT_VALIDEE, STATUT_ANNULEE),
+            STATUT_VALIDEE: (STATUT_ANNULEE,),
+            STATUT_ANNULEE: (),
+        }
+        if nouveau_statut == programmation["statut"]:
+            return True
+        if nouveau_statut not in transitions.get(programmation["statut"], ()):
+            raise ValueError("Transition de statut interdite")
+        if nouveau_statut == STATUT_VALIDEE and not self.ListerCreneaux(IDprogrammation_structure, conserves_seulement=True):
+            raise ValueError("Une programmation sans créneau ne peut pas être validée")
+        valeurs = {"statut": nouveau_statut, "date_modification": _maintenant(date)}
+        return self.db.ReqMAJ(
+            "structures_programmations", _liste_pairs(valeurs, CHAMPS_PROGRAMMATION),
+            "IDprogrammation_structure", int(IDprogrammation_structure)
+        )
+
+    def RenouvelerProgrammation(self, IDprogrammation_source, IDrelation_structure, saison, date_debut, date_fin, date=None):
+        source = self.LireProgrammation(IDprogrammation_source)
+        if not source:
+            raise ValueError("Programmation source introuvable")
+        if source["statut"] != STATUT_VALIDEE:
+            raise ValueError("Seule une programmation validée peut être renouvelée")
+        nouvelle_id = self.CreerProgrammation(
+            {
+                "IDrelation_structure": IDrelation_structure,
+                "IDprogrammation_source": IDprogrammation_source,
+                "saison": saison,
+                "date_debut": date_debut,
+                "date_fin": date_fin,
+                "notes": source.get("notes") or "",
+            },
+            date=date,
+        )
+        nouvelle = self.LireProgrammation(nouvelle_id)
+        for ancien in self.ListerCreneaux(IDprogrammation_source, conserves_seulement=True):
+            donnees = dict((champ, ancien.get(champ)) for champ in CHAMPS_CRENEAU)
+            for champ in ("uid", "IDprogrammation_structure", "date_creation", "date_modification"):
+                donnees.pop(champ, None)
+            donnees["IDcreneau_source"] = ancien["IDcreneau_programmation"]
+            donnees["etat_renouvellement"] = RENOUVELLEMENT_INCHANGE
+            if ancien.get("date_debut"):
+                donnees["date_debut"] = nouvelle["date_debut"]
+            if ancien.get("date_fin"):
+                donnees["date_fin"] = nouvelle["date_fin"]
+            self.CreerCreneau(nouvelle_id, donnees, date=date)
+        return nouvelle_id
+
+    def _parametres_recurrence(self, programmation, creneau):
+        debut = max(_date_obj(programmation["date_debut"], "date_debut"), _date_obj(creneau["date_debut"], "date_debut") if creneau.get("date_debut") else _date_obj(programmation["date_debut"], "date_debut"))
+        fin = min(_date_obj(programmation["date_fin"], "date_fin"), _date_obj(creneau["date_fin"], "date_fin") if creneau.get("date_fin") else _date_obj(programmation["date_fin"], "date_fin"))
+        if fin < debut:
+            return None
+        jour = int(creneau["jour_semaine"])
+        return {
+            "date_debut": debut,
+            "date_fin": fin,
+            "heure_debut": creneau["heure_debut"],
+            "heure_fin": creneau["heure_fin"],
+            "jours_vacances": [jour] if creneau.get("appliquer_vacances") else [],
+            "jours_scolaires": [jour] if creneau.get("appliquer_scolaire") else [],
+            "semaines": int(creneau["frequence"]),
+            "feries": bool(creneau.get("inclure_feries")),
+        }
+
+    def GenererApercuOccurrences(self, IDprogrammation_structure, calculateur_occurrences):
+        if not callable(calculateur_occurrences):
+            raise TypeError("calculateur_occurrences doit être appelable")
+        programmation = self.LireProgrammation(IDprogrammation_structure)
+        if not programmation:
+            raise ValueError("Programmation introuvable")
+        if programmation["statut"] == STATUT_ANNULEE:
+            raise ValueError("Une programmation annulée ne produit pas d'occurrences")
+        relation = self._verifier_relation(programmation["IDrelation_structure"])
+        occurrences = []
+        deja = set()
+        for creneau in self.ListerCreneaux(IDprogrammation_structure, conserves_seulement=True):
+            params = self._parametres_recurrence(programmation, creneau)
+            if params is None:
+                continue
+            for donnee in calculateur_occurrences(dict(params)) or ():
+                debut = donnee.get("date_debut")
+                fin = donnee.get("date_fin")
+                if not isinstance(debut, datetime.datetime) or not isinstance(fin, datetime.datetime):
+                    raise ValueError("Le calculateur historique doit retourner des datetime")
+                if fin <= debut:
+                    raise ValueError("Occurrence historique de durée invalide")
+                signature = "%s|%s|%s" % (creneau["uid"], debut.isoformat(), fin.isoformat())
+                uid = "OCC-%s" % hashlib.sha256(signature.encode("utf-8")).hexdigest()[:40]
+                if uid in deja:
+                    continue
+                deja.add(uid)
+                occurrences.append({
+                    "uid": uid,
+                    "IDprogrammation_structure": programmation["IDprogrammation_structure"],
+                    "uid_programmation": programmation["uid"],
+                    "IDcreneau_programmation": creneau["IDcreneau_programmation"],
+                    "uid_creneau": creneau["uid"],
+                    "IDrelation_structure": programmation["IDrelation_structure"],
+                    "uid_relation": relation["uid"],
+                    "IDstructure": relation["IDstructure"],
+                    "IDgroupe_structure": creneau.get("IDgroupe_structure"),
+                    "IDlieu": creneau.get("IDlieu"),
+                    "nature": creneau["nature"],
+                    "libelle": creneau["libelle"],
+                    "date": debut.date().isoformat(),
+                    "heure_debut": debut.strftime("%H:%M"),
+                    "heure_fin": fin.strftime("%H:%M"),
+                    "duree_minutes": int((fin - debut).total_seconds() // 60),
+                    "observations": creneau.get("observations") or "",
+                })
+        return sorted(occurrences, key=lambda x: (x["date"], x["heure_debut"], x["uid"]))
+
+    def ConstruireAnnexePrevisionnelle(self, IDprogrammation_structure, calculateur_occurrences):
+        programmation = self.LireProgrammation(IDprogrammation_structure)
+        if not programmation:
+            raise ValueError("Programmation introuvable")
+        occurrences = self.GenererApercuOccurrences(IDprogrammation_structure, calculateur_occurrences)
+        lignes = []
+        for index, occurrence in enumerate(occurrences, 1):
+            date_obj = _date_obj(occurrence["date"], "date")
+            lignes.append({
+                "numero": index,
+                "uid": occurrence["uid"],
+                "date": occurrence["date"],
+                "jour": JOURS[date_obj.weekday()],
+                "heure_debut": occurrence["heure_debut"],
+                "heure_fin": occurrence["heure_fin"],
+                "duree_minutes": occurrence["duree_minutes"],
+                "IDgroupe_structure": occurrence["IDgroupe_structure"],
+                "IDlieu": occurrence["IDlieu"],
+                "libelle": occurrence["libelle"],
+            })
+        total = sum(ligne["duree_minutes"] for ligne in lignes)
+        return {
+            "uid_programmation": programmation["uid"],
+            "saison": programmation["saison"],
+            "date_debut": programmation["date_debut"],
+            "date_fin": programmation["date_fin"],
+            "nb_seances": len(lignes),
+            "duree_totale_minutes": total,
+            "lignes": lignes,
+        }

--- a/noethys/Utils/UTILS_Programmations_Structures_Schema.py
+++ b/noethys/Utils/UTILS_Programmations_Structures_Schema.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Activation additive contrôlée des programmations Noe-062E."""
+from __future__ import unicode_literals
+
+import re
+
+from Data import DATA_Programmations_Structures
+from Data import DATA_Structures
+
+
+TABLE_RELATIONS = "structures_relations"
+TABLES_PROGRAMMATION = (
+    "structures_programmations",
+    "structures_programmations_creneaux",
+)
+
+
+def _description(nom_table):
+    if nom_table in DATA_Programmations_Structures.DB_PROGRAMMATIONS_STRUCTURES:
+        return tuple(DATA_Programmations_Structures.DB_PROGRAMMATIONS_STRUCTURES[nom_table])
+    return tuple(DATA_Structures.DB_STRUCTURES[nom_table])
+
+
+def _dico_creation(nom_table):
+    if nom_table in DATA_Programmations_Structures.DB_PROGRAMMATIONS_STRUCTURES:
+        return DATA_Programmations_Structures.DB_PROGRAMMATIONS_STRUCTURES
+    return DATA_Structures.DB_STRUCTURES
+
+
+def _chaine(valeur):
+    if isinstance(valeur, bytes):
+        return valeur.decode("ascii", "ignore")
+    return str(valeur)
+
+
+def _categorie(type_sql):
+    if type_sql is None:
+        return ""
+    base = _chaine(type_sql).strip().lower().split("(", 1)[0].strip()
+    if "int" in base:
+        return "integer"
+    if base in ("float", "real", "double", "decimal", "numeric"):
+        return "real"
+    if base in ("char", "varchar", "text", "tinytext", "mediumtext", "longtext"):
+        return "text"
+    if base in ("blob", "tinyblob", "mediumblob", "longblob"):
+        return "blob"
+    if base in ("date", "datetime", "timestamp"):
+        return "date"
+    return base
+
+
+def _type_attendu(type_decl, is_network):
+    type_decl = type_decl.upper().strip()
+    if not is_network:
+        if type_decl == "LONGBLOB":
+            return "BLOB"
+        if type_decl == "BIGINT":
+            return "INTEGER"
+        return type_decl
+    if type_decl == "INTEGER PRIMARY KEY AUTOINCREMENT":
+        return "INTEGER PRIMARY KEY AUTO_INCREMENT"
+    if type_decl == "FLOAT":
+        return "REAL"
+    if type_decl == "DATE":
+        return "VARCHAR(10)"
+    if type_decl.startswith("VARCHAR"):
+        match = re.search(r"\((\d+)\)", type_decl)
+        if match:
+            taille = int(match.group(1))
+            if taille > 20000:
+                return "MEDIUMTEXT"
+            if taille > 255:
+                return "TEXT(%d)" % taille
+    return type_decl
+
+
+def _metadata(db, nom_table):
+    colonnes = {}
+    is_network = bool(getattr(db, "isNetwork", False))
+    if not is_network:
+        if db.ExecuterReq("PRAGMA table_info('%s');" % nom_table) != 1:
+            return None
+        for cid, nom, type_sql, notnull, default, pk in db.ResultatReq():
+            colonnes[_chaine(nom)] = {
+                "type": type_sql,
+                "pk": bool(pk),
+                "auto": bool(pk) and _categorie(type_sql) == "integer",
+            }
+    else:
+        if db.ExecuterReq("SHOW COLUMNS FROM %s;" % nom_table) != 1:
+            return None
+        for valeurs in db.ResultatReq():
+            colonnes[_chaine(valeurs[0])] = {
+                "type": valeurs[1],
+                "pk": _chaine(valeurs[3] if len(valeurs) > 3 else "").upper() == "PRI",
+                "auto": "auto_increment" in _chaine(valeurs[5] if len(valeurs) > 5 else "").lower(),
+            }
+    return colonnes
+
+
+def _inspecter(db, nom_table):
+    existe = bool(db.IsTableExists(nom_table))
+    description = _description(nom_table)
+    attendus = tuple(item[0] for item in description)
+    rapport = {
+        "existe": existe,
+        "champs_attendus": attendus,
+        "champs_presents": (),
+        "champs_manquants": attendus,
+        "champs_incompatibles": (),
+        "metadata_ok": False,
+        "conforme": False,
+    }
+    if not existe:
+        return rapport
+    metadata = _metadata(db, nom_table)
+    if metadata is None:
+        return rapport
+    rapport["metadata_ok"] = True
+    rapport["champs_presents"] = tuple(metadata.keys())
+    rapport["champs_manquants"] = tuple(x for x in attendus if x not in metadata)
+    incompatibles = []
+    is_network = bool(getattr(db, "isNetwork", False))
+    for nom, type_decl, info in description:
+        if nom not in metadata:
+            continue
+        attendu = _type_attendu(type_decl, is_network)
+        present = metadata[nom]
+        if _categorie(attendu) != _categorie(present["type"]):
+            incompatibles.append(nom)
+        elif "PRIMARY KEY" in attendu and not present["pk"]:
+            incompatibles.append(nom)
+        elif "AUTO_INCREMENT" in attendu and not present["auto"]:
+            incompatibles.append(nom)
+    rapport["champs_incompatibles"] = tuple(incompatibles)
+    rapport["conforme"] = not rapport["champs_manquants"] and not incompatibles
+    return rapport
+
+
+def InspecterSchemaProgrammations(db):
+    noms = (TABLE_RELATIONS,) + TABLES_PROGRAMMATION
+    return dict((nom, _inspecter(db, nom)) for nom in noms)
+
+
+def AssurerSchemaProgrammations(db, appliquer=False):
+    """Crée uniquement les deux tables de programmation.
+
+    ``structures_relations`` doit déjà exister et être conforme. Le préflight
+    vérifie toutes les tables avant la première écriture.
+    """
+    avant = InspecterSchemaProgrammations(db)
+    relation = avant[TABLE_RELATIONS]
+    incoherentes = tuple(
+        nom for nom, rapport in avant.items()
+        if rapport["existe"] and not rapport["conforme"]
+    )
+    if not relation["existe"] or not relation["conforme"] or incoherentes:
+        return {
+            "ok": False,
+            "appliquer": bool(appliquer),
+            "tables_creees": (),
+            "tables_absentes": tuple(n for n, r in avant.items() if not r["existe"]),
+            "tables_incoherentes": incoherentes,
+            "prerequis_absents": () if relation["existe"] else (TABLE_RELATIONS,),
+            "rapport": avant,
+        }
+
+    creees = []
+    if appliquer:
+        for nom in TABLES_PROGRAMMATION:
+            if not avant[nom]["existe"]:
+                db.CreationTable(nom, _dico_creation(nom))
+                db.Commit()
+                creees.append(nom)
+
+    apres = InspecterSchemaProgrammations(db)
+    absentes = tuple(n for n, r in apres.items() if not r["existe"])
+    incoherentes = tuple(n for n, r in apres.items() if r["existe"] and not r["conforme"])
+    return {
+        "ok": not incoherentes and (not appliquer or not absentes),
+        "appliquer": bool(appliquer),
+        "tables_creees": tuple(creees),
+        "tables_absentes": absentes,
+        "tables_incoherentes": incoherentes,
+        "prerequis_absents": (),
+        "rapport": apres,
+    }

--- a/tests/test_noe_062_programmations_occurrences.py
+++ b/tests/test_noe_062_programmations_occurrences.py
@@ -1,0 +1,383 @@
+# -*- coding: utf-8 -*-
+import datetime
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOETHYS = ROOT / "noethys"
+if str(NOETHYS) not in sys.path:
+    sys.path.insert(0, str(NOETHYS))
+
+
+def _charger(path, nom):
+    spec = importlib.util.spec_from_file_location(nom, str(ROOT / path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+DATA = _charger("noethys/Data/DATA_Structures.py", "DATA_Structures_prog062")
+DATA_PROG = _charger("noethys/Data/DATA_Programmations_Structures.py", "DATA_Programmations_062")
+SCHEMA = _charger("noethys/Utils/UTILS_Programmations_Structures_Schema.py", "SCHEMA_Programmations_062")
+PROG = _charger("noethys/Utils/UTILS_Programmations_Structures.py", "UTILS_Programmations_062")
+REL = _charger("noethys/Utils/UTILS_Relations_Structures.py", "UTILS_Relations_prog062")
+
+
+class SQLiteDB(object):
+    isNetwork = False
+
+    def __init__(self):
+        self.conn = sqlite3.connect(":memory:")
+        self._resultat = []
+        self.creations = []
+        self.commits = 0
+
+    def IsTableExists(self, nom_table):
+        return self.conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (nom_table,)
+        ).fetchone() is not None
+
+    def ExecuterReq(self, req):
+        try:
+            cur = self.conn.execute(req)
+            self._resultat = cur.fetchall()
+            return 1
+        except sqlite3.Error:
+            self._resultat = []
+            return 0
+
+    def ResultatReq(self):
+        return list(self._resultat)
+
+    def CreationTable(self, nom_table, dico):
+        champs = []
+        for nom, type_sql, info in dico[nom_table]:
+            if type_sql == "LONGBLOB":
+                type_sql = "BLOB"
+            elif type_sql == "BIGINT":
+                type_sql = "INTEGER"
+            champs.append("%s %s" % (nom, type_sql))
+        self.conn.execute("CREATE TABLE %s (%s)" % (nom_table, ", ".join(champs)))
+        self.creations.append(nom_table)
+
+    def Commit(self):
+        self.conn.commit()
+        self.commits += 1
+
+    def ReqInsert(self, table, donnees, commit=True):
+        donnees = list(donnees)
+        champs = [c for c, v in donnees]
+        valeurs = [v for c, v in donnees]
+        req = "INSERT INTO %s (%s) VALUES (%s)" % (
+            table, ", ".join(champs), ", ".join(["?"] * len(champs))
+        )
+        cur = self.conn.execute(req, valeurs)
+        if commit:
+            self.conn.commit()
+        return cur.lastrowid
+
+    def ReqMAJ(self, table, donnees, cle, ID, IDestChaine=False, commit=True):
+        donnees = list(donnees)
+        champs = [c for c, v in donnees]
+        valeurs = [v for c, v in donnees]
+        self.conn.execute(
+            "UPDATE %s SET %s WHERE %s=?" % (
+                table, ", ".join("%s=?" % c for c in champs), cle
+            ),
+            valeurs + [ID],
+        )
+        if commit:
+            self.conn.commit()
+        return True
+
+
+def _creer_table(db, nom):
+    db.CreationTable(nom, DATA.DB_STRUCTURES)
+    db.Commit()
+
+
+def _base(avec_programmations=True):
+    db = SQLiteDB()
+    for table in ("structures", "structures_groupes", "lieux", "structures_relations", "structures_payeurs"):
+        _creer_table(db, table)
+    if avec_programmations:
+        for table in DATA_PROG.GetNomsTables():
+            db.CreationTable(table, DATA_PROG.DB_PROGRAMMATIONS_STRUCTURES)
+            db.Commit()
+    db.ReqInsert("structures", [
+        ("uid", "STR-ASSO"), ("type_structure", "association"),
+        ("nom", "Club test"), ("actif", 1),
+        ("date_creation", "2026-09-01"), ("date_modification", "2026-09-01"),
+    ])
+    db.ReqInsert("structures_groupes", [
+        ("IDstructure", 1), ("nom", "Section badminton"), ("actif", 1), ("memo", ""),
+    ])
+    db.ReqInsert("lieux", [
+        ("uid", "LIEU-GYM"), ("nom", "Gymnase test"), ("type_lieu", "gymnase"),
+        ("actif", 1), ("date_creation", "2026-09-01"), ("date_modification", "2026-09-01"),
+    ])
+    relation = REL.GestionnaireRelationsStructures(db).CreerRelation({
+        "uid": "REL-PROG-2026",
+        "IDstructure": 1,
+        "type_relation": "mise_disposition",
+        "libelle": "Badminton annuel",
+        "saison": "2026-2027",
+        "date_debut": "2026-09-01",
+        "date_fin": "2027-08-31",
+        "tarif": 44,
+        "unite_tarif": "heure",
+        "regle_adhesion": "requise",
+        "mode_facturation": "mensuel",
+    }, date="2026-09-01")
+    return db, relation
+
+
+def _programmation(db, relation, uid="PROG-2026"):
+    gestion = PROG.GestionnaireProgrammationsStructures(db)
+    IDprog = gestion.CreerProgrammation({
+        "uid": uid,
+        "IDrelation_structure": relation,
+        "saison": "2026-2027",
+        "date_debut": "2026-09-01",
+        "date_fin": "2027-08-31",
+    }, date="2026-09-01")
+    return gestion, IDprog
+
+
+def _creneau(gestion, IDprog, uid="CRN-MARDI"):
+    return gestion.CreerCreneau(IDprog, {
+        "uid": uid,
+        "jour_semaine": 1,
+        "heure_debut": "18:00",
+        "heure_fin": "19:30",
+        "IDgroupe_structure": 1,
+        "IDlieu": 1,
+        "nature": "sport",
+        "libelle": "Badminton adultes",
+        "appliquer_scolaire": 1,
+        "appliquer_vacances": 0,
+        "inclure_feries": 0,
+        "frequence": 1,
+    }, date="2026-09-01")
+
+
+def test_schema_declare_programmation_et_creneaux():
+    assert DATA_PROG.GetNomsTables() == (
+        "structures_programmations", "structures_programmations_creneaux"
+    )
+    assert "IDrelation_structure" in DATA_PROG.GetChamps("structures_programmations")
+    champs = DATA_PROG.GetChamps("structures_programmations_creneaux")
+    for champ in ("jour_semaine", "appliquer_scolaire", "appliquer_vacances", "frequence", "etat_renouvellement"):
+        assert champ in champs
+
+
+def test_activation_refuse_absence_relation_et_ne_cree_rien():
+    db = SQLiteDB()
+    resultat = SCHEMA.AssurerSchemaProgrammations(db, appliquer=True)
+    assert resultat["ok"] is False
+    assert resultat["prerequis_absents"] == ("structures_relations",)
+    assert db.creations == []
+
+
+def test_activation_cree_uniquement_les_deux_tables_et_est_idempotente():
+    db = SQLiteDB()
+    _creer_table(db, "structures_relations")
+    avant = list(db.creations)
+    resultat = SCHEMA.AssurerSchemaProgrammations(db, appliquer=True)
+    assert resultat["ok"] is True
+    assert resultat["tables_creees"] == DATA_PROG.GetNomsTables()
+    assert db.creations == avant + list(DATA_PROG.GetNomsTables())
+    resultat2 = SCHEMA.AssurerSchemaProgrammations(db, appliquer=True)
+    assert resultat2["ok"] is True
+    assert resultat2["tables_creees"] == ()
+
+
+def test_schema_incomplet_bloque_preflight():
+    db = SQLiteDB()
+    _creer_table(db, "structures_relations")
+    db.conn.execute("CREATE TABLE structures_programmations (IDprogrammation_structure INTEGER PRIMARY KEY AUTOINCREMENT, uid VARCHAR(64))")
+    db.conn.commit()
+    resultat = SCHEMA.AssurerSchemaProgrammations(db, appliquer=True)
+    assert resultat["ok"] is False
+    assert resultat["tables_incoherentes"] == ("structures_programmations",)
+    assert "IDrelation_structure" in resultat["rapport"]["structures_programmations"]["champs_manquants"]
+    assert "structures_programmations_creneaux" not in db.creations
+
+
+def test_programmation_est_bornee_par_relation_et_unique_par_saison():
+    db, relation = _base()
+    gestion, IDprog = _programmation(db, relation)
+    prog = gestion.LireProgrammation(IDprog)
+    assert prog["uid"] == "PROG-2026"
+    assert prog["statut"] == PROG.STATUT_BROUILLON
+    try:
+        _programmation(db, relation, uid="PROG-DOUBLON")
+        assert False, "programmation doublon acceptée"
+    except ValueError:
+        pass
+    try:
+        gestion.CreerProgrammation({
+            "IDrelation_structure": relation, "saison": "2027-2028",
+            "date_debut": "2026-08-01", "date_fin": "2027-08-31",
+        })
+        assert False, "programmation hors relation acceptée"
+    except ValueError:
+        pass
+
+
+def test_creneau_valide_groupe_lieu_horaire_et_regles_calendrier():
+    db, relation = _base()
+    gestion, IDprog = _programmation(db, relation)
+    IDcreneau = _creneau(gestion, IDprog)
+    cr = gestion.LireCreneau(IDcreneau)
+    assert cr["IDgroupe_structure"] == 1
+    assert cr["IDlieu"] == 1
+    assert cr["etat_renouvellement"] == PROG.RENOUVELLEMENT_AJOUTE
+    try:
+        gestion.CreerCreneau(IDprog, {
+            "jour_semaine": 7, "heure_debut": "18:00", "heure_fin": "19:00"
+        })
+        assert False, "jour invalide accepté"
+    except ValueError:
+        pass
+    try:
+        gestion.CreerCreneau(IDprog, {
+            "jour_semaine": 1, "heure_debut": "19:00", "heure_fin": "18:00"
+        })
+        assert False, "horaire inversé accepté"
+    except ValueError:
+        pass
+    try:
+        gestion.CreerCreneau(IDprog, {
+            "jour_semaine": 1, "heure_debut": "18:00", "heure_fin": "19:00",
+            "appliquer_scolaire": 0, "appliquer_vacances": 0,
+        })
+        assert False, "règle calendrier vide acceptée"
+    except ValueError:
+        pass
+
+
+def test_validation_verrouille_programmation_et_creneaux():
+    db, relation = _base()
+    gestion, IDprog = _programmation(db, relation)
+    IDcreneau = _creneau(gestion, IDprog)
+    assert gestion.ChangerStatut(IDprog, PROG.STATUT_VALIDEE) is True
+    assert gestion.LireProgrammation(IDprog)["statut"] == PROG.STATUT_VALIDEE
+    try:
+        gestion.ModifierProgrammation(IDprog, {"notes": "interdit"})
+        assert False, "programmation validée modifiée"
+    except ValueError:
+        pass
+    try:
+        gestion.ModifierCreneau(IDcreneau, {"libelle": "interdit"})
+        assert False, "créneau validé modifié"
+    except ValueError:
+        pass
+
+
+def test_renouvellement_conserve_filiation_et_detecte_modification_suppression():
+    db, relation = _base()
+    gestion, IDprog = _programmation(db, relation)
+    ancien_creneau = _creneau(gestion, IDprog)
+    gestion.ChangerStatut(IDprog, PROG.STATUT_VALIDEE)
+
+    relation2 = REL.GestionnaireRelationsStructures(db).CreerRelation({
+        "uid": "REL-PROG-2027", "IDstructure": 1,
+        "type_relation": "mise_disposition", "libelle": "Badminton annuel",
+        "saison": "2027-2028", "date_debut": "2027-09-01", "date_fin": "2028-08-31",
+        "tarif": 46, "unite_tarif": "heure", "regle_adhesion": "requise",
+        "mode_facturation": "mensuel",
+    }, date="2027-06-01")
+    nouveau = gestion.RenouvelerProgrammation(
+        IDprog, relation2, "2027-2028", "2027-09-01", "2028-08-31", date="2027-06-01"
+    )
+    prog2 = gestion.LireProgrammation(nouveau)
+    assert prog2["IDprogrammation_source"] == IDprog
+    copies = gestion.ListerCreneaux(nouveau)
+    assert len(copies) == 1
+    copie = copies[0]
+    assert copie["IDcreneau_source"] == ancien_creneau
+    assert copie["etat_renouvellement"] == PROG.RENOUVELLEMENT_INCHANGE
+
+    gestion.ModifierCreneau(copie["IDcreneau_programmation"], {"heure_fin": "20:00"})
+    assert gestion.LireCreneau(copie["IDcreneau_programmation"])["etat_renouvellement"] == PROG.RENOUVELLEMENT_MODIFIE
+    gestion.SupprimerCreneau(copie["IDcreneau_programmation"])
+    assert gestion.LireCreneau(copie["IDcreneau_programmation"])["etat_renouvellement"] == PROG.RENOUVELLEMENT_SUPPRIME
+    assert gestion.ListerCreneaux(nouveau, conserves_seulement=True) == []
+
+
+def test_apercu_delegue_strictement_au_calculateur_historique():
+    db, relation = _base()
+    gestion, IDprog = _programmation(db, relation)
+    _creneau(gestion, IDprog)
+    appels = []
+
+    def calculateur(params):
+        appels.append(dict(params))
+        assert params["jours_scolaires"] == [1]
+        assert params["jours_vacances"] == []
+        assert params["semaines"] == 1
+        assert params["feries"] is False
+        return [
+            {"date_debut": datetime.datetime(2026, 9, 8, 18, 0), "date_fin": datetime.datetime(2026, 9, 8, 19, 30)},
+            {"date_debut": datetime.datetime(2026, 9, 15, 18, 0), "date_fin": datetime.datetime(2026, 9, 15, 19, 30)},
+        ]
+
+    occurrences = gestion.GenererApercuOccurrences(IDprog, calculateur)
+    assert len(appels) == 1
+    assert len(occurrences) == 2
+    assert occurrences[0]["date"] == "2026-09-08"
+    assert occurrences[0]["duree_minutes"] == 90
+    assert occurrences[0]["uid"].startswith("OCC-")
+    assert occurrences[0]["uid_relation"] == "REL-PROG-2026"
+    assert occurrences[0]["IDstructure"] == 1
+
+
+def test_occurrences_sont_deterministes_et_dedoublonnees():
+    db, relation = _base()
+    gestion, IDprog = _programmation(db, relation)
+    _creneau(gestion, IDprog)
+    occurrence = {"date_debut": datetime.datetime(2026, 9, 8, 18, 0), "date_fin": datetime.datetime(2026, 9, 8, 19, 30)}
+    def calculateur(params):
+        return [occurrence, occurrence]
+    premier = gestion.GenererApercuOccurrences(IDprog, calculateur)
+    second = gestion.GenererApercuOccurrences(IDprog, calculateur)
+    assert len(premier) == 1
+    assert premier[0]["uid"] == second[0]["uid"]
+
+
+def test_annexe_est_triee_et_calcule_volume_previsionnel():
+    db, relation = _base()
+    gestion, IDprog = _programmation(db, relation)
+    _creneau(gestion, IDprog)
+    def calculateur(params):
+        return [
+            {"date_debut": datetime.datetime(2026, 9, 15, 18, 0), "date_fin": datetime.datetime(2026, 9, 15, 19, 30)},
+            {"date_debut": datetime.datetime(2026, 9, 8, 18, 0), "date_fin": datetime.datetime(2026, 9, 8, 19, 30)},
+        ]
+    annexe = gestion.ConstruireAnnexePrevisionnelle(IDprog, calculateur)
+    assert annexe["nb_seances"] == 2
+    assert annexe["duree_totale_minutes"] == 180
+    assert [x["numero"] for x in annexe["lignes"]] == [1, 2]
+    assert annexe["lignes"][0]["date"] == "2026-09-08"
+    assert annexe["lignes"][0]["jour"] == "mardi"
+
+
+def test_calculateur_invalide_est_refuse_et_programmation_annulee_ne_genere_rien():
+    db, relation = _base()
+    gestion, IDprog = _programmation(db, relation)
+    _creneau(gestion, IDprog)
+    try:
+        gestion.GenererApercuOccurrences(IDprog, None)
+        assert False, "calculateur absent accepté"
+    except TypeError:
+        pass
+    gestion.ChangerStatut(IDprog, PROG.STATUT_ANNULEE)
+    try:
+        gestion.GenererApercuOccurrences(IDprog, lambda params: [])
+        assert False, "programmation annulée génératrice"
+    except ValueError:
+        pass


### PR DESCRIPTION
## Objectif

Ajouter la programmation annuelle persistée au-dessus des relations Noe-062 et produire un aperçu d'occurrences/annexe sans réimplémenter le moteur calendrier historique de Noethys.

## Stockage additif

Deux nouvelles tables autonomes :
- `structures_programmations` : relation, saison, période, statut, filiation N-1 ;
- `structures_programmations_creneaux` : jour/heures, bornes optionnelles, groupe, lieu, nature/libellé, paramètres calendrier et état de renouvellement.

Activation explicite via `AssurerSchemaProgrammations(..., appliquer=True)` :
- `structures_relations` est un prérequis obligatoire ;
- aucun tiers/relation/intervention n'est créé implicitement ;
- préflight global avant écriture ;
- refus des schémas expérimentaux incohérents ;
- idempotence.

## Workflow métier

- programmation créée en brouillon et bornée par sa relation ;
- une programmation active par relation/saison ;
- créneaux vérifiés contre le bénéficiaire, ses groupes et les lieux actifs ;
- validation verrouille programmation et créneaux ;
- renouvellement N-1 depuis une programmation validée avec `IDprogrammation_source` / `IDcreneau_source` ;
- états `inchange`, `modifie`, `supprime`, `ajoute` conservés pour l'arbitrage de rentrée.

## Occurrences

`GenererApercuOccurrences()` n'implémente aucune connaissance des vacances ou jours fériés. Il exige un `calculateur_occurrences` injecté respectant le contrat historique de `DLG_Saisie_location.Calcule_occurences` :
- entrée : dates, heures, jours scolaires/vacances, code fréquence 1–6, inclusion des fériés ;
- sortie : `datetime` début/fin.

Les occurrences reçoivent un UID déterministe `OCC-...` dérivé du créneau et de leurs horaires, ce qui prépare une matérialisation idempotente ultérieure vers `interventions`.

`ConstruireAnnexePrevisionnelle()` trie ces occurrences et fournit nombre de séances, durée totale et lignes d'annexe.

## Garde-fous

- aucune duplication du calcul vacances/fériés/récurrence ;
- aucune facture/prestation générée ;
- aucune séance `interventions` écrite dans ce lot : prévision et matérialisation restent deux étapes distinctes ;
- aucun changement des tables familles/individus ni de `DATA_Tables.py` ;
- la programmation annulée ne produit aucune occurrence.

## Tests

Recette SQLite réelle : activation/idempotence, schéma incomplet, bornes relation, unicité saison, validation groupe/lieu/horaire/calendrier, verrouillage, renouvellement N-1, modification/suppression, délégation au calculateur historique, UID déterministes/dédoublonnage et annexe triée avec volume prévisionnel.

Relates #60.