### PR TITLE
Noe-062E : générer l’annexe depuis la récurrence commune

### DIFF
--- a/noethys/Utils/UTILS_Conventions_Structures_Recurrence.py
+++ b/noethys/Utils/UTILS_Conventions_Structures_Recurrence.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Adaptateur Noe-062 entre le moteur commun de récurrence et les documents.
+
+Ce module ne calcule aucune règle de calendrier : il appelle exclusivement
+``UTILS_Locations_Recurrence.CalculerOccurrencesAnnexe`` puis convertit les
+occurrences obtenues vers le contrat d'annexe de
+``UTILS_Conventions_Structures_Documents``.
+
+Aucune écriture en base, prestation ou PDF n'est créée ici.
+"""
+from __future__ import unicode_literals
+
+import hashlib
+
+from Utils import UTILS_Conventions_Structures_Documents
+from Utils import UTILS_Locations_Recurrence
+
+
+def _texte(valeur):
+    if valeur is None:
+        return u""
+    try:
+        return valeur.strip()
+    except Exception:
+        return valeur
+
+
+def _identifiant_occurrence(convention_uid, debut, fin, groupe, lieu):
+    """Produit un identifiant déterministe pour une occurrence d'annexe."""
+    cle = u"|".join((
+        _texte(convention_uid),
+        debut.isoformat(),
+        fin.isoformat(),
+        _texte(groupe),
+        _texte(lieu),
+    ))
+    return "SEANCE-%s" % hashlib.sha256(cle.encode("utf-8")).hexdigest()[:24]
+
+
+def ConstruireLignesAnnexeDepuisOccurrences(
+    occurrences=None,
+    convention_uid="",
+    groupe="",
+    lieu="",
+    observations="",
+):
+    """Convertit les occurrences du moteur historique en lignes d'annexe."""
+    lignes = []
+    for occurrence in occurrences or ():
+        occurrence = dict(occurrence or {})
+        debut = occurrence.get("date_debut")
+        fin = occurrence.get("date_fin")
+        if debut is None or fin is None:
+            raise ValueError("Une occurrence doit fournir date_debut et date_fin")
+        if fin < debut:
+            raise ValueError("La fin d'une occurrence ne peut pas précéder son début")
+        duree_secondes = (fin - debut).total_seconds()
+        if duree_secondes % 60:
+            raise ValueError("La durée d'une occurrence doit être exprimable en minutes entières")
+        lignes.append({
+            "identifiant_stable": _identifiant_occurrence(
+                convention_uid, debut, fin, groupe, lieu
+            ),
+            "date": debut.date().isoformat(),
+            "heure_debut": debut.strftime("%H:%M"),
+            "heure_fin": fin.strftime("%H:%M"),
+            "duree_minutes": int(duree_secondes // 60),
+            "groupe": _texte(groupe),
+            "lieu": _texte(lieu),
+            "observations": _texte(observations),
+        })
+    return UTILS_Conventions_Structures_Documents.NormaliserAnnexe(lignes)
+
+
+def CalculerLignesAnnexe(
+    dictDonnees=None,
+    convention_uid="",
+    groupe="",
+    lieu="",
+    observations="",
+    DB=None,
+    calendrier=None,
+):
+    """Calcule via le moteur commun puis adapte le résultat pour le document."""
+    occurrences = UTILS_Locations_Recurrence.CalculerOccurrencesAnnexe(
+        dictDonnees=dictDonnees,
+        DB=DB,
+        calendrier=calendrier,
+    )
+    return ConstruireLignesAnnexeDepuisOccurrences(
+        occurrences=occurrences,
+        convention_uid=convention_uid,
+        groupe=groupe,
+        lieu=lieu,
+        observations=observations,
+    )
+
+
+def ConstruirePaquetDocumentaireDepuisRecurrence(
+    gestion,
+    IDconvention_structure,
+    dictDonnees,
+    groupe="",
+    lieu="",
+    observations="",
+    DB=None,
+    calendrier=None,
+):
+    """Construit le paquet documentaire avec une annexe issue du moteur commun."""
+    convention = gestion.LireConvention(IDconvention_structure)
+    if not convention:
+        raise ValueError("Convention introuvable")
+    lignes = CalculerLignesAnnexe(
+        dictDonnees=dictDonnees,
+        convention_uid=convention.get("uid") or "",
+        groupe=groupe,
+        lieu=lieu,
+        observations=observations,
+        DB=DB,
+        calendrier=calendrier,
+    )
+    return gestion.ConstruirePaquetDocumentaire(
+        IDconvention_structure,
+        lignes_annexe=lignes,
+    )

--- a/tests/test_noe_062_annexe_recurrence.py
+++ b/tests/test_noe_062_annexe_recurrence.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+import datetime
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOETHYS = ROOT / "noethys"
+if str(NOETHYS) not in sys.path:
+    sys.path.insert(0, str(NOETHYS))
+
+
+def _charger(path, nom):
+    spec = importlib.util.spec_from_file_location(nom, str(ROOT / path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+DOC_TESTS = _charger(
+    "tests/test_noe_062_conventions_documents.py",
+    "test_noe_062_conventions_documents_base_annexe",
+)
+ADAPTER = _charger(
+    "noethys/Utils/UTILS_Conventions_Structures_Recurrence.py",
+    "UTILS_Conventions_Structures_Recurrence_test",
+)
+COMMON = _charger(
+    "noethys/Utils/UTILS_Locations_Recurrence.py",
+    "UTILS_Locations_Recurrence_annexe_test",
+)
+
+
+def _regle(debut, fin, semaines=1, feries=False):
+    return {
+        "date_debut": debut,
+        "date_fin": fin,
+        "heure_debut": "10:30",
+        "heure_fin": "11:15",
+        "jours_vacances": [],
+        "jours_scolaires": [0],
+        "semaines": semaines,
+        "feries": feries,
+    }
+
+
+def test_paquet_documentaire_recoit_directement_annexe_du_moteur_commun():
+    db = DOC_TESTS.BASE._preparer_base()
+    gestion, IDrelation, IDconv = DOC_TESTS._creer_documentable(db)
+    gestion.ValiderConvention(IDconv, date="2026-09-03")
+    commits_avant = db.commits
+
+    paquet = ADAPTER.ConstruirePaquetDocumentaireDepuisRecurrence(
+        gestion,
+        IDconv,
+        _regle(datetime.date(2026, 9, 7), datetime.date(2026, 9, 21)),
+        groupe="Groupe 1",
+        lieu="Salle A",
+        calendrier=([], []),
+    )
+
+    assert db.commits == commits_avant
+    assert paquet["champs"]["{ANNEXE_NB_SEANCES}"] == "3"
+    assert paquet["champs"]["{ANNEXE_DUREE_TOTALE_MINUTES}"] == "135"
+    assert [ligne["date"] for ligne in paquet["lignes_annexe"]] == [
+        "2026-09-07",
+        "2026-09-14",
+        "2026-09-21",
+    ]
+    assert all(ligne["groupe"] == "Groupe 1" for ligne in paquet["lignes_annexe"])
+    assert all(ligne["lieu"] == "Salle A" for ligne in paquet["lignes_annexe"])
+
+
+def test_lignes_annexe_sont_strictement_alignees_sur_occurrences_communes():
+    regle = _regle(
+        datetime.date(2026, 9, 7),
+        datetime.date(2026, 10, 5),
+        semaines=2,
+    )
+    occurrences = COMMON.CalculerOccurrencesAnnexe(regle, calendrier=([], []))
+    lignes = ADAPTER.CalculerLignesAnnexe(
+        regle,
+        convention_uid="CONV-PARITE",
+        calendrier=([], []),
+    )
+    assert [ligne["date"] for ligne in lignes] == [
+        item["date_debut"].date().isoformat() for item in occurrences
+    ]
+    assert [ligne["heure_debut"] for ligne in lignes] == [
+        item["date_debut"].strftime("%H:%M") for item in occurrences
+    ]
+    assert [ligne["heure_fin"] for ligne in lignes] == [
+        item["date_fin"].strftime("%H:%M") for item in occurrences
+    ]
+
+
+def test_identifiants_occurrences_sont_deterministes_et_namespaces_par_convention():
+    occurrence = {
+        "date_debut": datetime.datetime(2026, 9, 7, 10, 30),
+        "date_fin": datetime.datetime(2026, 9, 7, 11, 15),
+    }
+    lignes1 = ADAPTER.ConstruireLignesAnnexeDepuisOccurrences(
+        [occurrence], convention_uid="CONV-A", groupe="G1", lieu="Salle"
+    )
+    lignes2 = ADAPTER.ConstruireLignesAnnexeDepuisOccurrences(
+        [occurrence], convention_uid="CONV-A", groupe="G1", lieu="Salle"
+    )
+    lignes3 = ADAPTER.ConstruireLignesAnnexeDepuisOccurrences(
+        [occurrence], convention_uid="CONV-B", groupe="G1", lieu="Salle"
+    )
+    assert lignes1[0]["identifiant_stable"] == lignes2[0]["identifiant_stable"]
+    assert lignes1[0]["identifiant_stable"] != lignes3[0]["identifiant_stable"]
+    assert lignes1[0]["identifiant_stable"].startswith("SEANCE-")
+
+
+def test_adaptateur_refuse_occurrence_incomplete_negative_ou_non_minute():
+    cas = [
+        {"date_debut": datetime.datetime(2026, 9, 7, 10, 30)},
+        {
+            "date_debut": datetime.datetime(2026, 9, 7, 11, 15),
+            "date_fin": datetime.datetime(2026, 9, 7, 10, 30),
+        },
+        {
+            "date_debut": datetime.datetime(2026, 9, 7, 10, 30, 0),
+            "date_fin": datetime.datetime(2026, 9, 7, 11, 15, 30),
+        },
+    ]
+    for occurrence in cas:
+        try:
+            ADAPTER.ConstruireLignesAnnexeDepuisOccurrences([occurrence])
+            assert False, "occurrence invalide acceptée"
+        except ValueError:
+            pass
+
+
+def test_adaptateur_ne_reimplemente_aucune_requete_calendrier():
+    source = (
+        ROOT / "noethys" / "Utils" / "UTILS_Conventions_Structures_Recurrence.py"
+    ).read_text(encoding="utf-8")
+    assert "FROM vacances" not in source
+    assert "FROM jours_feries" not in source
+    assert "CalculerOccurrencesAnnexe" in source


### PR DESCRIPTION
## Objectif

Relier directement le moteur commun de récurrence fusionné par #308 au paquet documentaire Noe-062 de #306, sans recopier aucune règle de calendrier.

## Contenu

Nouveau `UTILS_Conventions_Structures_Recurrence.py` :

- appelle exclusivement `UTILS_Locations_Recurrence.CalculerOccurrencesAnnexe()` ;
- convertit les occurrences historiques en lignes d’annexe documentaires ;
- calcule date, horaires et durée en minutes sans recalcul vacances/fériés/fréquence ;
- génère un identifiant `SEANCE-*` déterministe, namespacé par l’UID de convention + occurrence + groupe + lieu ;
- fournit `ConstruirePaquetDocumentaireDepuisRecurrence()` pour alimenter directement le paquet documentaire figé existant ;
- aucune écriture DB, prestation, facture ou PDF.

## Garde-fous

- occurrence incomplète refusée ;
- fin antérieure au début refusée ;
- durée non exprimable en minutes entières refusée ;
- aucune requête `vacances` / `jours_feries` dans l’adaptateur ;
- les champs et l’empreinte du document restent produits par le moteur documentaire existant ;
- le moteur de récurrence reste l’unique source des occurrences.

## Tests

Recette couvrant :
- génération directe d’une annexe de 3 séances dans un paquet documentaire validé ;
- absence d’écriture DB ;
- parité stricte des dates/horaires avec le moteur commun ;
- stabilité et namespacing des IDs de séance ;
- validation des occurrences invalides ;
- absence de SQL calendrier dupliqué.

Relates #60.