### PR TITLE
Noe-062E — verrouiller les modifications de programmation

### DIFF
--- a/noethys/Utils/UTILS_Programmations_Structures.py
+++ b/noethys/Utils/UTILS_Programmations_Structures.py
@@ -425,7 +425,7 @@ class GestionnaireProgrammationsStructures(object):
             if fin_relation and fin > fin_relation:
                 raise ValueError("La programmation se termine après la relation")
 
-    def _programmation_source_saison_existe(self, valeurs):
+    def _programmation_source_saison_existe(self, valeurs, IDprogrammation_exclue=None):
         conditions = [
             "type_source='%s'" % _sql_texte(valeurs["type_source"]),
             "saison='%s'" % _sql_texte(valeurs["saison"]),
@@ -439,6 +439,10 @@ class GestionnaireProgrammationsStructures(object):
                 conditions.append("IDgroupe_activite=%d" % int(valeurs["IDgroupe_activite"]))
             else:
                 conditions.append("IDgroupe_activite IS NULL")
+        if IDprogrammation_exclue:
+            conditions.append(
+                "IDprogrammation_structure<>%d" % int(IDprogrammation_exclue)
+            )
         req = "SELECT IDprogrammation_structure FROM structures_programmations WHERE %s;" % " AND ".join(conditions)
         if self.db.ExecuterReq(req) != 1:
             return False
@@ -478,6 +482,16 @@ class GestionnaireProgrammationsStructures(object):
         controle.update(changements)
         relation = self._source_existe(controle)
         self._verifier_periode_source(controle, relation=relation)
+        if self._programmation_source_saison_existe(
+            controle, IDprogrammation_exclue=IDprogrammation_structure
+        ):
+            raise ValueError("Une programmation active existe déjà pour cette source et cette saison")
+        for creneau in self.ListerCreneaux(
+            IDprogrammation_structure,
+            actifs_seulement=True,
+            conserves_seulement=True,
+        ):
+            self._verifier_creneau_dans_programmation(controle, creneau)
         return self.db.ReqMAJ(
             "structures_programmations",
             _liste_pairs(changements, CHAMPS_PROGRAMMATION),

--- a/tests/test_noe_062_programmations_modification_guards.py
+++ b/tests/test_noe_062_programmations_modification_guards.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _charger(path, nom):
+    spec = importlib.util.spec_from_file_location(nom, str(ROOT / path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+BASE = _charger(
+    "tests/test_noe_062_programmations_persistantes.py",
+    "test_noe_062_programmations_persistantes_base_modification_guards",
+)
+PROG = BASE.PROG
+
+
+def _creer_programme_meme_source(gestion, IDrelation, uid, saison):
+    return gestion.CreerProgrammation(
+        {
+            "uid": uid,
+            "type_source": "relation",
+            "IDrelation_structure": IDrelation,
+            "saison": saison,
+            "libelle": "Programme parallèle",
+            "date_debut": "2026-09-01",
+            "date_fin": "2027-08-31",
+        },
+        date="2026-09-01",
+    )
+
+
+def test_modifier_saison_refuse_collision_avec_autre_programmation_active():
+    db, gestion, IDrelation = BASE._preparer_relation_programmable()
+    IDpremier = BASE._creer_programme_relation(gestion, IDrelation)
+    IDsecond = _creer_programme_meme_source(
+        gestion,
+        IDrelation,
+        uid="PROG-2027-002",
+        saison="2027-2028",
+    )
+
+    try:
+        gestion.ModifierProgrammation(
+            IDpremier,
+            {"saison": "2027-2028"},
+            date="2026-09-02",
+        )
+        assert False, "collision source/saison acceptée pendant la modification"
+    except ValueError as err:
+        assert "existe déjà" in str(err)
+
+    assert gestion.LireProgrammation(IDpremier)["saison"] == "2026-2027"
+    assert gestion.LireProgrammation(IDsecond)["saison"] == "2027-2028"
+
+
+def test_modifier_programmation_ignore_sa_propre_ligne_dans_controle_unicite():
+    db, gestion, IDrelation = BASE._preparer_relation_programmable()
+    IDprog = BASE._creer_programme_relation(gestion, IDrelation)
+
+    assert gestion.ModifierProgrammation(
+        IDprog,
+        {"saison": "2026-2027", "libelle": "Programme renommé"},
+        date="2026-09-02",
+    ) is True
+    programme = gestion.LireProgrammation(IDprog)
+    assert programme["saison"] == "2026-2027"
+    assert programme["libelle"] == "Programme renommé"
+
+
+def test_reduire_periode_refuse_de_laisser_un_creneau_actif_hors_bornes():
+    db, gestion, IDrelation = BASE._preparer_relation_programmable()
+    IDprog = BASE._creer_programme_relation(gestion, IDrelation)
+    BASE._ajouter_lundi(
+        gestion,
+        IDprog,
+        uid="CREN-BORNE-MODIFICATION",
+        date_debut="2026-10-01",
+        date_fin="2027-03-31",
+    )
+
+    for changements, fragment in (
+        ({"date_debut": "2026-11-01"}, "débute avant"),
+        ({"date_fin": "2027-02-28"}, "se termine après"),
+    ):
+        try:
+            gestion.ModifierProgrammation(
+                IDprog,
+                changements,
+                date="2026-09-02",
+            )
+            assert False, "réduction incompatible avec un créneau actif acceptée"
+        except ValueError as err:
+            assert fragment in str(err)
+
+        programme = gestion.LireProgrammation(IDprog)
+        assert programme["date_debut"] == "2026-09-01"
+        assert programme["date_fin"] == "2027-08-31"
+
+
+def test_reduire_periode_reste_possible_si_tous_les_creneaux_restent_inclus():
+    db, gestion, IDrelation = BASE._preparer_relation_programmable()
+    IDprog = BASE._creer_programme_relation(gestion, IDrelation)
+    BASE._ajouter_lundi(
+        gestion,
+        IDprog,
+        uid="CREN-BORNE-INCLUS",
+        date_debut="2026-10-01",
+        date_fin="2027-03-31",
+    )
+
+    assert gestion.ModifierProgrammation(
+        IDprog,
+        {"date_debut": "2026-10-01", "date_fin": "2027-03-31"},
+        date="2026-09-02",
+    ) is True
+    programme = gestion.LireProgrammation(IDprog)
+    assert programme["date_debut"] == "2026-10-01"
+    assert programme["date_fin"] == "2027-03-31"


### PR DESCRIPTION
## Objet

Traite les deux garde-fous résiduels identifiés dans #317 sur le `master` courant, sans changement de schéma ni de moteur de récurrence.

## Corrections

- le contrôle d’unicité `source + saison` est désormais réexécuté lors d’une modification, en excluant explicitement la programmation courante ;
- une réduction de `date_debut` / `date_fin` est refusée si un créneau actif et conservé deviendrait partiellement ou totalement hors des nouvelles bornes ;
- les créneaux archivés ou marqués `supprime` ne bloquent pas la modification ;
- aucune écriture n’est faite avant la fin de ces précontrôles.

## Régressions ciblées

Nouveau test dédié couvrant :
- collision de saison entre deux programmations actives de la même source ;
- non-collision avec la programmation elle-même ;
- réduction impossible côté début et côté fin lorsqu’un créneau borné sortirait de la période ;
- réduction valide lorsque tous les créneaux restent inclus.

Branche créée directement depuis `master` `6a126dc50ac3ee175f06a1d25d10d7780b74589c`.

Fixes #317.