### PR TITLE
Noe-062 : vérifier l’enveloppe inter-domaines avant le réalisé

### DIFF
--- a/noethys/Utils/UTILS_Interdomain_Delivery.py
+++ b/noethys/Utils/UTILS_Interdomain_Delivery.py
@@ -26,18 +26,13 @@ CONTRACT_VERSION = "session-actual/1"
 EVENT_TYPE = "session_actual_validated"
 ACK_STATUSES = ("accepted", "replayed", "rejected", "retryable")
 
-try:
-    string_types = (basestring,)  # noqa: F821 - Python 2 historique
-except NameError:
-    string_types = (str,)
-
 
 class DeliveryEnvelopeError(ValueError):
     """Enveloppe absente, mal formée, non authentifiée ou mal adressée."""
 
 
 def _text(value, field, maximum):
-    if not isinstance(value, string_types):
+    if not isinstance(value, str):
         raise DeliveryEnvelopeError("%s obligatoire" % field)
     value = value.strip()
     if not value:
@@ -96,19 +91,9 @@ def _signature(envelope, secret):
 
 
 def _compare_digest(expected, received):
-    comparer = getattr(hmac, "compare_digest", None)
-    if callable(comparer):
-        return comparer(expected, received)
-    # Repli constant-time pour les environnements Python historiques où
-    # ``hmac.compare_digest`` n'existe pas encore.
-    if not isinstance(expected, string_types) or not isinstance(received, string_types):
+    if not isinstance(expected, str) or not isinstance(received, str):
         return False
-    if len(expected) != len(received):
-        return False
-    result = 0
-    for left, right in zip(bytearray(expected.encode("ascii")), bytearray(received.encode("ascii"))):
-        result |= left ^ right
-    return result == 0
+    return hmac.compare_digest(expected, received)
 
 
 def VerifierEnveloppe(livraison, keyring, target_domain=TARGET_DOMAIN, source_domain=SOURCE_DOMAIN):
@@ -170,7 +155,7 @@ def ConstruireAccuse(status, idempotence_key, correlation_id, detail=""):
     correlation_id = _text(correlation_id, "correlation_id", 128)
     if detail is None:
         detail = ""
-    if not isinstance(detail, string_types) or len(detail) > 500:
+    if not isinstance(detail, str) or len(detail) > 500:
         raise DeliveryEnvelopeError("detail invalide")
     return {
         "status": status,

--- a/noethys/Utils/UTILS_Interdomain_Delivery.py
+++ b/noethys/Utils/UTILS_Interdomain_Delivery.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Adaptateur d'entrée ``inter-domain-delivery/1`` pour le domaine activité/usagers.
+
+Ce module ne fournit aucun serveur ni transport réseau. Il vérifie une enveloppe
+signée selon ADR-012 puis délègue le payload métier au consommateur
+``session-actual/1`` déjà porté par Noethys.
+
+Les secrets sont exclusivement injectés via ``keyring`` ; aucun secret n'est
+stocké dans le code ou dans les journaux.
+"""
+from __future__ import unicode_literals
+
+import hashlib
+import hmac
+import json
+import re
+
+from Utils import UTILS_Interventions_Actual_Inbox
+
+
+ENVELOPE_VERSION = "inter-domain-delivery/1"
+SOURCE_DOMAIN = "operations_portal"
+TARGET_DOMAIN = "activity_users"
+CONTRACT_VERSION = "session-actual/1"
+EVENT_TYPE = "session_actual_validated"
+ACK_STATUSES = ("accepted", "replayed", "rejected", "retryable")
+
+try:
+    string_types = (basestring,)  # noqa: F821 - Python 2 historique
+except NameError:
+    string_types = (str,)
+
+
+class DeliveryEnvelopeError(ValueError):
+    """Enveloppe absente, mal formée, non authentifiée ou mal adressée."""
+
+
+def _text(value, field, maximum):
+    if not isinstance(value, string_types):
+        raise DeliveryEnvelopeError("%s obligatoire" % field)
+    value = value.strip()
+    if not value:
+        raise DeliveryEnvelopeError("%s obligatoire" % field)
+    if len(value) > maximum or any(ord(character) < 32 for character in value):
+        raise DeliveryEnvelopeError("%s invalide" % field)
+    return value
+
+
+def _secret(value):
+    if not isinstance(value, bytes):
+        raise DeliveryEnvelopeError("secret HMAC binaire obligatoire")
+    if len(value) < 32:
+        raise DeliveryEnvelopeError("secret HMAC trop court")
+    return value
+
+
+def _occurred_at(value):
+    value = _text(value, "occurred_at", 40)
+    # ADR-012 impose un horodatage timezone-aware. La représentation de
+    # référence est UTC ``Z`` mais une implémentation peut conserver un offset.
+    if not re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[+-]\d{2}:\d{2})$", value):
+        raise DeliveryEnvelopeError("occurred_at invalide")
+    return value
+
+
+def _mapping_copy(value, field):
+    if not isinstance(value, dict):
+        raise DeliveryEnvelopeError("%s invalide" % field)
+    try:
+        # L'aller-retour JSON détache le résultat de l'objet mutable fourni et
+        # vérifie qu'il est sérialisable selon le même sous-ensemble que Portail.
+        return json.loads(json.dumps(value, ensure_ascii=True))
+    except (TypeError, ValueError) as error:
+        raise DeliveryEnvelopeError("%s non sérialisable" % field)
+
+
+def _canonical_json(envelope):
+    if not isinstance(envelope, dict):
+        raise DeliveryEnvelopeError("enveloppe invalide")
+    try:
+        return json.dumps(
+            envelope,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        )
+    except (TypeError, ValueError) as error:
+        raise DeliveryEnvelopeError("enveloppe non sérialisable")
+
+
+def _signature(envelope, secret):
+    secret = _secret(secret)
+    message = _canonical_json(envelope).encode("utf-8")
+    return hmac.new(secret, message, hashlib.sha256).hexdigest()
+
+
+def _compare_digest(expected, received):
+    comparer = getattr(hmac, "compare_digest", None)
+    if callable(comparer):
+        return comparer(expected, received)
+    # Repli constant-time pour les environnements Python historiques où
+    # ``hmac.compare_digest`` n'existe pas encore.
+    if not isinstance(expected, string_types) or not isinstance(received, string_types):
+        return False
+    if len(expected) != len(received):
+        return False
+    result = 0
+    for left, right in zip(bytearray(expected.encode("ascii")), bytearray(received.encode("ascii"))):
+        result |= left ^ right
+    return result == 0
+
+
+def VerifierEnveloppe(livraison, keyring, target_domain=TARGET_DOMAIN, source_domain=SOURCE_DOMAIN):
+    """Vérifie et retourne une copie détachée de l'enveloppe authentifiée."""
+    if not isinstance(livraison, dict):
+        raise DeliveryEnvelopeError("livraison signée invalide")
+    if set(livraison.keys()) != set(("envelope", "signature")):
+        raise DeliveryEnvelopeError("livraison signée invalide")
+
+    envelope = _mapping_copy(livraison.get("envelope"), "enveloppe")
+    signature = _text(livraison.get("signature"), "signature", 64).lower()
+    if not re.match(r"^[0-9a-f]{64}$", signature):
+        raise DeliveryEnvelopeError("signature HMAC invalide")
+
+    if envelope.get("envelope_version") != ENVELOPE_VERSION:
+        raise DeliveryEnvelopeError("version d'enveloppe non supportée")
+    if _text(envelope.get("source_domain"), "source_domain", 64) != source_domain:
+        raise DeliveryEnvelopeError("domaine source inattendu")
+    if _text(envelope.get("target_domain"), "target_domain", 64) != target_domain:
+        raise DeliveryEnvelopeError("domaine cible inattendu")
+
+    contract_version = _text(envelope.get("contract_version"), "contract_version", 64)
+    event_type = _text(envelope.get("event_type"), "event_type", 64)
+    idempotence_key = _text(envelope.get("idempotence_key"), "idempotence_key", 255)
+    correlation_id = _text(envelope.get("correlation_id"), "correlation_id", 128)
+    _occurred_at(envelope.get("occurred_at"))
+    key_id = _text(envelope.get("key_id"), "key_id", 64)
+
+    payload = envelope.get("payload")
+    if not isinstance(payload, dict):
+        raise DeliveryEnvelopeError("payload invalide")
+    if payload.get("contract_version") != contract_version:
+        raise DeliveryEnvelopeError("contract_version incohérente avec le payload")
+    if payload.get("event_type") != event_type:
+        raise DeliveryEnvelopeError("event_type incohérent avec le payload")
+    if contract_version != CONTRACT_VERSION:
+        raise DeliveryEnvelopeError("contrat métier non supporté")
+    if event_type != EVENT_TYPE:
+        raise DeliveryEnvelopeError("type d'événement non supporté")
+
+    if not isinstance(keyring, dict) or key_id not in keyring:
+        raise DeliveryEnvelopeError("key_id inconnu")
+    expected = _signature(envelope, keyring[key_id])
+    if not _compare_digest(expected, signature):
+        raise DeliveryEnvelopeError("signature HMAC invalide")
+
+    # Force la lecture des identifiants avant de rendre l'enveloppe : ils sont
+    # utilisés tels quels pour l'accusé et l'idempotence métier.
+    envelope["idempotence_key"] = idempotence_key
+    envelope["correlation_id"] = correlation_id
+    return envelope
+
+
+def ConstruireAccuse(status, idempotence_key, correlation_id, detail=""):
+    status = _text(status, "status", 32)
+    if status not in ACK_STATUSES:
+        raise DeliveryEnvelopeError("statut d'accusé invalide")
+    idempotence_key = _text(idempotence_key, "idempotence_key", 255)
+    correlation_id = _text(correlation_id, "correlation_id", 128)
+    if detail is None:
+        detail = ""
+    if not isinstance(detail, string_types) or len(detail) > 500:
+        raise DeliveryEnvelopeError("detail invalide")
+    return {
+        "status": status,
+        "idempotence_key": idempotence_key,
+        "correlation_id": correlation_id,
+        "detail": detail,
+    }
+
+
+def RecevoirLivraisonSignee(db, livraison, keyring, date_reception=None):
+    """Vérifie l'enveloppe puis applique son payload métier à Noethys.
+
+    Les erreurs déterministes d'enveloppe ou de contrat sont classées
+    ``rejected``. Une panne technique inattendue est volontairement propagée :
+    l'adaptateur de transport physique devra la classer ``retryable`` sans
+    masquer une erreur de programmation ou de base.
+    """
+    try:
+        envelope = VerifierEnveloppe(livraison, keyring)
+    except DeliveryEnvelopeError as error:
+        idempotence_key = "invalid"
+        correlation_id = "invalid"
+        if isinstance(livraison, dict) and isinstance(livraison.get("envelope"), dict):
+            candidate = livraison["envelope"]
+            try:
+                idempotence_key = _text(candidate.get("idempotence_key"), "idempotence_key", 255)
+            except DeliveryEnvelopeError:
+                pass
+            try:
+                correlation_id = _text(candidate.get("correlation_id"), "correlation_id", 128)
+            except DeliveryEnvelopeError:
+                pass
+        return ConstruireAccuse("rejected", idempotence_key, correlation_id, str(error))
+
+    gestionnaire = UTILS_Interventions_Actual_Inbox.GestionnaireInboxRealise(db)
+    try:
+        resultat = gestionnaire.AppliquerMessage(
+            envelope["payload"],
+            envelope["idempotence_key"],
+            source_domain=envelope["source_domain"],
+            date_reception=date_reception,
+        )
+    except UTILS_Interventions_Actual_Inbox.ActualInboxError as error:
+        return ConstruireAccuse(
+            "rejected",
+            envelope["idempotence_key"],
+            envelope["correlation_id"],
+            str(error),
+        )
+
+    if resultat.get("replay") is True:
+        status = "replayed"
+    elif resultat.get("applique") is True:
+        status = "accepted"
+    else:
+        raise RuntimeError("résultat du consommateur de réalisé indéterminé")
+    return ConstruireAccuse(
+        status,
+        envelope["idempotence_key"],
+        envelope["correlation_id"],
+    )

--- a/tests/test_noe_062_inter_domain_delivery.py
+++ b/tests/test_noe_062_inter_domain_delivery.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+import hashlib
+import hmac
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NOETHYS = ROOT / "noethys"
+if str(NOETHYS) not in sys.path:
+    sys.path.insert(0, str(NOETHYS))
+
+
+def _charger_module(path, nom):
+    spec = importlib.util.spec_from_file_location(nom, str(ROOT / path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+DELIVERY = _charger_module(
+    "noethys/Utils/UTILS_Interdomain_Delivery.py",
+    "UTILS_Interdomain_Delivery_noe062_test",
+)
+FIXTURE = _charger_module(
+    "tests/test_noe_062_session_actual_inbox.py",
+    "test_noe_062_session_actual_inbox_fixture",
+)
+
+
+SECRET_A = b"a" * 32
+SECRET_B = b"b" * 32
+KEY_ID = "activity-2026-01"
+EXPECTED_VECTOR_SIGNATURE = "5465917b1e13104c0494c562c0458f0751c2fc9947d0c0a55dce82cf04adb5a5"
+
+
+def _signer(envelope, secret):
+    serialise = json.dumps(envelope, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hmac.new(secret, serialise.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def livraison(payload=None, secret=SECRET_A, key_id=KEY_ID, **overrides):
+    payload = payload or FIXTURE.payload_realise()
+    envelope = {
+        "envelope_version": "inter-domain-delivery/1",
+        "source_domain": "operations_portal",
+        "target_domain": "activity_users",
+        "contract_version": "session-actual/1",
+        "event_type": "session_actual_validated",
+        "idempotence_key": "session-actual:%s:r%d:activity_users" % (
+            payload["actual_uuid"], payload["actual_revision"]
+        ),
+        "correlation_id": payload["actual_uuid"],
+        "occurred_at": "2026-09-04T10:46:00Z",
+        "key_id": key_id,
+        "payload": payload,
+    }
+    envelope.update(overrides)
+    return {"envelope": envelope, "signature": _signer(envelope, secret)}
+
+
+class Noe062InterDomainDeliveryTests(unittest.TestCase):
+
+    def test_vecteur_hmac_est_identique_a_la_reference_portail(self):
+        signed = livraison()
+        self.assertEqual(EXPECTED_VECTOR_SIGNATURE, signed["signature"])
+        verified = DELIVERY.VerifierEnveloppe(signed, {KEY_ID: SECRET_A})
+        self.assertEqual("activity_users", verified["target_domain"])
+        self.assertEqual(FIXTURE.ACTUAL_UUID, verified["correlation_id"])
+        self.assertEqual(FIXTURE.payload_realise(), verified["payload"])
+
+    def test_payload_altere_apres_signature_est_refuse(self):
+        signed = livraison()
+        signed["envelope"]["payload"]["actual_revision"] = 5
+        with self.assertRaisesRegex(DELIVERY.DeliveryEnvelopeError, "signature HMAC invalide"):
+            DELIVERY.VerifierEnveloppe(signed, {KEY_ID: SECRET_A})
+
+    def test_mauvaise_cible_et_key_id_inconnu_sont_refuses(self):
+        wrong_target = livraison(target_domain="hr_employment")
+        with self.assertRaisesRegex(DELIVERY.DeliveryEnvelopeError, "domaine cible inattendu"):
+            DELIVERY.VerifierEnveloppe(wrong_target, {KEY_ID: SECRET_A})
+
+        signed = livraison()
+        with self.assertRaisesRegex(DELIVERY.DeliveryEnvelopeError, "key_id inconnu"):
+            DELIVERY.VerifierEnveloppe(signed, {"activity-old": SECRET_A})
+
+    def test_rotation_de_cle_accepte_chaque_secret_associe_a_son_key_id(self):
+        old = livraison(secret=SECRET_A, key_id="activity-old")
+        new = livraison(secret=SECRET_B, key_id="activity-new")
+        keyring = {"activity-old": SECRET_A, "activity-new": SECRET_B}
+        self.assertEqual("activity-old", DELIVERY.VerifierEnveloppe(old, keyring)["key_id"])
+        self.assertEqual("activity-new", DELIVERY.VerifierEnveloppe(new, keyring)["key_id"])
+
+    def test_livraison_valide_est_appliquee_puis_rejouee_sans_doublon(self):
+        db = FIXTURE._db_pret()
+        try:
+            signed = livraison()
+            first = DELIVERY.RecevoirLivraisonSignee(
+                db,
+                signed,
+                {KEY_ID: SECRET_A},
+                date_reception="2026-09-04 10:46:00",
+            )
+            second = DELIVERY.RecevoirLivraisonSignee(
+                db,
+                signed,
+                {KEY_ID: SECRET_A},
+                date_reception="2026-09-04 10:47:00",
+            )
+            self.assertEqual("accepted", first["status"])
+            self.assertEqual("replayed", second["status"])
+            self.assertEqual(first["idempotence_key"], second["idempotence_key"])
+            self.assertEqual(FIXTURE.ACTUAL_UUID, first["correlation_id"])
+            db.cursor.execute("SELECT COUNT(*) FROM interventions")
+            self.assertEqual(1, db.cursor.fetchone()[0])
+            db.cursor.execute("SELECT COUNT(*) FROM interventions_execution_inbox")
+            self.assertEqual(1, db.cursor.fetchone()[0])
+        finally:
+            db.Close()
+
+    def test_erreur_metier_deterministe_est_un_rejet_sans_ecriture(self):
+        db = FIXTURE._db_pret()
+        try:
+            invalid_payload = FIXTURE.payload_realise(actual_duration_minutes=91)
+            receipt = DELIVERY.RecevoirLivraisonSignee(
+                db,
+                livraison(payload=invalid_payload),
+                {KEY_ID: SECRET_A},
+                date_reception="2026-09-04 10:46:00",
+            )
+            self.assertEqual("rejected", receipt["status"])
+            self.assertIn("durée réelle incohérente", receipt["detail"])
+            db.cursor.execute("SELECT COUNT(*) FROM interventions_execution_inbox")
+            self.assertEqual(0, db.cursor.fetchone()[0])
+            db.cursor.execute("SELECT statut FROM interventions WHERE uid=?", (FIXTURE.SESSION_UID,))
+            self.assertEqual("planifiee", db.cursor.fetchone()[0])
+        finally:
+            db.Close()
+
+    def test_signature_invalide_produit_un_rejet_et_ne_touche_pas_la_base(self):
+        db = FIXTURE._db_pret()
+        try:
+            signed = livraison()
+            signed["signature"] = "0" * 64
+            receipt = DELIVERY.RecevoirLivraisonSignee(db, signed, {KEY_ID: SECRET_A})
+            self.assertEqual("rejected", receipt["status"])
+            self.assertIn("signature HMAC invalide", receipt["detail"])
+            db.cursor.execute("SELECT COUNT(*) FROM interventions_execution_inbox")
+            self.assertEqual(0, db.cursor.fetchone()[0])
+        finally:
+            db.Close()
+
+    def test_panne_technique_inattendue_n_est_pas_masquee_en_rejected(self):
+        signed = livraison()
+        with self.assertRaises(AttributeError):
+            DELIVERY.RecevoirLivraisonSignee(None, signed, {KEY_ID: SECRET_A})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Objectif

Ajouter l’adaptateur d’entrée ADR-012 côté domaine activité/usagers, sans imposer de transport physique.

## Chaîne

`inter-domain-delivery/1` signé → vérification source/cible/HMAC → payload `session-actual/1` → consommateur Noe-062 existant.

## Sécurité et contrat

- HMAC-SHA256 sur JSON canonique identique à Portail ;
- `source_domain = operations_portal` ;
- `target_domain = activity_users` ;
- rotation via `key_id` et keyring injecté ;
- aucun secret dans le dépôt ;
- contrat et type d’événement de l’enveloppe cohérents avec le payload ;
- signature comparée en temps constant ;
- aucune URL, aucun serveur HTTP, aucune migration.

## Accusés

- application métier → `accepted` ;
- replay exact → `replayed` ;
- erreur déterministe d’enveloppe ou de contrat → `rejected` ;
- panne technique inattendue volontairement propagée pour classification `retryable` par le futur transport physique.

## Recette

- vecteur HMAC partagé avec l’implémentation Portail ;
- altération de payload ;
- mauvaise cible / clé inconnue ;
- rotation de clé ;
- vrai passage SQLite jusqu’à `interventions_execution` ;
- replay sans doublon ;
- erreur métier sans écriture ;
- absence de masquage des pannes techniques.