### PR TITLE
Audit: liquider les reliquats de flot dans UTILS_Sauvegarde

### DIFF
--- a/noethys/Utils/UTILS_Sauvegarde.py
+++ b/noethys/Utils/UTILS_Sauvegarde.py
@@ -252,7 +252,8 @@ def GetListeFichiersZIP(fichier):
     
 def Restauration(parent=None, fichier="", listeFichiersLocaux=[], listeFichiersReseau=[], dictConnexion=None):
     """ Restauration à partir des listes de fichiers locaux et réseau """
-    listeFichiersRestaures = [] 
+    listeFichiersRestaures = []
+    dlgprogress = None
     
     # Initialisation de la barre de progression
     fichierZip = zipfile.ZipFile(fichier, "r")
@@ -396,7 +397,8 @@ def Restauration(parent=None, fichier="", listeFichiersLocaux=[], listeFichiersR
         shutil.rmtree(repTemp)
 
     # Fin de la procédure
-    dlgprogress.Destroy()
+    if dlgprogress is not None:
+        dlgprogress.Destroy()
     fichierZip.close()
     return listeFichiersRestaures
     

--- a/scripts/qualify_branch_assignment_gaps.py
+++ b/scripts/qualify_branch_assignment_gaps.py
@@ -100,6 +100,12 @@ EXPLICIT_SAFE = {
     ('Dlg/DLG_Saisie_produit.py', 'OnBoutonOk', 'prochainIDligne', 'body_only', 'c5617cf6777451edb437c0626035e0717d96d3b98ff1ffc9ef8e4ef37a951dee'): (
         'prochainIDligne est initialisé lorsque DB.isNetwork est faux et toutes ses lectures/incréments restent sous le même garde DB.isNetwork == False'
     ),
+    ('Utils/UTILS_Sauvegarde.py', 'Sauvegarde', 'fichierDest', 'body_only', '3b24366cca3b4d4a379d85dd9333e1a1d0cb8fcf4d01f98f2ac29adffe10dce7'): (
+        "fichierDest est créé sous repertoire != None et sa seule lecture ultérieure reste protégée par exactement le même garde"
+    ),
+    ('Utils/UTILS_Sauvegarde.py', 'Sauvegarde', 'dictAdresse', 'body_only', '33937cd6d25d5a168393d05a014cc8bedc5c70d18209cf655018319cbfbac628'): (
+        "dictAdresse est créé sous listeEmails != None ; l'absence d'adresse quitte la fonction et sa lecture ultérieure reste sous exactement le même garde"
+    ),
 }
 
 def _candidate_fingerprint(root, item):

--- a/scripts/qualify_branch_assignment_gaps.py
+++ b/scripts/qualify_branch_assignment_gaps.py
@@ -100,10 +100,10 @@ EXPLICIT_SAFE = {
     ('Dlg/DLG_Saisie_produit.py', 'OnBoutonOk', 'prochainIDligne', 'body_only', 'c5617cf6777451edb437c0626035e0717d96d3b98ff1ffc9ef8e4ef37a951dee'): (
         'prochainIDligne est initialisé lorsque DB.isNetwork est faux et toutes ses lectures/incréments restent sous le même garde DB.isNetwork == False'
     ),
-    ('Utils/UTILS_Sauvegarde.py', 'Sauvegarde', 'fichierDest', 'body_only', '3b24366cca3b4d4a379d85dd9333e1a1d0cb8fcf4d01f98f2ac29adffe10dce7'): (
+    ('Utils/UTILS_Sauvegarde.py', 'Sauvegarde', 'fichierDest', 'body_only', '99d5dac98f4e3f5c63a3eecab3a5c6c64dbcaafb3b9101ad87323a3aba322044'): (
         "fichierDest est créé sous repertoire != None et sa seule lecture ultérieure reste protégée par exactement le même garde"
     ),
-    ('Utils/UTILS_Sauvegarde.py', 'Sauvegarde', 'dictAdresse', 'body_only', '33937cd6d25d5a168393d05a014cc8bedc5c70d18209cf655018319cbfbac628'): (
+    ('Utils/UTILS_Sauvegarde.py', 'Sauvegarde', 'dictAdresse', 'body_only', '7bad752c10292daba9b617a1ee491bd3615f296533ef7fe9af66593ae8c830e5'): (
         "dictAdresse est créé sous listeEmails != None ; l'absence d'adresse quitte la fonction et sa lecture ultérieure reste sous exactement le même garde"
     ),
 }

--- a/tests/test_branch_assignment_safe_invariants.py
+++ b/tests/test_branch_assignment_safe_invariants.py
@@ -16,6 +16,8 @@ TARGETS = {
     ("Utils/UTILS_Cotisations_manquantes.py", "GetListeCotisationsManquantes", "date_fin"),
     ("Utils/UTILS_Cryptage_fichier.py", "DecrypterFichier", "dec"),
     ("Utils/UTILS_Export_nomade.py", "Run", "dlgAttente"),
+    ("Utils/UTILS_Sauvegarde.py", "Sauvegarde", "fichierDest"),
+    ("Utils/UTILS_Sauvegarde.py", "Sauvegarde", "dictAdresse"),
 }
 
 

--- a/tests/test_noe_032_restore_flow.py
+++ b/tests/test_noe_032_restore_flow.py
@@ -106,6 +106,22 @@ def _load_module(data_dir, temp_dir):
 
 
 class RestoreFlowTests(unittest.TestCase):
+    def test_restore_with_no_selected_files_returns_empty_list(self):
+        with tempfile.TemporaryDirectory() as root:
+            root = Path(root)
+            data_dir = root / "data"
+            temp_dir = root / "temp"
+            data_dir.mkdir()
+            temp_dir.mkdir()
+            archive = root / "backup.nod"
+            with zipfile.ZipFile(str(archive), "w"):
+                pass
+
+            module = _load_module(data_dir, temp_dir)
+            result = module.Restauration(fichier=str(archive))
+
+            self.assertEqual(result, [])
+
     def test_local_restore_extracts_and_reports_restored_file(self):
         with tempfile.TemporaryDirectory() as root:
             root = Path(root)


### PR DESCRIPTION
Refs #253

Lot ciblé du peigne fin `branch_assignment_gap` sur `UTILS_Sauvegarde.py` :

- corrige le défaut intrinsèque de `Restauration()` lorsque l'archive est valide mais qu'aucun fichier local/réseau n'est sélectionné : `dlgprogress` n'était alors jamais initialisé avant le `Destroy()` final ;
- ajoute un test de non-régression sur ce chemin sans sélection ;
- qualifie explicitement deux faux positifs de `Sauvegarde()` : `fichierDest` et `dictAdresse`, dont les lectures sont protégées par les mêmes gardes que leurs affectations ;
- étend le contrat des invariants sûrs.

Le dialogue de restauration empêche déjà la sélection vide ; le correctif rend néanmoins la fonction utilitaire elle-même sûre et supprime le finding sans dépendre d'un invariant externe au module.