### PR TITLE
Noe-062 : recevoir le réalisé validé par UID de séance

### DIFF
--- a/noethys/Data/DATA_Interventions_Actual_Inbox.py
+++ b/noethys/Data/DATA_Interventions_Actual_Inbox.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Schéma additif de réception du réalisé canonique d'une séance.
+
+Cette table mémorise les messages effectivement appliqués au domaine
+activité/usagers. Elle ne remplace ni ``interventions`` ni
+``interventions_execution``.
+"""
+from __future__ import unicode_literals
+
+
+TABLE_INBOX = "interventions_execution_inbox"
+
+DB_INTERVENTIONS_ACTUAL_INBOX = {
+    TABLE_INBOX: [
+        ("IDinbox_execution", "INTEGER PRIMARY KEY AUTOINCREMENT", u"ID local de réception"),
+        ("idempotence_key", "VARCHAR(255)", u"Clé stable du message reçu"),
+        ("source_domain", "VARCHAR(64)", u"Domaine émetteur stable, indépendant du nom du produit"),
+        ("contract_version", "VARCHAR(64)", u"Version du contrat métier reçu"),
+        ("event_type", "VARCHAR(64)", u"Type d'événement métier reçu"),
+        ("actual_uuid", "VARCHAR(64)", u"Identifiant du réalisé côté domaine opérations"),
+        ("session_uid", "VARCHAR(128)", u"UID canonique de la séance"),
+        ("actual_revision", "INTEGER", u"Révision du réalisé validé"),
+        ("payload_sha256", "VARCHAR(64)", u"Empreinte du payload canonique appliqué"),
+        ("date_reception", "DATETIME", u"Horodatage de réception"),
+    ],
+}

--- a/noethys/Data/DATA_Interventions_Actual_Inbox.py
+++ b/noethys/Data/DATA_Interventions_Actual_Inbox.py
@@ -14,7 +14,8 @@ TABLE_INBOX = "interventions_execution_inbox"
 DB_INTERVENTIONS_ACTUAL_INBOX = {
     TABLE_INBOX: [
         ("IDinbox_execution", "INTEGER PRIMARY KEY AUTOINCREMENT", u"ID local de réception"),
-        ("idempotence_key", "VARCHAR(255)", u"Clé stable du message reçu"),
+        ("idempotence_key", "VARCHAR(255) UNIQUE", u"Clé stable du message reçu"),
+        ("revision_key", "VARCHAR(255) UNIQUE", u"Clé unique domaine + séance + révision"),
         ("source_domain", "VARCHAR(64)", u"Domaine émetteur stable, indépendant du nom du produit"),
         ("contract_version", "VARCHAR(64)", u"Version du contrat métier reçu"),
         ("event_type", "VARCHAR(64)", u"Type d'événement métier reçu"),

--- a/noethys/Utils/UTILS_Interventions_Actual_Inbox.py
+++ b/noethys/Utils/UTILS_Interventions_Actual_Inbox.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Réception idempotente du réalisé validé dans le domaine activité/usagers.
+
+Le contrat est indépendant des noms de produits. Un message met à jour la séance
+canonique existante identifiée par ``session_uid`` et son extension 1:1 ; il ne
+crée jamais de nouvelle séance ni de nouveau lieu.
+"""
+from __future__ import unicode_literals
+
+import datetime
+import hashlib
+import json
+
+from Data import DATA_Interventions_Actual_Inbox
+from Utils import UTILS_Interventions
+from Utils import UTILS_Interventions_Execution
+from Utils import UTILS_Lieux
+
+
+TABLE_INBOX = DATA_Interventions_Actual_Inbox.TABLE_INBOX
+SOURCE_DOMAIN = "operations_portal"
+CONTRACT_VERSION = "session-actual/1"
+EVENT_TYPE = "session_actual_validated"
+STATUTS_ACCEPTES = ("realisee", "annulee")
+
+
+class ActualInboxError(ValueError):
+    pass
+
+
+def _texte(valeur):
+    if valeur is None:
+        return u""
+    try:
+        return valeur.strip()
+    except Exception:
+        return str(valeur).strip()
+
+
+def _texte_requis(valeur, champ, longueur=255):
+    valeur = _texte(valeur)
+    if not valeur:
+        raise ActualInboxError("%s obligatoire" % champ)
+    if len(valeur) > longueur or any(ord(ch) < 32 for ch in valeur):
+        raise ActualInboxError("%s invalide" % champ)
+    return valeur
+
+
+def _sql_texte(valeur):
+    return _texte(valeur).replace("'", "''")
+
+
+def _revision(valeur):
+    try:
+        valeur = int(valeur)
+    except (TypeError, ValueError):
+        raise ActualInboxError("actual_revision invalide")
+    if valeur < 1:
+        raise ActualInboxError("actual_revision invalide")
+    return valeur
+
+
+def _date_iso(valeur, champ="assignment_date"):
+    if isinstance(valeur, datetime.datetime):
+        valeur = valeur.date()
+    if isinstance(valeur, datetime.date):
+        return valeur.isoformat()
+    valeur = _texte_requis(valeur, champ, 10)
+    try:
+        datetime.datetime.strptime(valeur, "%Y-%m-%d")
+    except ValueError:
+        raise ActualInboxError("%s invalide" % champ)
+    return valeur
+
+
+def _heure_optionnelle(valeur, champ):
+    if valeur in (None, "", u""):
+        return None
+    valeur = _texte_requis(valeur, champ, 5)
+    try:
+        return datetime.datetime.strptime(valeur, "%H:%M").strftime("%H:%M")
+    except ValueError:
+        raise ActualInboxError("%s invalide" % champ)
+
+
+def _datetime_reception(valeur=None):
+    valeur = valeur or datetime.datetime.now()
+    if isinstance(valeur, datetime.datetime):
+        return valeur.strftime("%Y-%m-%d %H:%M:%S")
+    texte = _texte_requis(valeur, "date_reception", 40).replace("T", " ")
+    texte = texte[:19]
+    try:
+        datetime.datetime.strptime(texte, "%Y-%m-%d %H:%M:%S")
+    except ValueError:
+        raise ActualInboxError("date_reception invalide")
+    return texte
+
+
+def _json_stable(donnees):
+    return json.dumps(donnees, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _sha256(donnees):
+    return hashlib.sha256(_json_stable(donnees).encode("utf-8")).hexdigest()
+
+
+def _rollback(db):
+    methode = getattr(db, "Rollback", None)
+    if callable(methode):
+        methode()
+        return
+    connexion = getattr(db, "connexion", None) or getattr(db, "conn", None)
+    if connexion is not None and hasattr(connexion, "rollback"):
+        connexion.rollback()
+        return
+    raise RuntimeError("La connexion DB ne permet pas le rollback")
+
+
+def _commit(db):
+    methode = getattr(db, "Commit", None)
+    if callable(methode):
+        methode()
+        return
+    connexion = getattr(db, "connexion", None) or getattr(db, "conn", None)
+    if connexion is not None and hasattr(connexion, "commit"):
+        connexion.commit()
+        return
+    raise RuntimeError("La connexion DB ne permet pas le commit")
+
+
+def _normaliser_message(payload):
+    if not isinstance(payload, dict):
+        raise ActualInboxError("payload invalide")
+    contract_version = _texte_requis(payload.get("contract_version"), "contract_version", 64)
+    if contract_version != CONTRACT_VERSION:
+        raise ActualInboxError("version de contrat non supportée")
+    event_type = _texte_requis(payload.get("event_type"), "event_type", 64)
+    if event_type != EVENT_TYPE:
+        raise ActualInboxError("type d'événement non supporté")
+    actual_uuid = _texte_requis(payload.get("actual_uuid"), "actual_uuid", 64)
+    session_uid = _texte_requis(payload.get("session_uid"), "session_uid", 128)
+    revision = _revision(payload.get("actual_revision"))
+    statut = _texte_requis(payload.get("session_status"), "session_status", 32)
+    if statut not in STATUTS_ACCEPTES:
+        raise ActualInboxError("session_status doit être realisee ou annulee")
+    assignment_date = _date_iso(payload.get("assignment_date"))
+    validated_at = _texte_requis(payload.get("validated_at"), "validated_at", 64)
+    actual_staff_uid = _texte(payload.get("actual_staff_uid")) or None
+    if actual_staff_uid is not None:
+        if len(actual_staff_uid) > 100 or any(ord(ch) < 32 for ch in actual_staff_uid):
+            raise ActualInboxError("actual_staff_uid invalide")
+    actual_place_uid = _texte(payload.get("actual_place_uid")) or None
+    if actual_place_uid is not None and len(actual_place_uid) > 128:
+        raise ActualInboxError("actual_place_uid invalide")
+    debut = _heure_optionnelle(payload.get("actual_start_time"), "actual_start_time")
+    fin = _heure_optionnelle(payload.get("actual_end_time"), "actual_end_time")
+    commentaire = _texte(payload.get("actual_comment"))
+    if len(commentaire) > 2000:
+        raise ActualInboxError("actual_comment trop long")
+
+    duree = payload.get("actual_duration_minutes")
+    if statut == "realisee":
+        if not actual_staff_uid:
+            raise ActualInboxError("intervenant réel obligatoire pour une séance réalisée")
+        if debut is None or fin is None:
+            raise ActualInboxError("horaires réels obligatoires pour une séance réalisée")
+        calculee = UTILS_Interventions.CalculerDureeMinutes(debut, fin)
+        try:
+            duree = int(duree)
+        except (TypeError, ValueError):
+            raise ActualInboxError("actual_duration_minutes invalide")
+        if duree != calculee:
+            raise ActualInboxError("durée réelle incohérente avec les horaires")
+    else:
+        if actual_staff_uid is not None or actual_place_uid is not None or debut is not None or fin is not None or duree not in (None, "", u""):
+            raise ActualInboxError("une séance annulée ne porte ni intervenant, ni lieu, ni horaires réels")
+        if not commentaire:
+            raise ActualInboxError("commentaire obligatoire pour une séance annulée")
+        duree = None
+
+    return {
+        "contract_version": contract_version,
+        "event_type": event_type,
+        "actual_uuid": actual_uuid,
+        "actual_revision": revision,
+        "session_uid": session_uid,
+        "session_status": statut,
+        "assignment_date": assignment_date,
+        "validated_at": validated_at,
+        "actual_staff_uid": actual_staff_uid,
+        "actual_place_uid": actual_place_uid,
+        "actual_start_time": debut,
+        "actual_end_time": fin,
+        "actual_duration_minutes": duree,
+        "actual_comment": commentaire,
+    }
+
+
+class GestionnaireInboxRealise(object):
+    def __init__(self, db):
+        self.db = db
+        self.executions = UTILS_Interventions_Execution.GestionnaireExecutionInterventions(db)
+        self.lieux = UTILS_Lieux.GestionnaireLieux(db)
+
+    def _exiger_schema(self):
+        requises = ("interventions", "interventions_execution", "lieux", TABLE_INBOX)
+        absentes = [nom for nom in requises if not self.db.IsTableExists(nom)]
+        if absentes:
+            raise ActualInboxError("Tables requises absentes: %s" % ", ".join(absentes))
+
+    def _lire_intervention_par_uid(self, uid):
+        req = "SELECT IDintervention, uid, date, statut, actif FROM interventions WHERE uid='%s';" % _sql_texte(uid)
+        if self.db.ExecuterReq(req) != 1:
+            raise ActualInboxError("Impossible de lire la séance canonique")
+        lignes = self.db.ResultatReq() or []
+        if len(lignes) > 1:
+            raise ActualInboxError("UID de séance canonique dupliqué")
+        if not lignes:
+            raise ActualInboxError("Séance canonique introuvable ; aucune création implicite")
+        champs = ("IDintervention", "uid", "date", "statut", "actif")
+        return dict(zip(champs, lignes[0]))
+
+    def _lire_idempotence(self, cle):
+        req = "SELECT idempotence_key, revision_key, source_domain, actual_uuid, session_uid, actual_revision, payload_sha256 FROM %s WHERE idempotence_key='%s';" % (
+            TABLE_INBOX, _sql_texte(cle)
+        )
+        if self.db.ExecuterReq(req) != 1:
+            raise ActualInboxError("Impossible de lire l'inbox")
+        lignes = self.db.ResultatReq() or []
+        if len(lignes) > 1:
+            raise ActualInboxError("Clé d'idempotence dupliquée")
+        if not lignes:
+            return None
+        champs = (
+            "idempotence_key", "revision_key", "source_domain", "actual_uuid",
+            "session_uid", "actual_revision", "payload_sha256",
+        )
+        return dict(zip(champs, lignes[0]))
+
+    def _lire_derniere_revision(self, source_domain, session_uid):
+        req = "SELECT idempotence_key, revision_key, source_domain, actual_uuid, session_uid, actual_revision, payload_sha256 FROM %s WHERE source_domain='%s' AND session_uid='%s' ORDER BY actual_revision DESC, IDinbox_execution DESC LIMIT 1;" % (
+            TABLE_INBOX, _sql_texte(source_domain), _sql_texte(session_uid)
+        )
+        if self.db.ExecuterReq(req) != 1:
+            raise ActualInboxError("Impossible de lire la dernière révision reçue")
+        lignes = self.db.ResultatReq() or []
+        if not lignes:
+            return None
+        champs = (
+            "idempotence_key", "revision_key", "source_domain", "actual_uuid",
+            "session_uid", "actual_revision", "payload_sha256",
+        )
+        return dict(zip(champs, lignes[0]))
+
+    def AppliquerMessage(self, payload, idempotence_key, source_domain=SOURCE_DOMAIN, date_reception=None):
+        """Applique une révision validée sur la séance existante, atomiquement."""
+        self._exiger_schema()
+        source_domain = _texte_requis(source_domain, "source_domain", 64)
+        if source_domain != SOURCE_DOMAIN:
+            raise ActualInboxError("domaine source non supporté")
+        idempotence_key = _texte_requis(idempotence_key, "idempotence_key", 255)
+        normalise = _normaliser_message(payload)
+        empreinte = _sha256(normalise)
+        revision_key = "%s:%s:r%d" % (
+            source_domain, normalise["session_uid"], normalise["actual_revision"]
+        )
+        if len(revision_key) > 255:
+            raise ActualInboxError("revision_key trop longue")
+        date_reception_sql = _datetime_reception(date_reception)
+
+        deja = self._lire_idempotence(idempotence_key)
+        if deja is not None:
+            if deja["payload_sha256"] != empreinte:
+                raise ActualInboxError("clé d'idempotence rejouée avec un payload différent")
+            return {
+                "applique": False,
+                "replay": True,
+                "session_uid": normalise["session_uid"],
+                "actual_revision": normalise["actual_revision"],
+            }
+
+        derniere = self._lire_derniere_revision(source_domain, normalise["session_uid"])
+        if derniere is not None:
+            derniere_revision = int(derniere["actual_revision"])
+            if normalise["actual_revision"] < derniere_revision:
+                raise ActualInboxError("révision reçue obsolète")
+            if normalise["actual_revision"] == derniere_revision:
+                if derniere["payload_sha256"] == empreinte and derniere["actual_uuid"] == normalise["actual_uuid"]:
+                    return {
+                        "applique": False,
+                        "replay": True,
+                        "session_uid": normalise["session_uid"],
+                        "actual_revision": normalise["actual_revision"],
+                    }
+                raise ActualInboxError("conflit de payload pour la même révision")
+            if derniere["actual_uuid"] != normalise["actual_uuid"]:
+                raise ActualInboxError("identité du réalisé modifiée pour une même séance")
+
+        intervention = self._lire_intervention_par_uid(normalise["session_uid"])
+        if _date_iso(intervention["date"], "date de séance") != normalise["assignment_date"]:
+            raise ActualInboxError("date reçue incohérente avec la séance canonique")
+        if intervention["actif"] in (0, False, "0"):
+            raise ActualInboxError("séance canonique archivée")
+
+        IDlieu_reel = None
+        if normalise["actual_place_uid"]:
+            lieu = self.lieux.LireLieuParUID(normalise["actual_place_uid"])
+            if not lieu:
+                raise ActualInboxError("lieu réel canonique introuvable")
+            IDlieu_reel = int(lieu["IDlieu"])
+
+        valeurs_execution = {
+            "UIDintervenant_reel": normalise["actual_staff_uid"],
+            "IDlieu_reel": IDlieu_reel,
+            "heure_debut_reelle": normalise["actual_start_time"],
+            "heure_fin_reelle": normalise["actual_end_time"],
+            "commentaire_realise": normalise["actual_comment"],
+        }
+        valeurs_inbox = (
+            ("idempotence_key", idempotence_key),
+            ("revision_key", revision_key),
+            ("source_domain", source_domain),
+            ("contract_version", normalise["contract_version"]),
+            ("event_type", normalise["event_type"]),
+            ("actual_uuid", normalise["actual_uuid"]),
+            ("session_uid", normalise["session_uid"]),
+            ("actual_revision", normalise["actual_revision"]),
+            ("payload_sha256", empreinte),
+            ("date_reception", date_reception_sql),
+        )
+        date_modification = date_reception_sql[:10]
+
+        try:
+            IDinbox = self.db.ReqInsert(TABLE_INBOX, list(valeurs_inbox), commit=False)
+            if IDinbox is None:
+                raise ActualInboxError("échec d'enregistrement de l'inbox")
+            self.executions.EnregistrerExecution(
+                intervention["IDintervention"],
+                valeurs_execution,
+                date=date_modification,
+                commit=False,
+            )
+            resultat_maj = self.db.ReqMAJ(
+                "interventions",
+                [("statut", normalise["session_status"]), ("date_modification", date_modification)],
+                "IDintervention",
+                int(intervention["IDintervention"]),
+                commit=False,
+            )
+            if resultat_maj is False:
+                raise ActualInboxError("échec de mise à jour du statut de séance")
+            _commit(self.db)
+        except Exception:
+            try:
+                _rollback(self.db)
+            except Exception:
+                pass
+            raise
+
+        execution = self.executions.LireExecution(intervention["IDintervention"])
+        if normalise["session_status"] == "realisee":
+            if execution.get("duree_reelle_minutes") != normalise["actual_duration_minutes"]:
+                raise RuntimeError("durée réelle persistée incohérente après commit")
+        return {
+            "applique": True,
+            "replay": False,
+            "IDintervention": int(intervention["IDintervention"]),
+            "session_uid": normalise["session_uid"],
+            "actual_revision": normalise["actual_revision"],
+        }

--- a/noethys/Utils/UTILS_Interventions_Actual_Inbox_Schema.py
+++ b/noethys/Utils/UTILS_Interventions_Actual_Inbox_Schema.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Activation additive de l'inbox du réalisé canonique de séance.
+
+Le socle Noe-062C doit déjà être présent et conforme. Cette activation ne crée
+que ``interventions_execution_inbox`` et ne modifie aucune table existante.
+"""
+from __future__ import unicode_literals
+
+import re
+
+from Data import DATA_Interventions_Actual_Inbox
+from Data import DATA_Structures
+
+
+TABLE_INBOX = DATA_Interventions_Actual_Inbox.TABLE_INBOX
+PREREQUIS = ("interventions", "lieux", "interventions_execution")
+
+
+def _description(nom_table):
+    if nom_table == TABLE_INBOX:
+        return tuple(DATA_Interventions_Actual_Inbox.DB_INTERVENTIONS_ACTUAL_INBOX[nom_table])
+    return tuple(DATA_Structures.DB_STRUCTURES[nom_table])
+
+
+def _chaine(valeur):
+    if isinstance(valeur, bytes):
+        return valeur.decode("ascii", "ignore")
+    return str(valeur)
+
+
+def _categorie_type(type_sql):
+    valeur = _chaine(type_sql or "").strip().lower()
+    base = valeur.split("(", 1)[0].strip()
+    if "int" in base:
+        return "integer"
+    if base in ("float", "real", "double", "decimal", "numeric"):
+        return "real"
+    if base in ("char", "varchar", "text", "tinytext", "mediumtext", "longtext"):
+        return "text"
+    if base in ("blob", "tinyblob", "mediumblob", "longblob"):
+        return "blob"
+    if base in ("date", "datetime", "timestamp"):
+        return "date"
+    return base
+
+
+def _type_attendu(type_decl, is_network):
+    type_decl = type_decl.upper().strip()
+    if not is_network:
+        if type_decl == "LONGBLOB":
+            return "BLOB"
+        if type_decl == "BIGINT":
+            return "INTEGER"
+        return type_decl
+    if type_decl == "INTEGER PRIMARY KEY AUTOINCREMENT":
+        return "INTEGER PRIMARY KEY AUTO_INCREMENT"
+    if type_decl == "FLOAT":
+        return "REAL"
+    if type_decl in ("DATE", "DATETIME"):
+        return "VARCHAR(10)" if type_decl == "DATE" else "DATETIME"
+    if type_decl.startswith("VARCHAR"):
+        match = re.search(r"\((\d+)\)", type_decl)
+        if match:
+            taille = int(match.group(1))
+            if taille > 20000:
+                return "MEDIUMTEXT"
+            if taille > 255:
+                return "TEXT(%d)" % taille
+    return type_decl
+
+
+def _metadata_table(db, nom_table):
+    is_network = bool(getattr(db, "isNetwork", False))
+    colonnes = {}
+    if not is_network:
+        if db.ExecuterReq("PRAGMA table_info('%s');" % nom_table) != 1:
+            return None
+        for cid, nom, type_sql, notnull, valeur_defaut, pk in db.ResultatReq():
+            colonnes[_chaine(nom)] = {
+                "type": type_sql,
+                "pk": bool(pk),
+                "auto": bool(pk) and _categorie_type(type_sql) == "integer",
+            }
+    else:
+        if db.ExecuterReq("SHOW COLUMNS FROM %s;" % nom_table) != 1:
+            return None
+        for valeurs in db.ResultatReq():
+            colonnes[_chaine(valeurs[0])] = {
+                "type": valeurs[1],
+                "pk": _chaine(valeurs[3] if len(valeurs) > 3 else "").upper() == "PRI",
+                "auto": "auto_increment" in _chaine(valeurs[5] if len(valeurs) > 5 else "").lower(),
+            }
+    return colonnes
+
+
+def _inspecter_table(db, nom_table):
+    existe = bool(db.IsTableExists(nom_table))
+    description = _description(nom_table)
+    attendus = tuple(champ[0] for champ in description)
+    rapport = {
+        "existe": existe,
+        "champs_attendus": attendus,
+        "champs_presents": (),
+        "champs_manquants": attendus,
+        "champs_incompatibles": (),
+        "conforme": False,
+    }
+    if not existe:
+        return rapport
+    metadata = _metadata_table(db, nom_table)
+    if metadata is None:
+        return rapport
+    rapport["champs_presents"] = tuple(metadata.keys())
+    rapport["champs_manquants"] = tuple(champ for champ in attendus if champ not in metadata)
+    incompatibles = []
+    is_network = bool(getattr(db, "isNetwork", False))
+    for nom, type_decl, info in description:
+        if nom not in metadata:
+            continue
+        attendu = _type_attendu(type_decl, is_network)
+        present = metadata[nom]
+        if _categorie_type(attendu) != _categorie_type(present["type"]):
+            incompatibles.append(nom)
+        elif "PRIMARY KEY" in attendu and not present["pk"]:
+            incompatibles.append(nom)
+        elif "AUTO_INCREMENT" in attendu and not present["auto"]:
+            incompatibles.append(nom)
+    rapport["champs_incompatibles"] = tuple(incompatibles)
+    rapport["conforme"] = not rapport["champs_manquants"] and not rapport["champs_incompatibles"]
+    return rapport
+
+
+def InspecterSchemaInboxRealise(db):
+    noms = PREREQUIS + (TABLE_INBOX,)
+    return dict((nom, _inspecter_table(db, nom)) for nom in noms)
+
+
+def AssurerSchemaInboxRealise(db, appliquer=False):
+    """Crée uniquement l'inbox après préflight complet du socle Noe-062C."""
+    avant = InspecterSchemaInboxRealise(db)
+    prerequis_absents = tuple(nom for nom in PREREQUIS if not avant[nom]["existe"])
+    incoherentes = tuple(
+        nom for nom, rapport in avant.items()
+        if rapport["existe"] and not rapport["conforme"]
+    )
+    if prerequis_absents or incoherentes:
+        return {
+            "ok": False,
+            "appliquer": bool(appliquer),
+            "tables_creees": (),
+            "prerequis_absents": prerequis_absents,
+            "tables_incoherentes": incoherentes,
+            "rapport": avant,
+        }
+    creees = []
+    if appliquer and not avant[TABLE_INBOX]["existe"]:
+        db.CreationTable(
+            TABLE_INBOX,
+            DATA_Interventions_Actual_Inbox.DB_INTERVENTIONS_ACTUAL_INBOX,
+        )
+        db.Commit()
+        creees.append(TABLE_INBOX)
+    apres = InspecterSchemaInboxRealise(db)
+    return {
+        "ok": all(apres[nom]["conforme"] for nom in PREREQUIS) and (
+            apres[TABLE_INBOX]["conforme"] if appliquer else True
+        ),
+        "appliquer": bool(appliquer),
+        "tables_creees": tuple(creees),
+        "prerequis_absents": (),
+        "tables_incoherentes": tuple(
+            nom for nom, rapport in apres.items()
+            if rapport["existe"] and not rapport["conforme"]
+        ),
+        "rapport": apres,
+    }

--- a/noethys/Utils/UTILS_Interventions_Execution.py
+++ b/noethys/Utils/UTILS_Interventions_Execution.py
@@ -3,8 +3,8 @@
 """Extension opérationnelle 1:1 des séances Noe-062C.
 
 La séance canonique reste dans ``interventions``. Ce module ne duplique ni le
-référentiel RH (Teamworks reste source de vérité), ni les lieux : il conserve
-uniquement leurs UID/IDs de référence et les écarts entre prévu et réalisé.
+référentiel RH, ni les lieux : il conserve uniquement leurs UID/IDs de
+référence et les écarts entre prévu et réalisé.
 """
 from __future__ import unicode_literals
 
@@ -96,8 +96,13 @@ class GestionnaireExecutionInterventions(object):
             raise RuntimeError("Plusieurs exécutions existent pour une même séance canonique")
         return dict(zip(("IDexecution_intervention",) + CHAMPS_EXECUTION, lignes[0]))
 
-    def EnregistrerExecution(self, IDintervention, donnees, date=None):
-        """Crée ou met à jour l'unique extension opérationnelle d'une séance."""
+    def EnregistrerExecution(self, IDintervention, donnees, date=None, commit=True):
+        """Crée ou met à jour l'unique extension opérationnelle d'une séance.
+
+        ``commit`` vaut ``True`` par défaut pour préserver le comportement
+        historique. Les orchestrateurs multi-écritures peuvent demander
+        ``commit=False`` puis gérer eux-mêmes commit/rollback atomique.
+        """
         self._verifier_intervention(IDintervention)
         donnees = dict(donnees or {})
         if not donnees:
@@ -142,12 +147,17 @@ class GestionnaireExecutionInterventions(object):
         )
 
         if courant is None:
-            return self.db.ReqInsert("interventions_execution", _liste_pairs(valeurs))
+            return self.db.ReqInsert(
+                "interventions_execution",
+                _liste_pairs(valeurs),
+                commit=bool(commit),
+            )
         self.db.ReqMAJ(
             "interventions_execution",
             _liste_pairs(valeurs),
             "IDexecution_intervention",
             int(courant["IDexecution_intervention"]),
+            commit=bool(commit),
         )
         return courant["IDexecution_intervention"]
 

--- a/tests/test_noe_062_session_actual_inbox.py
+++ b/tests/test_noe_062_session_actual_inbox.py
@@ -1,0 +1,396 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import sqlite3
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOETHYS = ROOT / "noethys"
+if str(NOETHYS) not in sys.path:
+    sys.path.insert(0, str(NOETHYS))
+
+
+def _charger_module(path, nom):
+    spec = importlib.util.spec_from_file_location(nom, str(ROOT / path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+SCHEMA_C = _charger_module("noethys/Utils/UTILS_Tiers_Schema062C.py", "UTILS_Tiers_Schema_noe062_inbox")
+SCHEMA_INBOX = _charger_module("noethys/Utils/UTILS_Interventions_Actual_Inbox_Schema.py", "UTILS_Inbox_Schema_noe062")
+INBOX = _charger_module("noethys/Utils/UTILS_Interventions_Actual_Inbox.py", "UTILS_Inbox_noe062")
+LIEUX = _charger_module("noethys/Utils/UTILS_Lieux.py", "UTILS_Lieux_noe062_inbox")
+EXECUTION = _charger_module("noethys/Utils/UTILS_Interventions_Execution.py", "UTILS_Execution_noe062_inbox")
+
+
+SESSION_UID = "INT-INBOX-SESSION-001"
+ACTUAL_UUID = "actual-33333333-3333-3333-3333-333333333333"
+
+
+class SQLiteDB(object):
+    isNetwork = False
+
+    def __init__(self):
+        self.connexion = sqlite3.connect(":memory:")
+        self.cursor = self.connexion.cursor()
+        self.creations = []
+        self.commits = 0
+        self.rollbacks = 0
+        self.fail_intervention_update = False
+
+    def Close(self):
+        self.connexion.close()
+
+    def IsTableExists(self, nom_table):
+        self.cursor.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (nom_table,))
+        return self.cursor.fetchone() is not None
+
+    def ExecuterReq(self, req):
+        try:
+            self.cursor.execute(req)
+            return 1
+        except Exception:
+            return 0
+
+    def ResultatReq(self):
+        return self.cursor.fetchall()
+
+    def CreationTable(self, nom_table, dico):
+        champs = []
+        for nom, type_champ, info in dico[nom_table]:
+            if type_champ == "LONGBLOB":
+                type_champ = "BLOB"
+            if type_champ == "BIGINT":
+                type_champ = "INTEGER"
+            champs.append("%s %s" % (nom, type_champ))
+        self.cursor.execute("CREATE TABLE %s (%s)" % (nom_table, ", ".join(champs)))
+        self.creations.append(nom_table)
+
+    def Commit(self):
+        self.connexion.commit()
+        self.commits += 1
+
+    def Rollback(self):
+        self.connexion.rollback()
+        self.rollbacks += 1
+
+    def ReqInsert(self, nom_table, liste_donnees, commit=True):
+        noms = [nom for nom, valeur in liste_donnees]
+        valeurs = [valeur for nom, valeur in liste_donnees]
+        marqueurs = ", ".join("?" for nom in noms)
+        self.cursor.execute(
+            "INSERT INTO %s (%s) VALUES (%s)" % (nom_table, ", ".join(noms), marqueurs),
+            tuple(valeurs),
+        )
+        if commit:
+            self.connexion.commit()
+        return self.cursor.lastrowid
+
+    def ReqMAJ(self, nom_table, liste_donnees, nom_champ_id, ID, IDestChaine=False, commit=True):
+        if self.fail_intervention_update and nom_table == "interventions":
+            raise RuntimeError("échec simulé de mise à jour séance")
+        clauses = ["%s=?" % nom for nom, valeur in liste_donnees]
+        valeurs = [valeur for nom, valeur in liste_donnees]
+        valeurs.append(ID)
+        self.cursor.execute(
+            "UPDATE %s SET %s WHERE %s=?" % (nom_table, ", ".join(clauses), nom_champ_id),
+            tuple(valeurs),
+        )
+        if commit:
+            self.connexion.commit()
+        return True
+
+
+def _db_pret():
+    db = SQLiteDB()
+    resultat = SCHEMA_C.AssurerSchema062C(db, appliquer=True)
+    assert resultat["ok"] is True
+    resultat_inbox = SCHEMA_INBOX.AssurerSchemaInboxRealise(db, appliquer=True)
+    assert resultat_inbox["ok"] is True
+    db.ReqInsert("interventions", [
+        ("uid", SESSION_UID),
+        ("nature", "sport"),
+        ("date", "2026-09-04"),
+        ("heure_debut", "09:00"),
+        ("heure_fin", "10:30"),
+        ("duree_minutes", 90),
+        ("libelle", "EPS - cycle athlétisme"),
+        ("statut", "planifiee"),
+        ("notes", ""),
+        ("actif", 1),
+        ("date_creation", "2026-09-01"),
+        ("date_modification", "2026-09-01"),
+    ])
+    return db
+
+
+def payload_realise(revision=4, **overrides):
+    donnees = {
+        "contract_version": "session-actual/1",
+        "event_type": "session_actual_validated",
+        "actual_uuid": ACTUAL_UUID,
+        "actual_revision": revision,
+        "session_uid": SESSION_UID,
+        "session_status": "realisee",
+        "assignment_date": "2026-09-04",
+        "validated_at": "2026-09-04T10:45:00+00:00",
+        "actual_staff_uid": "EMP-11111111-1111-1111-1111-111111111111",
+        "actual_place_uid": None,
+        "actual_start_time": "09:05",
+        "actual_end_time": "10:35",
+        "actual_duration_minutes": 90,
+        "actual_comment": "RAS",
+    }
+    donnees.update(overrides)
+    return donnees
+
+
+def payload_annule(revision=5, **overrides):
+    donnees = {
+        "contract_version": "session-actual/1",
+        "event_type": "session_actual_validated",
+        "actual_uuid": ACTUAL_UUID,
+        "actual_revision": revision,
+        "session_uid": SESSION_UID,
+        "session_status": "annulee",
+        "assignment_date": "2026-09-04",
+        "validated_at": "2026-09-04T10:50:00+00:00",
+        "actual_staff_uid": None,
+        "actual_place_uid": None,
+        "actual_start_time": None,
+        "actual_end_time": None,
+        "actual_duration_minutes": None,
+        "actual_comment": "Séance annulée par l'établissement",
+    }
+    donnees.update(overrides)
+    return donnees
+
+
+class Noe062SessionActualInboxTests(unittest.TestCase):
+
+    def test_schema_inbox_est_additif_explicite_et_idempotent(self):
+        db = SQLiteDB()
+        try:
+            resultat_sans_socle = SCHEMA_INBOX.AssurerSchemaInboxRealise(db, appliquer=True)
+            self.assertFalse(resultat_sans_socle["ok"])
+            self.assertIn("interventions", resultat_sans_socle["prerequis_absents"])
+            self.assertFalse(db.IsTableExists("interventions_execution_inbox"))
+
+            self.assertTrue(SCHEMA_C.AssurerSchema062C(db, appliquer=True)["ok"])
+            resultat = SCHEMA_INBOX.AssurerSchemaInboxRealise(db, appliquer=True)
+            self.assertTrue(resultat["ok"])
+            self.assertEqual(("interventions_execution_inbox",), resultat["tables_creees"])
+            creations = list(db.creations)
+            resultat2 = SCHEMA_INBOX.AssurerSchemaInboxRealise(db, appliquer=True)
+            self.assertTrue(resultat2["ok"])
+            self.assertEqual((), resultat2["tables_creees"])
+            self.assertEqual(creations, db.creations)
+        finally:
+            db.Close()
+
+    def test_realise_met_a_jour_la_meme_seance_sans_en_creer(self):
+        db = _db_pret()
+        try:
+            lieux = LIEUX.GestionnaireLieux(db)
+            IDlieu = lieux.CreerLieu({"uid": "LIEU-GYMNASE-001", "nom": "Gymnase A", "type_lieu": "gymnase"})
+            message = payload_realise(actual_place_uid="LIEU-GYMNASE-001")
+            resultat = INBOX.GestionnaireInboxRealise(db).AppliquerMessage(
+                message,
+                "session-actual:%s:r4:activity_users" % ACTUAL_UUID,
+                date_reception="2026-09-04 10:46:00",
+            )
+            self.assertTrue(resultat["applique"])
+            db.cursor.execute("SELECT COUNT(*) FROM interventions")
+            self.assertEqual(1, db.cursor.fetchone()[0])
+            db.cursor.execute("SELECT statut FROM interventions WHERE uid=?", (SESSION_UID,))
+            self.assertEqual("realisee", db.cursor.fetchone()[0])
+            db.cursor.execute("SELECT COUNT(*) FROM interventions_execution_inbox")
+            self.assertEqual(1, db.cursor.fetchone()[0])
+            execution = EXECUTION.GestionnaireExecutionInterventions(db).LireExecution(resultat["IDintervention"])
+            self.assertEqual("EMP-11111111-1111-1111-1111-111111111111", execution["UIDintervenant_reel"])
+            self.assertEqual(IDlieu, execution["IDlieu_reel"])
+            self.assertEqual("09:05", execution["heure_debut_reelle"])
+            self.assertEqual("10:35", execution["heure_fin_reelle"])
+            self.assertEqual(90, execution["duree_reelle_minutes"])
+        finally:
+            db.Close()
+
+    def test_rejeu_exact_est_un_noop(self):
+        db = _db_pret()
+        try:
+            service = INBOX.GestionnaireInboxRealise(db)
+            cle = "session-actual:%s:r4:activity_users" % ACTUAL_UUID
+            premier = service.AppliquerMessage(payload_realise(), cle, date_reception="2026-09-04 10:46:00")
+            second = service.AppliquerMessage(payload_realise(), cle, date_reception="2026-09-04 10:47:00")
+            self.assertTrue(premier["applique"])
+            self.assertTrue(second["replay"])
+            self.assertFalse(second["applique"])
+            db.cursor.execute("SELECT COUNT(*) FROM interventions_execution_inbox")
+            self.assertEqual(1, db.cursor.fetchone()[0])
+            db.cursor.execute("SELECT COUNT(*) FROM interventions_execution")
+            self.assertEqual(1, db.cursor.fetchone()[0])
+        finally:
+            db.Close()
+
+    def test_meme_cle_avec_payload_different_est_un_conflit(self):
+        db = _db_pret()
+        try:
+            service = INBOX.GestionnaireInboxRealise(db)
+            cle = "session-actual:%s:r4:activity_users" % ACTUAL_UUID
+            service.AppliquerMessage(payload_realise(), cle, date_reception="2026-09-04 10:46:00")
+            with self.assertRaisesRegex(INBOX.ActualInboxError, "payload différent"):
+                service.AppliquerMessage(
+                    payload_realise(actual_comment="payload divergent"),
+                    cle,
+                    date_reception="2026-09-04 10:47:00",
+                )
+        finally:
+            db.Close()
+
+    def test_meme_revision_avec_autre_payload_est_un_conflit(self):
+        db = _db_pret()
+        try:
+            service = INBOX.GestionnaireInboxRealise(db)
+            service.AppliquerMessage(
+                payload_realise(), "message-A", date_reception="2026-09-04 10:46:00"
+            )
+            with self.assertRaisesRegex(INBOX.ActualInboxError, "même révision"):
+                service.AppliquerMessage(
+                    payload_realise(actual_comment="divergent"),
+                    "message-B",
+                    date_reception="2026-09-04 10:47:00",
+                )
+            db.cursor.execute("SELECT COUNT(*) FROM interventions_execution_inbox")
+            self.assertEqual(1, db.cursor.fetchone()[0])
+        finally:
+            db.Close()
+
+    def test_revision_plus_ancienne_est_refusee(self):
+        db = _db_pret()
+        try:
+            service = INBOX.GestionnaireInboxRealise(db)
+            service.AppliquerMessage(
+                payload_realise(revision=5), "message-r5", date_reception="2026-09-04 10:46:00"
+            )
+            with self.assertRaisesRegex(INBOX.ActualInboxError, "obsolète"):
+                service.AppliquerMessage(
+                    payload_realise(revision=4), "message-r4", date_reception="2026-09-04 10:47:00"
+                )
+        finally:
+            db.Close()
+
+    def test_revision_suivante_annulee_efface_tout_le_reel(self):
+        db = _db_pret()
+        try:
+            service = INBOX.GestionnaireInboxRealise(db)
+            lieux = LIEUX.GestionnaireLieux(db)
+            lieux.CreerLieu({"uid": "LIEU-GYMNASE-001", "nom": "Gymnase A", "type_lieu": "gymnase"})
+            service.AppliquerMessage(
+                payload_realise(revision=4, actual_place_uid="LIEU-GYMNASE-001"),
+                "message-r4",
+                date_reception="2026-09-04 10:46:00",
+            )
+            service.AppliquerMessage(
+                payload_annule(revision=5),
+                "message-r5",
+                date_reception="2026-09-04 10:51:00",
+            )
+            db.cursor.execute("SELECT IDintervention, statut FROM interventions WHERE uid=?", (SESSION_UID,))
+            IDintervention, statut = db.cursor.fetchone()
+            self.assertEqual("annulee", statut)
+            execution = EXECUTION.GestionnaireExecutionInterventions(db).LireExecution(IDintervention)
+            self.assertIsNone(execution["UIDintervenant_reel"])
+            self.assertIsNone(execution["IDlieu_reel"])
+            self.assertIsNone(execution["heure_debut_reelle"])
+            self.assertIsNone(execution["heure_fin_reelle"])
+            self.assertIsNone(execution["duree_reelle_minutes"])
+            self.assertEqual("Séance annulée par l'établissement", execution["commentaire_realise"])
+        finally:
+            db.Close()
+
+    def test_lieu_inconnu_refuse_avant_toute_ecriture(self):
+        db = _db_pret()
+        try:
+            with self.assertRaises((INBOX.ActualInboxError, ValueError)):
+                INBOX.GestionnaireInboxRealise(db).AppliquerMessage(
+                    payload_realise(actual_place_uid="LIEU-INCONNU"),
+                    "message-lieu-inconnu",
+                    date_reception="2026-09-04 10:46:00",
+                )
+            db.cursor.execute("SELECT statut FROM interventions WHERE uid=?", (SESSION_UID,))
+            self.assertEqual("planifiee", db.cursor.fetchone()[0])
+            db.cursor.execute("SELECT COUNT(*) FROM interventions_execution")
+            self.assertEqual(0, db.cursor.fetchone()[0])
+            db.cursor.execute("SELECT COUNT(*) FROM interventions_execution_inbox")
+            self.assertEqual(0, db.cursor.fetchone()[0])
+        finally:
+            db.Close()
+
+    def test_seance_absente_n_est_jamais_creee(self):
+        db = _db_pret()
+        try:
+            message = payload_realise(session_uid="INT-ABSENTE")
+            with self.assertRaisesRegex(INBOX.ActualInboxError, "aucune création implicite"):
+                INBOX.GestionnaireInboxRealise(db).AppliquerMessage(
+                    message, "message-absent", date_reception="2026-09-04 10:46:00"
+                )
+            db.cursor.execute("SELECT COUNT(*) FROM interventions")
+            self.assertEqual(1, db.cursor.fetchone()[0])
+            db.cursor.execute("SELECT COUNT(*) FROM interventions_execution_inbox")
+            self.assertEqual(0, db.cursor.fetchone()[0])
+        finally:
+            db.Close()
+
+    def test_duree_incoherente_est_refusee_avant_ecriture(self):
+        db = _db_pret()
+        try:
+            with self.assertRaisesRegex(INBOX.ActualInboxError, "durée réelle incohérente"):
+                INBOX.GestionnaireInboxRealise(db).AppliquerMessage(
+                    payload_realise(actual_duration_minutes=91),
+                    "message-duree",
+                    date_reception="2026-09-04 10:46:00",
+                )
+            db.cursor.execute("SELECT COUNT(*) FROM interventions_execution_inbox")
+            self.assertEqual(0, db.cursor.fetchone()[0])
+        finally:
+            db.Close()
+
+    def test_echec_apres_insertion_inbox_provoque_un_rollback_integral(self):
+        db = _db_pret()
+        try:
+            db.fail_intervention_update = True
+            with self.assertRaises(RuntimeError):
+                INBOX.GestionnaireInboxRealise(db).AppliquerMessage(
+                    payload_realise(), "message-rollback", date_reception="2026-09-04 10:46:00"
+                )
+            self.assertGreaterEqual(db.rollbacks, 1)
+            db.cursor.execute("SELECT COUNT(*) FROM interventions_execution_inbox")
+            self.assertEqual(0, db.cursor.fetchone()[0])
+            db.cursor.execute("SELECT COUNT(*) FROM interventions_execution")
+            self.assertEqual(0, db.cursor.fetchone()[0])
+            db.cursor.execute("SELECT statut FROM interventions WHERE uid=?", (SESSION_UID,))
+            self.assertEqual("planifiee", db.cursor.fetchone()[0])
+        finally:
+            db.Close()
+
+    def test_vocabulaire_de_domaine_est_independant_des_noms_de_produits(self):
+        db = _db_pret()
+        try:
+            service = INBOX.GestionnaireInboxRealise(db)
+            with self.assertRaisesRegex(INBOX.ActualInboxError, "domaine source"):
+                service.AppliquerMessage(
+                    payload_realise(), "message-produit", source_domain="portail",
+                    date_reception="2026-09-04 10:46:00",
+                )
+            self.assertEqual("operations_portal", INBOX.SOURCE_DOMAIN)
+            self.assertNotIn("noethys", INBOX.SOURCE_DOMAIN.lower())
+            self.assertNotIn("teamworks", INBOX.SOURCE_DOMAIN.lower())
+        finally:
+            db.Close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Objectif

Recevoir dans le domaine activité/usagers un réalisé validé émis par le domaine opérations, en mettant à jour **la séance canonique existante** par `session_uid`, sans créer de nouvelle séance ni de nouveau lieu.

## Contrat

- `contract_version = session-actual/1` ;
- `event_type = session_actual_validated` ;
- domaine source stable `operations_portal`, indépendant du nom d'affichage du produit ;
- UID canonique de séance obligatoire ;
- statuts acceptés : `realisee` / `annulee` ;
- date du message recontrôlée contre la séance canonique ;
- durée réelle recalculée avec le moteur Noethys et comparée au payload ;
- lieu réel résolu uniquement par UID canonique existant ;
- aucune inférence prévu → réel.

## Inbox idempotente

Nouvelle table additive `interventions_execution_inbox` :
- clé d'idempotence unique ;
- clé unique domaine + séance + révision ;
- `actual_uuid`, `session_uid`, révision, version de contrat, type d'événement ;
- SHA-256 du payload canonique ;
- horodatage de réception.

Règles :
- replay exact => no-op réussi ;
- même clé avec payload différent => conflit ;
- même révision avec payload différent => conflit ;
- révision plus ancienne => refus ;
- changement d'identité du réalisé pour la même séance => refus.

## Atomicité

`interventions`, `interventions_execution` et l'inbox sont mis à jour dans une seule transaction. `GestionnaireExecutionInterventions.EnregistrerExecution(..., commit=True)` conserve son comportement historique et accepte désormais `commit=False` pour l'orchestration atomique.

## Schéma

Activation explicite via `AssurerSchemaInboxRealise(..., appliquer=True)` :
- exige le socle Noe-062C déjà présent et conforme ;
- crée uniquement `interventions_execution_inbox` ;
- aucune modification des tables existantes ;
- aucun effet au simple import.

## Tests

Recette SQLite couvrant activation/idempotence, mise à jour de la même séance, replay, conflits de payload/révision, révision obsolète, annulation effaçant les champs réels, lieu inconnu, séance absente sans création, durée incohérente, rollback forcé et vocabulaire indépendant des noms de produits.