### PR TITLE
Audit: fiabiliser l’historique de suppression des règlements SEPA

### DIFF
--- a/noethys/Ol/OL_Prelevements_sepa.py
+++ b/noethys/Ol/OL_Prelevements_sepa.py
@@ -970,10 +970,11 @@ class ListView(FastObjectListView):
             else :
 
                 if track.IDreglement != None :
-                    if not DB.ReqDEL("ventilation", "IDreglement", track.IDreglement, commit=False):
+                    IDreglement = track.IDreglement
+                    if not DB.ReqDEL("ventilation", "IDreglement", IDreglement, commit=False):
                         ok = False
                         break
-                    if not DB.ReqDEL("reglements", "IDreglement", track.IDreglement, commit=False):
+                    if not DB.ReqDEL("reglements", "IDreglement", IDreglement, commit=False):
                         ok = False
                         break
                     listeHistoriqueAjouts.append(self.MemoriseReglementHistorique(mode="suppression", IDfamille=track.IDfamille, IDreglement=IDreglement, montant=track.montant))

--- a/tests/test_sepa_reglement_history_contract.py
+++ b/tests/test_sepa_reglement_history_contract.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import ast
+import decimal
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from scripts import audit_branch_assignment_gaps
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_ROOT = ROOT / "noethys"
+TARGET = SOURCE_ROOT / "Ol" / "OL_Prelevements_sepa.py"
+
+
+class FakeDB:
+    def __init__(self):
+        self.result_sets = [[], []]
+        self.deletes = []
+
+    def ExecuterReq(self, req):
+        pass
+
+    def ResultatReq(self):
+        return self.result_sets.pop(0)
+
+    def ReqDEL(self, table, key, value, commit=False):
+        self.deletes.append((table, key, value, commit))
+        return True
+
+
+class FakeHistorique:
+    actions = []
+
+    @classmethod
+    def InsertActions(cls, actions, DB=None, commit=False):
+        cls.actions = list(actions)
+        return True
+
+
+class FakeView:
+    def __init__(self, track):
+        self.track = track
+
+    def GetObjects(self):
+        return [self.track]
+
+    def MemoriseReglementHistorique(self, mode="saisie", IDfamille=None, IDreglement=None, montant=0.0):
+        return {
+            "mode": mode,
+            "IDfamille": IDfamille,
+            "IDreglement": IDreglement,
+            "montant": montant,
+        }
+
+    def RefreshObject(self, track):
+        pass
+
+
+def load_method():
+    source = TARGET.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    method = next(
+        item
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "ListView"
+        for item in node.body
+        if isinstance(item, ast.FunctionDef) and item.name == "SauvegardeReglements"
+    )
+    module = ast.Module(body=[method], type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = {
+        "decimal": decimal,
+        "UTILS_Historique": FakeHistorique,
+    }
+    exec(compile(module, str(TARGET), "exec"), namespace)
+    return namespace["SauvegardeReglements"]
+
+
+class SepaReglementHistoryContractTests(unittest.TestCase):
+    def setUp(self):
+        FakeHistorique.actions = []
+
+    def test_first_deleted_payment_uses_its_own_id_in_history(self):
+        track = SimpleNamespace(
+            IDfacture=None,
+            reglement=False,
+            IDreglement=123,
+            IDfamille=45,
+            montant=12.5,
+        )
+        db = FakeDB()
+
+        result = load_method()(FakeView(track), DB=db, commit=False)
+
+        self.assertTrue(result)
+        self.assertEqual(
+            db.deletes,
+            [
+                ("ventilation", "IDreglement", 123, False),
+                ("reglements", "IDreglement", 123, False),
+            ],
+        )
+        self.assertEqual(len(FakeHistorique.actions), 1)
+        self.assertEqual(FakeHistorique.actions[0]["IDreglement"], 123)
+        self.assertEqual(FakeHistorique.actions[0]["mode"], "suppression")
+
+    def test_targeted_branch_assignment_gap_is_gone(self):
+        findings = audit_branch_assignment_gaps.scan_file(TARGET, SOURCE_ROOT)
+        targeted = [
+            item
+            for item in findings
+            if item.get("function") == "SauvegardeReglements"
+            and item.get("name") == "IDreglement"
+        ]
+        self.assertEqual(targeted, [], targeted)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #253

## Problème démontré

Dans `ListView.SauvegardeReglements`, la branche de suppression utilisait la variable locale `IDreglement` sans l’initialiser à partir du track supprimé.

Deux impacts sont possibles :
- si le premier règlement traité est un règlement existant à supprimer, `IDreglement` n’a encore reçu aucune valeur et la sauvegarde peut lever `UnboundLocalError` ;
- si un règlement précédent a initialisé la variable, l’historique de suppression peut enregistrer silencieusement l’identifiant de ce règlement précédent au lieu de celui réellement supprimé.

## Correction

La branche de suppression capture explicitement `track.IDreglement` dans `IDreglement` avant les suppressions, puis réutilise cette même valeur pour `ventilation`, `reglements` et l’historique.

## Régression

Ajout de `tests/test_sepa_reglement_history_contract.py` :
- exécute isolément `SauvegardeReglements` avec un faux backend DB ;
- couvre le cas où le premier track est un règlement existant à supprimer ;
- vérifie que les deux suppressions et l’historique utilisent exactement le même ID ;
- vérifie que le finding `branch_assignment_gap` ciblé sur `IDreglement` disparaît.

Le diff fonctionnel de `OL_Prelevements_sepa.py` est limité à 5 lignes (3 ajouts / 2 suppressions).