### PR TITLE
Windows — reconstruire l’installateur et préserver la configuration

### DIFF
--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -369,6 +369,65 @@ jobs:
             $env:LOCALAPPDATA = $savedLocalAppData
           }
 
+      - name: Collecter les diagnostics du smoke portable
+        if: failure()
+        shell: pwsh
+        run: |
+          $diag = Join-Path $PWD "artifacts/windows-portable-smoke-diagnostics"
+          $testRoot = Join-Path $env:RUNNER_TEMP "noethys-frozen-smoke"
+          $profileRoot = Join-Path $env:RUNNER_TEMP "noethys-frozen-profile"
+          New-Item -ItemType Directory -Path $diag -Force | Out-Null
+
+          @(
+            "GITHUB_SHA=$env:GITHUB_SHA"
+            "GITHUB_RUN_ID=$env:GITHUB_RUN_ID"
+            "RUNNER_TEMP=$env:RUNNER_TEMP"
+            "testRoot=$testRoot"
+            "profileRoot=$profileRoot"
+            "archive.exists=$(Test-Path 'Noethys-Windows-portable.zip')"
+            "exe.exists=$(Test-Path (Join-Path $testRoot 'Noethys.exe'))"
+            "portableMarker.exists=$(Test-Path (Join-Path $testRoot 'Portable/README.txt'))"
+            "errorMarker.exists=$(Test-Path (Join-Path $testRoot 'FROZEN-SMOKE-ERROR.txt'))"
+            "okMarker.exists=$(Test-Path (Join-Path $testRoot 'FROZEN-SMOKE-OK.txt'))"
+          ) | Set-Content -Path (Join-Path $diag "context.txt") -Encoding UTF8
+
+          foreach ($name in @("FROZEN-SMOKE-ERROR.txt", "FROZEN-SMOKE-OK.txt", "journal.log", "Config.json", "Config.json.bak")) {
+            $source = Join-Path $testRoot $name
+            if (Test-Path $source) {
+              Copy-Item $source (Join-Path $diag $name) -Force
+            }
+          }
+
+          if (Test-Path $testRoot) {
+            Get-ChildItem $testRoot -Force -ErrorAction SilentlyContinue |
+              Select-Object Name, Length, LastWriteTime |
+              Format-Table -AutoSize |
+              Out-String -Width 240 |
+              Set-Content -Path (Join-Path $diag "portable-root.txt") -Encoding UTF8
+          }
+          if (Test-Path $profileRoot) {
+            Get-ChildItem $profileRoot -Force -Recurse -ErrorAction SilentlyContinue |
+              Select-Object FullName, Length, LastWriteTime |
+              Format-Table -AutoSize |
+              Out-String -Width 240 |
+              Set-Content -Path (Join-Path $diag "profile-tree.txt") -Encoding UTF8
+          }
+
+          Get-Content (Join-Path $diag "context.txt")
+          if (Test-Path (Join-Path $diag "FROZEN-SMOKE-ERROR.txt")) {
+            Write-Host "--- FROZEN-SMOKE-ERROR.txt ---"
+            Get-Content (Join-Path $diag "FROZEN-SMOKE-ERROR.txt")
+          }
+
+      - name: Publier les diagnostics du smoke portable
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-portable-smoke-diagnostics
+          path: artifacts/windows-portable-smoke-diagnostics
+          if-no-files-found: error
+          retention-days: 14
+
       - uses: actions/upload-artifact@v7
         with:
           name: Noethys-Windows-installer

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -124,54 +124,55 @@ jobs:
         run: |
           $setup = (Resolve-Path "installer-output/Noethys-Upgrade-Setup.exe").Path
           $installRoot = Join-Path $env:RUNNER_TEMP "noethys-installed"
-          $profileRoot = Join-Path $env:RUNNER_TEMP "noethys-installed-profile"
           $workRoot = Join-Path $env:RUNNER_TEMP "noethys-foreign-cwd"
-          Remove-Item $installRoot -Recurse -Force -ErrorAction SilentlyContinue
-          Remove-Item $profileRoot -Recurse -Force -ErrorAction SilentlyContinue
-          Remove-Item $workRoot -Recurse -Force -ErrorAction SilentlyContinue
-          New-Item -ItemType Directory -Path $installRoot -Force | Out-Null
-          New-Item -ItemType Directory -Path $profileRoot -Force | Out-Null
-          New-Item -ItemType Directory -Path $workRoot -Force | Out-Null
-
-          $roaming = Join-Path $profileRoot "Roaming"
-          $local = Join-Path $profileRoot "Local"
-          $configDir = Join-Path $roaming "noethys"
-          New-Item -ItemType Directory -Path $configDir -Force | Out-Null
-          New-Item -ItemType Directory -Path $local -Force | Out-Null
+          $roaming = [Environment]::GetFolderPath([Environment+SpecialFolder]::ApplicationData)
+          if (-not $roaming) {
+            throw "Impossible de résoudre le dossier AppData itinérant Windows"
+          }
+          $configDir = Join-Path $roaming "Noethys"
           $config = Join-Path $configDir "Config.json"
           $trap = Join-Path $workRoot "Config.json"
-          '{"nomFichier":"SENTINEL_EXISTANT","derniersFichiers":[],"interface_mysql":"mysqldb","pool_mysql":5}' | Set-Content -Path $config -Encoding UTF8
-          '{"nomFichier":"NE_DOIT_JAMAIS_ETRE_MIGRE"}' | Set-Content -Path $trap -Encoding UTF8
-          $configHashBefore = (Get-FileHash $config -Algorithm SHA256).Hash
-          $trapHashBefore = (Get-FileHash $trap -Algorithm SHA256).Hash
 
-          $installer = Start-Process -FilePath $setup -ArgumentList @(
-            '/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', "/DIR=$installRoot"
-          ) -PassThru -Wait
-          if ($installer.ExitCode -ne 0) {
-            throw "Installation silencieuse en échec (code $($installer.ExitCode))"
-          }
+          Remove-Item $installRoot -Recurse -Force -ErrorAction SilentlyContinue
+          Remove-Item $workRoot -Recurse -Force -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Path $installRoot -Force | Out-Null
+          New-Item -ItemType Directory -Path $workRoot -Force | Out-Null
+          New-Item -ItemType Directory -Path $configDir -Force | Out-Null
 
-          $exe = Join-Path $installRoot "Noethys.exe"
-          if (-not (Test-Path $exe)) {
-            throw "Noethys.exe absent après installation"
-          }
-          if (Test-Path (Join-Path $installRoot "Portable")) {
-            throw "L'installateur a créé un mode Portable : la configuration existante serait ignorée"
+          $hadConfig = Test-Path $config
+          $originalConfig = $null
+          if ($hadConfig) {
+            $originalConfig = [IO.File]::ReadAllBytes($config)
           }
 
           $savedPath = $env:PATH
           $savedPythonHome = $env:PYTHONHOME
           $savedPythonPath = $env:PYTHONPATH
-          $savedAppData = $env:APPDATA
-          $savedLocalAppData = $env:LOCALAPPDATA
           try {
+            '{"nomFichier":"SENTINEL_EXISTANT","derniersFichiers":[],"interface_mysql":"mysqldb","pool_mysql":5}' | Set-Content -Path $config -Encoding UTF8
+            '{"nomFichier":"NE_DOIT_JAMAIS_ETRE_MIGRE"}' | Set-Content -Path $trap -Encoding UTF8
+            $configHashBefore = (Get-FileHash $config -Algorithm SHA256).Hash
+            $trapHashBefore = (Get-FileHash $trap -Algorithm SHA256).Hash
+
+            $installer = Start-Process -FilePath $setup -ArgumentList @(
+              '/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', "/DIR=$installRoot"
+            ) -PassThru -Wait
+            if ($installer.ExitCode -ne 0) {
+              throw "Installation silencieuse en échec (code $($installer.ExitCode))"
+            }
+
+            $exe = Join-Path $installRoot "Noethys.exe"
+            if (-not (Test-Path $exe)) {
+              throw "Noethys.exe absent après installation"
+            }
+            if (Test-Path (Join-Path $installRoot "Portable")) {
+              throw "L'installateur a créé un mode Portable : la configuration existante serait ignorée"
+            }
+
             $env:NOETHYS_INSTALL_CONFIG_SMOKE = "1"
             $env:NOETHYS_EXPECT_CONFIG_PATH = $config
             $env:PYTHONHOME = ""
             $env:PYTHONPATH = ""
-            $env:APPDATA = $roaming
-            $env:LOCALAPPDATA = $local
             $env:PATH = "$env:SystemRoot\System32;$env:SystemRoot"
 
             $process = Start-Process -FilePath $exe -WorkingDirectory $workRoot -PassThru
@@ -190,6 +191,15 @@ jobs:
               throw "Le smoke installable a quitté sans produire son marqueur de validation"
             }
             Get-Content $okMarker
+
+            $configHashAfter = (Get-FileHash $config -Algorithm SHA256).Hash
+            $trapHashAfter = (Get-FileHash $trap -Algorithm SHA256).Hash
+            if ($configHashAfter -ne $configHashBefore) {
+              throw "Config.json existant a été modifié par l'installation ou le démarrage"
+            }
+            if ($trapHashAfter -ne $trapHashBefore) {
+              throw "Un Config.json du répertoire courant a été déplacé ou modifié"
+            }
           }
           finally {
             Remove-Item Env:NOETHYS_INSTALL_CONFIG_SMOKE -ErrorAction SilentlyContinue
@@ -197,17 +207,12 @@ jobs:
             $env:PATH = $savedPath
             $env:PYTHONHOME = $savedPythonHome
             $env:PYTHONPATH = $savedPythonPath
-            $env:APPDATA = $savedAppData
-            $env:LOCALAPPDATA = $savedLocalAppData
-          }
-
-          $configHashAfter = (Get-FileHash $config -Algorithm SHA256).Hash
-          $trapHashAfter = (Get-FileHash $trap -Algorithm SHA256).Hash
-          if ($configHashAfter -ne $configHashBefore) {
-            throw "Config.json existant a été modifié par l'installation ou le démarrage"
-          }
-          if ($trapHashAfter -ne $trapHashBefore) {
-            throw "Un Config.json du répertoire courant a été déplacé ou modifié"
+            if ($hadConfig) {
+              [IO.File]::WriteAllBytes($config, $originalConfig)
+            }
+            elseif (Test-Path $config) {
+              Remove-Item $config -Force
+            }
           }
 
       - name: Collecter les diagnostics du smoke installable
@@ -216,9 +221,8 @@ jobs:
         run: |
           $diag = Join-Path $PWD "artifacts/windows-install-smoke-diagnostics"
           $installRoot = Join-Path $env:RUNNER_TEMP "noethys-installed"
-          $profileRoot = Join-Path $env:RUNNER_TEMP "noethys-installed-profile"
           $workRoot = Join-Path $env:RUNNER_TEMP "noethys-foreign-cwd"
-          $roaming = Join-Path $profileRoot "Roaming"
+          $roaming = [Environment]::GetFolderPath([Environment+SpecialFolder]::ApplicationData)
           New-Item -ItemType Directory -Path $diag -Force | Out-Null
 
           @(
@@ -226,11 +230,9 @@ jobs:
             "GITHUB_RUN_ID=$env:GITHUB_RUN_ID"
             "RUNNER_TEMP=$env:RUNNER_TEMP"
             "installRoot=$installRoot"
-            "profileRoot=$profileRoot"
             "workRoot=$workRoot"
             "roaming=$roaming"
             "installRoot.exists=$(Test-Path $installRoot)"
-            "profileRoot.exists=$(Test-Path $profileRoot)"
             "workRoot.exists=$(Test-Path $workRoot)"
             "exe.exists=$(Test-Path (Join-Path $installRoot 'Noethys.exe'))"
             "errorMarker.exists=$(Test-Path (Join-Path $installRoot 'INSTALL-CONFIG-SMOKE-ERROR.txt'))"
@@ -240,8 +242,8 @@ jobs:
           $copies = @{
             "INSTALL-CONFIG-SMOKE-ERROR.txt" = (Join-Path $installRoot "INSTALL-CONFIG-SMOKE-ERROR.txt")
             "INSTALL-CONFIG-SMOKE-OK.txt" = (Join-Path $installRoot "INSTALL-CONFIG-SMOKE-OK.txt")
-            "profile-Config.json" = (Join-Path $roaming "noethys/Config.json")
-            "profile-journal.log" = (Join-Path $roaming "noethys/journal.log")
+            "profile-Config.json" = (Join-Path $roaming "Noethys/Config.json")
+            "profile-journal.log" = (Join-Path $roaming "Noethys/journal.log")
             "foreign-cwd-Config.json" = (Join-Path $workRoot "Config.json")
           }
           foreach ($name in $copies.Keys) {
@@ -253,7 +255,7 @@ jobs:
 
           foreach ($entry in @(
             @{ Name = "install-root.txt"; Path = $installRoot; Recurse = $false },
-            @{ Name = "profile-tree.txt"; Path = $profileRoot; Recurse = $true },
+            @{ Name = "profile-tree.txt"; Path = (Join-Path $roaming "Noethys"); Recurse = $true },
             @{ Name = "foreign-cwd.txt"; Path = $workRoot; Recurse = $true }
           )) {
             if (Test-Path $entry.Path) {

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -1,18 +1,26 @@
 name: Package Windows
 
-# Workflow réutilisable uniquement. La porte d'entrée humaine et automatique
-# est désormais ci.yml afin d'éviter les demandes concurrentes dans Actions.
+# Workflow réutilisable pour la qualification complète. Les PR qui touchent
+# directement au packaging ou à la migration de configuration déclenchent aussi
+# ce job : ce sont précisément les changements pour lesquels un vrai artefact
+# Windows est nécessaire avant fusion.
 on:
   workflow_call:
+  pull_request:
+    paths:
+      - 'noethys/Utils/UTILS_Fichiers.py'
+      - 'packaging/**'
+      - 'tests/test_noe_041_portable_paths.py'
+      - '.github/workflows/windows-package.yml'
 
 permissions:
   contents: read
 
 jobs:
   package:
-    name: Construire et exécuter Noethys portable
+    name: Construire et tester Noethys portable + installateur
     runs-on: windows-latest
-    timeout-minutes: 45
+    timeout-minutes: 55
 
     steps:
       - uses: actions/checkout@v7
@@ -46,7 +54,7 @@ jobs:
       - name: Valider les ressources PyInstaller essentielles
         run: python scripts/smoke_packaged_resources.py
 
-      - name: Construire le dossier portable
+      - name: Construire le dossier PyInstaller
         run: pyinstaller --noconfirm --clean packaging/noethys.spec
 
       - name: Vérifier l'exécutable et le layout historique
@@ -66,25 +74,149 @@ jobs:
           }
           Get-ChildItem "dist/Noethys" -Recurse | Measure-Object | Format-List
 
+      - name: Écrire les informations de build communes
+        shell: pwsh
+        run: |
+          $pythonVersion = (python --version 2>&1)
+          @(
+            "Noethys Windows"
+            "Commit: $env:GITHUB_SHA"
+            "Python: $pythonVersion"
+            "Workflow run: $env:GITHUB_RUN_ID"
+            "Python 3 source fixes: applied before PyInstaller"
+            "Build UTC: $([DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ'))"
+          ) | Set-Content -Path "dist/Noethys/BUILD-INFO.txt" -Encoding UTF8
+
+      - name: Préparer le dossier installable sans mode Portable
+        shell: pwsh
+        run: |
+          Remove-Item "dist/Noethys-installable" -Recurse -Force -ErrorAction SilentlyContinue
+          Copy-Item "dist/Noethys" "dist/Noethys-installable" -Recurse
+          if (Test-Path "dist/Noethys-installable/Portable") {
+            throw "Le dossier installable ne doit jamais contenir le marqueur Portable"
+          }
+
+      - name: Installer Inno Setup si nécessaire
+        shell: pwsh
+        run: |
+          $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
+          if (-not (Test-Path $iscc)) {
+            choco install innosetup -y --no-progress
+          }
+          if (-not (Test-Path $iscc)) {
+            throw "ISCC.exe introuvable après installation d'Inno Setup"
+          }
+
+      - name: Construire l'installateur Windows
+        shell: pwsh
+        run: |
+          $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
+          $version = "1.3.4.2-upgrade.$env:GITHUB_RUN_NUMBER"
+          & $iscc "/DMyAppVersion=$version" "packaging/noethys-installer.iss"
+          if ($LASTEXITCODE -ne 0) {
+            throw "Inno Setup a échoué avec le code $LASTEXITCODE"
+          }
+          if (-not (Test-Path "installer-output/Noethys-Upgrade-Setup.exe")) {
+            throw "Installateur Noethys-Upgrade-Setup.exe absent"
+          }
+
+      - name: Tester une mise à niveau sans perdre la configuration
+        shell: pwsh
+        run: |
+          $setup = (Resolve-Path "installer-output/Noethys-Upgrade-Setup.exe").Path
+          $installRoot = Join-Path $env:RUNNER_TEMP "noethys-installed"
+          $profileRoot = Join-Path $env:RUNNER_TEMP "noethys-installed-profile"
+          $workRoot = Join-Path $env:RUNNER_TEMP "noethys-foreign-cwd"
+          Remove-Item $installRoot -Recurse -Force -ErrorAction SilentlyContinue
+          Remove-Item $profileRoot -Recurse -Force -ErrorAction SilentlyContinue
+          Remove-Item $workRoot -Recurse -Force -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Path $installRoot -Force | Out-Null
+          New-Item -ItemType Directory -Path $profileRoot -Force | Out-Null
+          New-Item -ItemType Directory -Path $workRoot -Force | Out-Null
+
+          $roaming = Join-Path $profileRoot "Roaming"
+          $local = Join-Path $profileRoot "Local"
+          $configDir = Join-Path $roaming "noethys"
+          New-Item -ItemType Directory -Path $configDir -Force | Out-Null
+          New-Item -ItemType Directory -Path $local -Force | Out-Null
+          $config = Join-Path $configDir "Config.json"
+          $trap = Join-Path $workRoot "Config.json"
+          '{"nomFichier":"SENTINEL_EXISTANT","derniersFichiers":[],"interface_mysql":"mysqldb","pool_mysql":5}' | Set-Content -Path $config -Encoding UTF8
+          '{"nomFichier":"NE_DOIT_JAMAIS_ETRE_MIGRE"}' | Set-Content -Path $trap -Encoding UTF8
+          $configHashBefore = (Get-FileHash $config -Algorithm SHA256).Hash
+          $trapHashBefore = (Get-FileHash $trap -Algorithm SHA256).Hash
+
+          $installer = Start-Process -FilePath $setup -ArgumentList @(
+            '/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', "/DIR=$installRoot"
+          ) -PassThru -Wait
+          if ($installer.ExitCode -ne 0) {
+            throw "Installation silencieuse en échec (code $($installer.ExitCode))"
+          }
+
+          $exe = Join-Path $installRoot "Noethys.exe"
+          if (-not (Test-Path $exe)) {
+            throw "Noethys.exe absent après installation"
+          }
+          if (Test-Path (Join-Path $installRoot "Portable")) {
+            throw "L'installateur a créé un mode Portable : la configuration existante serait ignorée"
+          }
+
+          $savedPath = $env:PATH
+          $savedPythonHome = $env:PYTHONHOME
+          $savedPythonPath = $env:PYTHONPATH
+          $savedAppData = $env:APPDATA
+          $savedLocalAppData = $env:LOCALAPPDATA
+          try {
+            $env:NOETHYS_INSTALL_CONFIG_SMOKE = "1"
+            $env:NOETHYS_EXPECT_CONFIG_PATH = $config
+            $env:PYTHONHOME = ""
+            $env:PYTHONPATH = ""
+            $env:APPDATA = $roaming
+            $env:LOCALAPPDATA = $local
+            $env:PATH = "$env:SystemRoot\System32;$env:SystemRoot"
+
+            $process = Start-Process -FilePath $exe -WorkingDirectory $workRoot -PassThru
+            if (-not $process.WaitForExit(30000)) {
+              $process.Kill()
+              throw "Le smoke de configuration installée n'a pas quitté sous 30 secondes"
+            }
+
+            $errorMarker = Join-Path $installRoot "INSTALL-CONFIG-SMOKE-ERROR.txt"
+            $okMarker = Join-Path $installRoot "INSTALL-CONFIG-SMOKE-OK.txt"
+            if ($process.ExitCode -ne 0) {
+              if (Test-Path $errorMarker) { Get-Content $errorMarker | Write-Error }
+              throw "Smoke de configuration installée en échec (code $($process.ExitCode))"
+            }
+            if (-not (Test-Path $okMarker)) {
+              throw "Le smoke installable a quitté sans produire son marqueur de validation"
+            }
+            Get-Content $okMarker
+          }
+          finally {
+            Remove-Item Env:NOETHYS_INSTALL_CONFIG_SMOKE -ErrorAction SilentlyContinue
+            Remove-Item Env:NOETHYS_EXPECT_CONFIG_PATH -ErrorAction SilentlyContinue
+            $env:PATH = $savedPath
+            $env:PYTHONHOME = $savedPythonHome
+            $env:PYTHONPATH = $savedPythonPath
+            $env:APPDATA = $savedAppData
+            $env:LOCALAPPDATA = $savedLocalAppData
+          }
+
+          $configHashAfter = (Get-FileHash $config -Algorithm SHA256).Hash
+          $trapHashAfter = (Get-FileHash $trap -Algorithm SHA256).Hash
+          if ($configHashAfter -ne $configHashBefore) {
+            throw "Config.json existant a été modifié par l'installation ou le démarrage"
+          }
+          if ($trapHashAfter -ne $trapHashBefore) {
+            throw "Un Config.json du répertoire courant a été déplacé ou modifié"
+          }
+
       - name: Activer l'isolation portable
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Path "dist/Noethys/Portable" -Force | Out-Null
           Copy-Item "packaging/portable/README.txt" "dist/Noethys/Portable/README.txt"
-
-      - name: Écrire les informations de build
-        shell: pwsh
-        run: |
-          $pythonVersion = (python --version 2>&1)
-          @(
-            "Noethys portable Windows"
-            "Commit: $env:GITHUB_SHA"
-            "Python: $pythonVersion"
-            "Workflow run: $env:GITHUB_RUN_ID"
-            "Portable mode: enabled (Portable/)"
-            "Python 3 source fixes: applied before PyInstaller"
-            "Build UTC: $([DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ'))"
-          ) | Set-Content -Path "dist/Noethys/BUILD-INFO.txt" -Encoding UTF8
+          Add-Content -Path "dist/Noethys/BUILD-INFO.txt" -Value "Portable mode: enabled (Portable/)"
 
       - name: Créer l'archive portable
         shell: pwsh
@@ -156,6 +288,13 @@ jobs:
             $env:APPDATA = $savedAppData
             $env:LOCALAPPDATA = $savedLocalAppData
           }
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: Noethys-Windows-installer
+          path: installer-output/Noethys-Upgrade-Setup.exe
+          if-no-files-found: error
+          retention-days: 14
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -111,8 +111,7 @@ jobs:
         shell: pwsh
         run: |
           $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
-          $version = "1.3.4.2-upgrade.$env:GITHUB_RUN_NUMBER"
-          & $iscc "/DMyAppVersion=$version" "packaging/noethys-installer.iss"
+          & $iscc "packaging/noethys-installer.iss"
           if ($LASTEXITCODE -ne 0) {
             throw "Inno Setup a échoué avec le code $LASTEXITCODE"
           }

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -210,6 +210,85 @@ jobs:
             throw "Un Config.json du répertoire courant a été déplacé ou modifié"
           }
 
+      - name: Collecter les diagnostics du smoke installable
+        if: failure()
+        shell: pwsh
+        run: |
+          $diag = Join-Path $PWD "artifacts/windows-install-smoke-diagnostics"
+          $installRoot = Join-Path $env:RUNNER_TEMP "noethys-installed"
+          $profileRoot = Join-Path $env:RUNNER_TEMP "noethys-installed-profile"
+          $workRoot = Join-Path $env:RUNNER_TEMP "noethys-foreign-cwd"
+          $roaming = Join-Path $profileRoot "Roaming"
+          New-Item -ItemType Directory -Path $diag -Force | Out-Null
+
+          @(
+            "GITHUB_SHA=$env:GITHUB_SHA"
+            "GITHUB_RUN_ID=$env:GITHUB_RUN_ID"
+            "RUNNER_TEMP=$env:RUNNER_TEMP"
+            "installRoot=$installRoot"
+            "profileRoot=$profileRoot"
+            "workRoot=$workRoot"
+            "roaming=$roaming"
+            "installRoot.exists=$(Test-Path $installRoot)"
+            "profileRoot.exists=$(Test-Path $profileRoot)"
+            "workRoot.exists=$(Test-Path $workRoot)"
+            "exe.exists=$(Test-Path (Join-Path $installRoot 'Noethys.exe'))"
+            "errorMarker.exists=$(Test-Path (Join-Path $installRoot 'INSTALL-CONFIG-SMOKE-ERROR.txt'))"
+            "okMarker.exists=$(Test-Path (Join-Path $installRoot 'INSTALL-CONFIG-SMOKE-OK.txt'))"
+          ) | Set-Content -Path (Join-Path $diag "context.txt") -Encoding UTF8
+
+          $copies = @{
+            "INSTALL-CONFIG-SMOKE-ERROR.txt" = (Join-Path $installRoot "INSTALL-CONFIG-SMOKE-ERROR.txt")
+            "INSTALL-CONFIG-SMOKE-OK.txt" = (Join-Path $installRoot "INSTALL-CONFIG-SMOKE-OK.txt")
+            "profile-Config.json" = (Join-Path $roaming "noethys/Config.json")
+            "profile-journal.log" = (Join-Path $roaming "noethys/journal.log")
+            "foreign-cwd-Config.json" = (Join-Path $workRoot "Config.json")
+          }
+          foreach ($name in $copies.Keys) {
+            $source = $copies[$name]
+            if (Test-Path $source) {
+              Copy-Item $source (Join-Path $diag $name) -Force
+            }
+          }
+
+          foreach ($entry in @(
+            @{ Name = "install-root.txt"; Path = $installRoot; Recurse = $false },
+            @{ Name = "profile-tree.txt"; Path = $profileRoot; Recurse = $true },
+            @{ Name = "foreign-cwd.txt"; Path = $workRoot; Recurse = $true }
+          )) {
+            if (Test-Path $entry.Path) {
+              if ($entry.Recurse) {
+                Get-ChildItem $entry.Path -Force -Recurse -ErrorAction SilentlyContinue |
+                  Select-Object FullName, Length, LastWriteTime |
+                  Format-Table -AutoSize |
+                  Out-String -Width 240 |
+                  Set-Content -Path (Join-Path $diag $entry.Name) -Encoding UTF8
+              }
+              else {
+                Get-ChildItem $entry.Path -Force -ErrorAction SilentlyContinue |
+                  Select-Object Name, Length, LastWriteTime |
+                  Format-Table -AutoSize |
+                  Out-String -Width 240 |
+                  Set-Content -Path (Join-Path $diag $entry.Name) -Encoding UTF8
+              }
+            }
+          }
+
+          Get-Content (Join-Path $diag "context.txt")
+          if (Test-Path (Join-Path $diag "INSTALL-CONFIG-SMOKE-ERROR.txt")) {
+            Write-Host "--- INSTALL-CONFIG-SMOKE-ERROR.txt ---"
+            Get-Content (Join-Path $diag "INSTALL-CONFIG-SMOKE-ERROR.txt")
+          }
+
+      - name: Publier les diagnostics du smoke installable
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-install-smoke-diagnostics
+          path: artifacts/windows-install-smoke-diagnostics
+          if-no-files-found: error
+          retention-days: 14
+
       - name: Activer l'isolation portable
         shell: pwsh
         run: |

--- a/docs/NOE-040-WINDOWS-PACKAGING.md
+++ b/docs/NOE-040-WINDOWS-PACKAGING.md
@@ -2,7 +2,7 @@
 
 ## Baseline
 
-Le portable Windows est construit avec :
+Le build Windows repose sur :
 
 - Python 3.10 ;
 - wxPython Phoenix ;
@@ -10,7 +10,12 @@ Le portable Windows est construit avec :
 - `packaging/noethys.spec` ;
 - toutes les dépendances de `requirements-build.txt`.
 
-Le résultat est une archive `Noethys-Windows-portable.zip` contenant `Noethys.exe`, les bibliothèques embarquées et les ressources Noethys nécessaires.
+Un même dossier PyInstaller sert de source à deux distributions distinctes :
+
+- **portable** : `Noethys-Windows-portable.zip`, avec marqueur `Portable/` et configuration isolée ;
+- **installable** : `Noethys-Upgrade-Setup.exe`, construit avec Inno Setup depuis une copie du bundle **sans** marqueur `Portable/`.
+
+Les deux artefacts doivent provenir du même SHA et conserver `BUILD-INFO.txt`.
 
 ## Contrôles avant build
 
@@ -23,22 +28,47 @@ Le workflow vérifie avant PyInstaller :
 
 ## Contrôle du véritable exécutable
 
-La qualification ne s'arrête plus à la présence de `Noethys.exe`.
+La qualification ne s'arrête pas à la présence de `Noethys.exe`.
 
-Après construction :
+Après construction du bundle commun :
 
-1. le dossier est archivé ;
-2. l'archive est extraite dans un répertoire neuf du runner ;
-3. `PYTHONHOME` et `PYTHONPATH` sont vidés ;
-4. les chemins Python/pip sont retirés du `PATH` ;
-5. `Noethys.exe` est réellement lancé avec `NOETHYS_FROZEN_SMOKE=1` ;
-6. un runtime hook vérifie que l'application est bien figée, que les ressources essentielles existent et que plusieurs dépendances critiques sont importables depuis le bundle ;
-7. le processus doit sortir avec le code 0 ;
-8. le smoke doit n'avoir créé aucun répertoire de configuration/données Noethys dans le profil Windows de test.
+1. le layout historique est vérifié ;
+2. une copie **installable** est préparée sans `Portable/` ;
+3. l'installateur Inno Setup est construit ;
+4. l'installateur est exécuté silencieusement dans un répertoire neuf ;
+5. un faux profil `%APPDATA%` contient une configuration sentinelle existante ;
+6. l'exécutable installé est lancé depuis un autre répertoire contenant un faux `Config.json` ;
+7. le smoke vérifie que la configuration active est exactement celle du profil utilisateur et qu'elle reste inchangée ;
+8. le faux `Config.json` du répertoire courant doit rester intact ;
+9. le dossier installable ne doit contenir aucun marqueur `Portable/` ;
+10. le bundle commun reçoit ensuite le marqueur `Portable/`, est archivé, extrait dans un répertoire neuf puis exécuté avec `NOETHYS_FROZEN_SMOKE=1` ;
+11. le portable doit retrouver ses ressources/dépendances sans Python externe et ne rien écrire dans le profil Windows de test.
 
-Le mode smoke s'arrête **avant** l'exécution de `Noethys.py` : il ne sélectionne, n'ouvre et ne migre donc aucune base utilisateur.
+## Migration de configuration
 
-## Piles vérifiées depuis le bundle
+`UTILS_Fichiers.DeplaceFichiers()` ne considère comme sources historiques que des emplacements explicitement rattachés à Noethys :
+
+- répertoire applicatif ;
+- ancien sous-répertoire `Data` ;
+- ancien `~/noethys`.
+
+Le répertoire courant du processus n'est jamais une source de migration.
+
+Lorsqu'une configuration existe déjà dans le profil utilisateur, elle est autoritaire et n'est pas remplacée. `Config.json.bak` suit le même contrat que `Config.json` lors d'une vraie migration legacy.
+
+## Installateur système
+
+`packaging/noethys-installer.iss` produit `Noethys-Upgrade-Setup.exe` avec les principes suivants :
+
+- `AppId` stable ;
+- réutilisation du répertoire d'une installation précédente compatible ;
+- aucun fichier de configuration ou de données utilisateur embarqué ;
+- aucune suppression de données utilisateur à la désinstallation ;
+- raccourcis Windows uniquement vers `Noethys.exe` installé.
+
+L'installateur complète le portable ; il ne le remplace pas.
+
+## Piles vérifiées depuis le bundle portable
 
 Le smoke figé charge notamment :
 
@@ -57,13 +87,29 @@ Ce contrôle complète les smoke tests fonctionnels exécutés avant le build.
 
 ## Identification du build
 
-`BUILD-INFO.txt` est inclus dans le dossier portable avec :
+`BUILD-INFO.txt` est inclus avec :
 
 - le commit Git ;
 - la version Python ;
 - l'identifiant du workflow ;
-- la date UTC du build.
+- la date UTC du build ;
+- le marqueur du mode portable uniquement dans l'archive portable.
+
+## Recette humaine obligatoire
+
+La CI garantit la construction, la séparation installable/portable et le contrat minimal de préservation de configuration. Elle ne remplace pas la recette sur Windows réel.
+
+Avant validation d'une RC, suivre `RC-CHECKLIST.md` et l'issue de recette installateur courante pour vérifier au minimum :
+
+- installation propre ;
+- mise à niveau d'une installation existante ;
+- lancement depuis un répertoire courant étranger contenant un `Config.json` sentinelle ;
+- séparation stricte entre configuration installable `%APPDATA%` et mode `Portable/` ;
+- désinstallation sans suppression des données/configurations utilisateur ;
+- retour arrière sur une copie distincte lorsque pertinent.
+
+La recette doit toujours porter sur **le SHA exact candidat**. Toute correction post-recette impose de recommencer la qualification sur le nouvel artefact.
 
 ## Limite volontaire
 
-Cette qualification prouve qu'une archive extraite lance son Python embarqué et retrouve ses ressources/dépendances sans utiliser l'environnement Python du runner. Elle ne remplace pas la recette métier Noe-030 sur une copie de base réelle.
+Ces qualifications prouvent que les distributions Windows lancent leur Python embarqué, retrouvent leurs ressources et respectent le contrat de configuration. Elles ne remplacent pas la recette métier Noe-030 sur une copie de base réelle.

--- a/noethys/Utils/UTILS_Fichiers.py
+++ b/noethys/Utils/UTILS_Fichiers.py
@@ -130,6 +130,34 @@ def _MigreFichierLocal(source, destination):
     return True
 
 
+def _MigreConfigurationLocale(repertoires_historiques):
+    """Migre Config.json et uniquement la sauvegarde qui lui correspond."""
+    destination_config = GetRepUtilisateur("Config.json")
+    destination_backup = GetRepUtilisateur("Config.json.bak")
+
+    # Si le profil possède déjà sa configuration active, elle est autoritaire.
+    # Importer séparément une ancienne sauvegarde créerait un couple incohérent
+    # et pourrait restaurer plus tard des réglages obsolètes.
+    if os.path.exists(destination_config):
+        return False
+
+    for rep in repertoires_historiques:
+        source_config = os.path.join(rep, "Config.json")
+        if not os.path.isfile(source_config):
+            continue
+
+        if not _MigreFichierLocal(source_config, destination_config):
+            return False
+
+        # La sauvegarde ne voyage qu'avec le Config.json choisi et depuis le
+        # même répertoire historique. Une sauvegarde orpheline est ignorée.
+        source_backup = os.path.join(rep, "Config.json.bak")
+        _MigreFichierLocal(source_backup, destination_backup)
+        return True
+
+    return False
+
+
 def DeplaceFichiers():
     """ Vérifie si des fichiers du répertoire Data ou du répertoire Utilisateur sont à déplacer vers le répertoire Utilisateur>AppData>Roaming """
 
@@ -142,11 +170,14 @@ def DeplaceFichiers():
         Chemins.GetMainPath("Data"),
         os.path.join(os.path.expanduser("~"), "noethys"),
     )
-    for nom in ("journal.log", "Config.json", "Config.json.bak", "Customize.ini") :
+    for nom in ("journal.log", "Customize.ini") :
         destination = GetRepUtilisateur(nom)
         for rep in repertoires_historiques :
             source = os.path.join(rep, nom)
-            _MigreFichierLocal(source, destination)
+            if _MigreFichierLocal(source, destination):
+                break
+
+    _MigreConfigurationLocale(repertoires_historiques)
 
     # Déplace les fichiers xlang
     if os.path.isdir(Chemins.GetMainPath("Lang")) :

--- a/noethys/Utils/UTILS_Fichiers.py
+++ b/noethys/Utils/UTILS_Fichiers.py
@@ -107,16 +107,46 @@ def GetRepUtilisateur(fichier=""):
         os.mkdir(chemin)
     return os.path.join(chemin, fichier)
 
+
+def _MigreFichierLocal(source, destination):
+    """Migre un fichier historique sans écraser le fichier utilisateur actif."""
+    if not os.path.isfile(source):
+        return False
+
+    source_absolue = os.path.abspath(source)
+    destination_absolue = os.path.abspath(destination)
+    if source_absolue == destination_absolue:
+        return False
+
+    # Une configuration déjà présente dans le profil utilisateur est
+    # autoritaire. Une mise à niveau ne doit jamais la remplacer par une copie
+    # ancienne trouvée près de l'exécutable ou dans un ancien répertoire Data.
+    if os.path.exists(destination):
+        print(["migration ignoree, destination deja presente :", source, " > ", destination])
+        return False
+
+    print(["deplacement fichier config :", source, " > ", destination])
+    shutil.move(source, destination)
+    return True
+
+
 def DeplaceFichiers():
     """ Vérifie si des fichiers du répertoire Data ou du répertoire Utilisateur sont à déplacer vers le répertoire Utilisateur>AppData>Roaming """
 
-    # Déplace les fichiers de config et le journal
-    for nom in ("journal.log", "Config.json", "Customize.ini") :
-        for rep in ("", Chemins.GetMainPath("Data"), os.path.join(os.path.expanduser("~"), "noethys")) :
-            fichier = os.path.join(rep, nom)
-            if os.path.isfile(fichier) :
-                print(["deplacement fichier config :", fichier, " > ", GetRepUtilisateur(nom)])
-                shutil.move(fichier, GetRepUtilisateur(nom))
+    # Déplace les fichiers de config et le journal. Ne jamais utiliser le
+    # répertoire courant du processus comme source : un raccourci Windows ou un
+    # installateur peut démarrer Noethys depuis un dossier sans rapport avec
+    # l'application.
+    repertoires_historiques = (
+        Chemins.GetMainPath(""),
+        Chemins.GetMainPath("Data"),
+        os.path.join(os.path.expanduser("~"), "noethys"),
+    )
+    for nom in ("journal.log", "Config.json", "Config.json.bak", "Customize.ini") :
+        destination = GetRepUtilisateur(nom)
+        for rep in repertoires_historiques :
+            source = os.path.join(rep, nom)
+            _MigreFichierLocal(source, destination)
 
     # Déplace les fichiers xlang
     if os.path.isdir(Chemins.GetMainPath("Lang")) :

--- a/packaging/noethys-installer.iss
+++ b/packaging/noethys-installer.iss
@@ -1,0 +1,42 @@
+; Installateur Windows de la ligne Upgrade Noethys.
+; Les données et la configuration utilisateur ne sont jamais embarquées ici :
+; elles restent gérées par UTILS_Fichiers dans le profil utilisateur.
+
+#ifndef MyAppVersion
+  #define MyAppVersion "1.3.4.2-upgrade"
+#endif
+
+[Setup]
+AppId=Noethys
+AppName=Noethys
+AppVersion={#MyAppVersion}
+AppPublisher=Noethys
+DefaultDirName={autopf}\Noethys
+DefaultGroupName=Noethys
+DisableProgramGroupPage=yes
+UsePreviousAppDir=yes
+PrivilegesRequired=admin
+OutputDir=..\installer-output
+OutputBaseFilename=Noethys-Upgrade-Setup
+SetupIconFile=..\noethys\Icone.ico
+UninstallDisplayIcon={app}\Noethys.exe
+Compression=lzma2
+SolidCompression=yes
+WizardStyle=modern
+CloseApplications=yes
+RestartApplications=no
+ChangesAssociations=no
+ChangesEnvironment=no
+
+[Files]
+Source: "..\dist\Noethys-installable\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{group}\Noethys"; Filename: "{app}\Noethys.exe"; WorkingDir: "{app}"
+Name: "{autodesktop}\Noethys"; Filename: "{app}\Noethys.exe"; WorkingDir: "{app}"; Tasks: desktopicon
+
+[Tasks]
+Name: "desktopicon"; Description: "Créer un raccourci sur le Bureau"; GroupDescription: "Raccourcis :"; Flags: unchecked
+
+[Run]
+Filename: "{app}\Noethys.exe"; Description: "Lancer Noethys"; Flags: nowait postinstall skipifsilent

--- a/packaging/noethys-installer.iss
+++ b/packaging/noethys-installer.iss
@@ -2,14 +2,10 @@
 ; Les données et la configuration utilisateur ne sont jamais embarquées ici :
 ; elles restent gérées par UTILS_Fichiers dans le profil utilisateur.
 
-#ifndef MyAppVersion
-  #define MyAppVersion "1.3.4.2-upgrade"
-#endif
-
 [Setup]
 AppId=Noethys
 AppName=Noethys
-AppVersion={#MyAppVersion}
+AppVersion=1.3.4.2-upgrade
 AppPublisher=Noethys
 DefaultDirName={autopf}\Noethys
 DefaultGroupName=Noethys

--- a/packaging/noethys.spec
+++ b/packaging/noethys.spec
@@ -70,7 +70,10 @@ datas += collect_data_files("pytz")
 datas += collect_data_files("reportlab")
 
 runtime_hooks = [
-    # Installer d'abord le journal d'erreurs : si un hook de compatibilité casse,
+    # Précharge d'abord la stdlib avant que les hooks wx n'exposent leurs
+    # sous-modules dans le layout historique plat du bundle.
+    str(ROOT / "packaging" / "runtime_stdlib_preload.py"),
+    # Installer ensuite le journal d'erreurs : si un hook de compatibilité casse,
     # le diagnostic est persisté au lieu de disparaître dans l'EXE sans console.
     str(ROOT / "packaging" / "runtime_crashlog.py"),
     # Mesure localement les délais d'ouverture des fenêtres et les allers-retours

--- a/packaging/noethys.spec
+++ b/packaging/noethys.spec
@@ -25,6 +25,12 @@ def collect_runtime_submodules(package):
 
 
 hiddenimports = [
+    # CTRL_Bandeau utilise le paquet ``html`` de la stdlib. Dans le bundle plat,
+    # l'absence de ce paquet peut faire résoudre ce nom vers ``wx/html.py`` comme
+    # module de premier niveau ; son import relatif ``from . import _html`` échoue
+    # alors sans package parent. On fige explicitement le paquet stdlib attendu.
+    "html",
+    "html.entities",
     # wx.richtext charge wx._xml au runtime. PyInstaller ne détecte pas toujours
     # ce module natif via le graphe d'import ; sans lui le portable plante dès
     # l'import de DLG_Portail_config.

--- a/packaging/runtime_frozen_smoke.py
+++ b/packaging/runtime_frozen_smoke.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import importlib
 import os
 import sys
+import traceback
 from pathlib import Path
 
 
@@ -157,8 +158,8 @@ if os.environ.get("NOETHYS_FROZEN_SMOKE") == "1":
             _finish(
                 root,
                 4,
-                "Import figé en échec pour %s: %s: %s"
-                % (module_name, type(exc).__name__, exc),
+                "Import figé en échec pour %s: %s: %s\n\n%s"
+                % (module_name, type(exc).__name__, exc, traceback.format_exc()),
             )
 
     _finish(root, 0, "Bundle figé Noethys validé")

--- a/packaging/runtime_frozen_smoke.py
+++ b/packaging/runtime_frozen_smoke.py
@@ -1,11 +1,14 @@
 # -*- coding: utf-8 -*-
-"""Smoke test du bundle PyInstaller avant l'exécution de Noethys.py.
+"""Smoke tests du bundle PyInstaller avant l'exécution de Noethys.py.
 
-Ce runtime hook ne fait strictement rien en usage normal. Quand
-``NOETHYS_FROZEN_SMOKE=1`` est défini, il valide que l'exécutable est réellement
-figé, que ses ressources essentielles sont présentes et que plusieurs piles
-runtime critiques sont importables depuis le bundle. Il quitte ensuite avant
-que Noethys n'ouvre une configuration ou une base utilisateur.
+Ce runtime hook ne fait strictement rien en usage normal.
+
+``NOETHYS_FROZEN_SMOKE=1`` valide le bundle portable sans ouvrir la
+configuration ni une base utilisateur.
+
+``NOETHYS_INSTALL_CONFIG_SMOKE=1`` valide le contrat de l'installable : la
+configuration doit rester dans le profil utilisateur, ne jamais dépendre du
+répertoire courant et ne pas être remplacée par la migration historique.
 
 Le hook utilise ``os._exit`` en mode smoke afin qu'un échec dans une application
 PyInstaller ``console=False`` ne puisse pas ouvrir une boîte de dialogue fatale
@@ -19,19 +22,96 @@ import sys
 from pathlib import Path
 
 
-def _finish(root: Path, code: int, message: str) -> None:
-    marker = root / ("FROZEN-SMOKE-OK.txt" if code == 0 else "FROZEN-SMOKE-ERROR.txt")
+def _finish(root: Path, code: int, message: str, marker_prefix: str = "FROZEN-SMOKE") -> None:
+    marker = root / (
+        "%s-OK.txt" % marker_prefix if code == 0 else "%s-ERROR.txt" % marker_prefix
+    )
     try:
         marker.write_text(message + "\n", encoding="utf-8")
     finally:
         os._exit(code)
 
 
+def _require_frozen(root: Path, marker_prefix: str) -> None:
+    if not getattr(sys, "frozen", False):
+        _finish(root, 2, "Le smoke exige un exécutable figé", marker_prefix)
+
+
+if os.environ.get("NOETHYS_INSTALL_CONFIG_SMOKE") == "1":
+    root = Path(sys.executable).resolve().parent
+    marker_prefix = "INSTALL-CONFIG-SMOKE"
+    _require_frozen(root, marker_prefix)
+
+    if (root / "Portable").exists():
+        _finish(
+            root,
+            5,
+            "L'installable contient un marqueur Portable et isolerait la configuration utilisateur",
+            marker_prefix,
+        )
+
+    expected_raw = os.environ.get("NOETHYS_EXPECT_CONFIG_PATH", "")
+    if not expected_raw:
+        _finish(root, 6, "NOETHYS_EXPECT_CONFIG_PATH est absent", marker_prefix)
+
+    expected = Path(expected_raw).resolve()
+    if not expected.is_file():
+        _finish(
+            root,
+            7,
+            "La configuration sentinelle attendue est absente: %s" % expected,
+            marker_prefix,
+        )
+
+    before = expected.read_bytes()
+    try:
+        import Chemins
+        from Utils import UTILS_Fichiers
+
+        actual = Path(UTILS_Fichiers.GetRepUtilisateur("Config.json")).resolve()
+        if actual != expected:
+            _finish(
+                root,
+                8,
+                "Mauvais chemin de configuration: %s (attendu: %s)" % (actual, expected),
+                marker_prefix,
+            )
+
+        application_root = Path(Chemins.GetMainPath("")).resolve()
+        if application_root != root:
+            _finish(
+                root,
+                9,
+                "Le chemin applicatif figé n'est pas ancré sur Noethys.exe: %s" % application_root,
+                marker_prefix,
+            )
+
+        # Rejoue la migration réellement exécutée au démarrage. Avec une
+        # configuration déjà existante, elle doit être strictement sans effet.
+        UTILS_Fichiers.DeplaceFichiers()
+    except Exception as exc:
+        _finish(
+            root,
+            10,
+            "Smoke configuration installée en échec: %s: %s"
+            % (type(exc).__name__, exc),
+            marker_prefix,
+        )
+
+    if not expected.is_file() or expected.read_bytes() != before:
+        _finish(
+            root,
+            11,
+            "La configuration utilisateur a été modifiée pendant la migration",
+            marker_prefix,
+        )
+
+    _finish(root, 0, "Configuration installable Noethys préservée", marker_prefix)
+
+
 if os.environ.get("NOETHYS_FROZEN_SMOKE") == "1":
     root = Path(sys.executable).resolve().parent
-
-    if not getattr(sys, "frozen", False):
-        _finish(root, 2, "Le smoke NOETHYS_FROZEN_SMOKE exige un exécutable figé")
+    _require_frozen(root, "FROZEN-SMOKE")
 
     required = (
         root / "Static",

--- a/packaging/runtime_stdlib_preload.py
+++ b/packaging/runtime_stdlib_preload.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+"""Précharge les modules stdlib qui entrent en collision avec le bundle wx plat.
+
+Le layout historique de Noethys place les modules wxPython à côté de l'EXE.
+Une fois ``wx`` chargé, un ``import html`` tardif peut alors être résolu vers
+``wx/html.py`` comme module de premier niveau. Ce fichier contient des imports
+relatifs et échoue dans ce contexte (``attempted relative import with no known
+parent package``).
+
+Le préchargement de la stdlib a lieu avant tout hook qui importe ``wx`` et fixe
+``sys.modules['html']`` sur le paquet Python attendu par ``CTRL_Bandeau``.
+"""
+
+import html as _stdlib_html  # noqa: F401  -- préchargement volontaire

--- a/tests/test_noe_041_portable_paths.py
+++ b/tests/test_noe_041_portable_paths.py
@@ -1,16 +1,24 @@
 # -*- coding: utf-8 -*-
 import importlib.util
+import os
 import sys
 import tempfile
 import types
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
-def _load_utils_files(root):
+def _load_utils_files(root, config_root=None):
+    root = Path(root)
+    config_root = Path(config_root) if config_root is not None else root / "outside-user-config"
+    (root / "outside-site-data").mkdir(parents=True, exist_ok=True)
+    (root / "outside-user-data").mkdir(parents=True, exist_ok=True)
+    config_root.mkdir(parents=True, exist_ok=True)
+
     chemins = types.ModuleType("Chemins")
-    chemins.GetMainPath = lambda fichier="": str(Path(root) / fichier)
-    chemins.GetStaticPath = lambda fichier="": str(Path(root) / "Static" / fichier)
+    chemins.GetMainPath = lambda fichier="": str(root / fichier)
+    chemins.GetStaticPath = lambda fichier="": str(root / "Static" / fichier)
     sys.modules["Chemins"] = chemins
 
     utils_pkg = types.ModuleType("Utils")
@@ -23,9 +31,9 @@ def _load_utils_files(root):
     utils_pkg.UTILS_Customize = customize
 
     appdirs = types.ModuleType("appdirs")
-    appdirs.site_data_dir = lambda **kwargs: str(Path(root) / "outside-site-data")
-    appdirs.user_data_dir = lambda **kwargs: str(Path(root) / "outside-user-data")
-    appdirs.user_config_dir = lambda **kwargs: str(Path(root) / "outside-user-config")
+    appdirs.site_data_dir = lambda **kwargs: str(root / "outside-site-data")
+    appdirs.user_data_dir = lambda **kwargs: str(root / "outside-user-data")
+    appdirs.user_config_dir = lambda **kwargs: str(config_root)
     sys.modules["appdirs"] = appdirs
 
     six = types.ModuleType("six")
@@ -80,6 +88,94 @@ class PortablePathsTests(unittest.TestCase):
             data = Path(module.GetRepData("demo.dat"))
             self.assertNotIn("outside-", str(config))
             self.assertNotIn("outside-", str(data))
+
+
+class InstallableConfigPathsTests(unittest.TestCase):
+    def test_config_path_is_independent_from_process_working_directory(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            profile = root / "profile-roaming"
+            module = _load_utils_files(root, config_root=profile)
+            cwd_a = root / "cwd-a"
+            cwd_b = root / "cwd-b"
+            cwd_a.mkdir()
+            cwd_b.mkdir()
+
+            previous = Path.cwd()
+            try:
+                os.chdir(str(cwd_a))
+                path_a = Path(module.GetRepUtilisateur("Config.json"))
+                os.chdir(str(cwd_b))
+                path_b = Path(module.GetRepUtilisateur("Config.json"))
+            finally:
+                os.chdir(str(previous))
+
+            expected = profile / "noethys" / "Config.json"
+            self.assertEqual(path_a, expected)
+            self.assertEqual(path_b, expected)
+
+    def test_migration_does_not_read_config_from_current_working_directory(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            profile = root / "profile-roaming"
+            module = _load_utils_files(root, config_root=profile)
+            cwd = root / "foreign-working-directory"
+            cwd.mkdir()
+            foreign_config = cwd / "Config.json"
+            foreign_config.write_text('{"source":"foreign"}', encoding="utf-8")
+            home = root / "home"
+            home.mkdir()
+
+            previous = Path.cwd()
+            try:
+                os.chdir(str(cwd))
+                with mock.patch.dict(os.environ, {"HOME": str(home)}, clear=False):
+                    module.DeplaceFichiers()
+            finally:
+                os.chdir(str(previous))
+
+            self.assertEqual(foreign_config.read_text(encoding="utf-8"), '{"source":"foreign"}')
+            self.assertFalse((profile / "noethys" / "Config.json").exists())
+
+    def test_migration_never_overwrites_existing_user_config(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            profile = root / "profile-roaming"
+            module = _load_utils_files(root, config_root=profile)
+            legacy_config = root / "Config.json"
+            legacy_config.write_text('{"source":"legacy"}', encoding="utf-8")
+            active_config = Path(module.GetRepUtilisateur("Config.json"))
+            active_config.write_text('{"source":"active"}', encoding="utf-8")
+            home = root / "home"
+            home.mkdir()
+
+            with mock.patch.dict(os.environ, {"HOME": str(home)}, clear=False):
+                module.DeplaceFichiers()
+
+            self.assertEqual(active_config.read_text(encoding="utf-8"), '{"source":"active"}')
+            self.assertEqual(legacy_config.read_text(encoding="utf-8"), '{"source":"legacy"}')
+
+    def test_migration_moves_application_config_and_backup_when_destination_is_empty(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            profile = root / "profile-roaming"
+            module = _load_utils_files(root, config_root=profile)
+            legacy_config = root / "Config.json"
+            legacy_backup = root / "Config.json.bak"
+            legacy_config.write_text('{"source":"legacy"}', encoding="utf-8")
+            legacy_backup.write_text('{"source":"backup"}', encoding="utf-8")
+            home = root / "home"
+            home.mkdir()
+
+            with mock.patch.dict(os.environ, {"HOME": str(home)}, clear=False):
+                module.DeplaceFichiers()
+
+            active_config = profile / "noethys" / "Config.json"
+            active_backup = profile / "noethys" / "Config.json.bak"
+            self.assertEqual(active_config.read_text(encoding="utf-8"), '{"source":"legacy"}')
+            self.assertEqual(active_backup.read_text(encoding="utf-8"), '{"source":"backup"}')
+            self.assertFalse(legacy_config.exists())
+            self.assertFalse(legacy_backup.exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_noe_041_portable_paths.py
+++ b/tests/test_noe_041_portable_paths.py
@@ -137,14 +137,17 @@ class InstallableConfigPathsTests(unittest.TestCase):
             self.assertEqual(foreign_config.read_text(encoding="utf-8"), '{"source":"foreign"}')
             self.assertFalse((profile / "noethys" / "Config.json").exists())
 
-    def test_migration_never_overwrites_existing_user_config(self):
+    def test_migration_never_overwrites_existing_user_config_or_imports_stale_backup(self):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             profile = root / "profile-roaming"
             module = _load_utils_files(root, config_root=profile)
             legacy_config = root / "Config.json"
+            legacy_backup = root / "Config.json.bak"
             legacy_config.write_text('{"source":"legacy"}', encoding="utf-8")
+            legacy_backup.write_text('{"source":"legacy-backup"}', encoding="utf-8")
             active_config = Path(module.GetRepUtilisateur("Config.json"))
+            active_backup = Path(module.GetRepUtilisateur("Config.json.bak"))
             active_config.write_text('{"source":"active"}', encoding="utf-8")
             home = root / "home"
             home.mkdir()
@@ -153,7 +156,26 @@ class InstallableConfigPathsTests(unittest.TestCase):
                 module.DeplaceFichiers()
 
             self.assertEqual(active_config.read_text(encoding="utf-8"), '{"source":"active"}')
+            self.assertFalse(active_backup.exists())
             self.assertEqual(legacy_config.read_text(encoding="utf-8"), '{"source":"legacy"}')
+            self.assertEqual(legacy_backup.read_text(encoding="utf-8"), '{"source":"legacy-backup"}')
+
+    def test_migration_does_not_import_orphan_legacy_backup(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            profile = root / "profile-roaming"
+            module = _load_utils_files(root, config_root=profile)
+            legacy_backup = root / "Config.json.bak"
+            legacy_backup.write_text('{"source":"orphan-backup"}', encoding="utf-8")
+            home = root / "home"
+            home.mkdir()
+
+            with mock.patch.dict(os.environ, {"HOME": str(home)}, clear=False):
+                module.DeplaceFichiers()
+
+            self.assertFalse((profile / "noethys" / "Config.json").exists())
+            self.assertFalse((profile / "noethys" / "Config.json.bak").exists())
+            self.assertEqual(legacy_backup.read_text(encoding="utf-8"), '{"source":"orphan-backup"}')
 
     def test_migration_moves_application_config_and_backup_when_destination_is_empty(self):
         with tempfile.TemporaryDirectory() as temp:


### PR DESCRIPTION
## Objet

Reconstruit depuis le `master` courant le lot Windows conservé comme référence dans l’ancienne PR #207, sans reprendre sa branche devenue obsolète.

Contribue à #323. La recette humaine A→E du SHA candidat reste nécessaire avant de considérer #323 comme terminé.

## Configuration / migration

- le répertoire courant du processus n’est plus une source possible de migration de `Config.json`, `Customize.ini` ou `journal.log` ;
- les sources legacy sont ancrées sur le répertoire applicatif, `Data` et l’ancien `~/noethys` ;
- une configuration déjà présente dans le profil utilisateur est autoritaire et n’est jamais écrasée ;
- `Config.json` et `Config.json.bak` sont traités comme une même unité de migration : une sauvegarde legacy n’est pas importée si la configuration principale n’est pas elle-même migrée ;
- tests ciblés : indépendance au CWD, piège `Config.json` étranger, conservation d’une configuration existante et migration config+backup.

## Installateur Windows

- ajoute `packaging/noethys-installer.iss` ;
- produit `Noethys-Upgrade-Setup.exe` depuis une copie du bundle PyInstaller sans `Portable/` ;
- conserve un `AppId` stable et `UsePreviousAppDir=yes` ;
- n’embarque aucune donnée/configuration utilisateur ;
- le portable historique reste construit séparément à partir du même SHA.

## Qualification automatisée

Le workflow Windows :

1. construit le bundle PyInstaller commun ;
2. construit et installe silencieusement l’installateur ;
3. place un `Config.json` sentinelle dans le véritable dossier Windows `ApplicationData/Noethys` résolu par l’API Windows, en sauvegardant/restaurant tout fichier préexistant du runner ;
4. lance l’EXE installé depuis un CWD étranger contenant un faux `Config.json` ;
5. vérifie que la configuration utilisateur reste byte-identique et que le piège CWD reste intact ;
6. vérifie l’absence de marqueur `Portable/` dans l’installation ;
7. construit ensuite le portable, puis exécute son smoke historique isolé ;
8. publie séparément les artefacts installateur et portable.

Le smoke installable utilise volontairement le véritable profil itinérant Windows : `appdirs.user_config_dir(roaming=True)` s’appuie sur le dossier connu Windows et ne peut pas être correctement redirigé en modifiant simplement `%APPDATA%` dans le processus CI.

## Documentation

`NOE-040-WINDOWS-PACKAGING.md` devient la référence du double packaging installable/portable et rappelle que la recette humaine du SHA exact candidat reste obligatoire.

La recette humaine A→E (installation propre, mise à niveau, piège CWD, séparation portable/installable, désinstallation/retour arrière) est détaillée dans #323.

Branche resynchronisée proprement sur le `master` `92f9e6a22c3c58ec0e4028e7313a4fb7e6f31d98` après fusion de #322 ; diff limité aux six fichiers du lot Windows.