### PR TITLE
Audit: sécuriser les contrats étiquettes et Noedoc

### DIFF
--- a/noethys/Dlg/DLG_Noedoc.py
+++ b/noethys/Dlg/DLG_Noedoc.py
@@ -3981,6 +3981,7 @@ class Panel_canvas(wx.Panel):
     def DeplacerObjet(self, objet, sens=None, newPosition=None):
         """ Déplacement d'un objet avec les touches """
         # Déplacement selon un sens
+        delta = None
         if sens != None :
             if sens == "haut" : delta = numpy.array([0, 1])
             if sens == "bas" : delta = numpy.array([0, -1])
@@ -3989,6 +3990,9 @@ class Panel_canvas(wx.Panel):
         # Déplacement selon une nouvelle position
         if hasattr(newPosition, "all"): #newPosition != None :
             delta = newPosition - objet.GetXY()
+        # Contrat d'entrée : il faut un sens reconnu ou une nouvelle position
+        if delta is None :
+            raise ValueError("DeplacerObjet nécessite un argument 'sens' valide (haut/bas/gauche/droite) ou 'newPosition'.")
         # Vérification si verrouillage de la position
         if objet.verrouillageX == True : delta[0] = 0
         if objet.verrouillageY == True : delta[1] = 0

--- a/noethys/Ol/OL_Etiquettes.py
+++ b/noethys/Ol/OL_Etiquettes.py
@@ -391,6 +391,7 @@ def GetListeFamilles(listview=None, listeActivites=None, presents=None, IDfamill
             cp = u""
             ville = u""
             listeMails = []
+            secteur = u""
         dictTemp = {
             "IDfamille" : IDfamille, "titulaires" : nomTitulaires, "nomRegime" : nomRegime, 
             "nomCaisse" : nomCaisse, "numAlloc" : numAlloc, "secteur": secteur,

--- a/tests/test_etiquettes_liste_familles_contract.py
+++ b/tests/test_etiquettes_liste_familles_contract.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import ast
+import types
+import unittest
+from pathlib import Path
+
+
+SOURCE = Path("noethys/Ol/OL_Etiquettes.py")
+
+
+def load_get_liste_familles(listeFamilles, titulaires):
+    tree = ast.parse(SOURCE.read_text(encoding="utf-8"))
+    fonction = next(
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "GetListeFamilles"
+    )
+    module = ast.Module(body=[fonction], type_ignores=[])
+    ast.fix_missing_locations(module)
+
+    class FakeDB:
+        def ExecuterReq(self, req):
+            return True
+
+        def ResultatReq(self):
+            return listeFamilles
+
+        def Close(self):
+            return None
+
+    def fake_track_famille(listview, donnees, infosIndividus):
+        return donnees
+
+    namespace = {
+        "GestionDB": types.SimpleNamespace(DB=FakeDB),
+        "FonctionsPerso": types.SimpleNamespace(GetIDfichier=lambda: 1),
+        "UTILS_Titulaires": types.SimpleNamespace(GetTitulaires=lambda: titulaires),
+        "TrackFamille": fake_track_famille,
+        "datetime": __import__("datetime"),
+        "_": lambda texte: texte,
+    }
+    exec(compile(module, str(SOURCE), "exec"), namespace)
+    return namespace["GetListeFamilles"]
+
+
+class EtiquettesListeFamillesContractTests(unittest.TestCase):
+    def test_famille_avec_titulaire_utilise_son_secteur(self):
+        fonction = load_get_liste_familles(
+            listeFamilles=[(10, "Regime", "Caisse", "123", None, None)],
+            titulaires={
+                10: {
+                    "titulairesSansCivilite": "Dupont",
+                    "adresse": {"rue": "Rue A", "cp": "75000", "ville": "Paris", "nomSecteur": "Nord"},
+                    "listeMails": [],
+                }
+            },
+        )
+
+        resultat = fonction()
+
+        self.assertEqual(resultat[0]["secteur"], "Nord")
+
+    def test_famille_sans_titulaire_ne_leve_pas_unboundlocalerror(self):
+        # Famille présente dans la requête mais absente du dictionnaire des titulaires
+        # (ex : famille sans rattachement de titulaire connu).
+        fonction = load_get_liste_familles(
+            listeFamilles=[(20, "Regime", "Caisse", "456", None, None)],
+            titulaires={},
+        )
+
+        resultat = fonction()
+
+        self.assertEqual(resultat[0]["secteur"], "")
+        self.assertEqual(resultat[0]["titulaires"], "Aucun titulaire")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_noedoc_deplacer_objet_contract.py
+++ b/tests/test_noedoc_deplacer_objet_contract.py
@@ -28,6 +28,10 @@ class Vector:
     def __getitem__(self, index):
         return self.values[index]
 
+    def all(self):
+        """Expose le marqueur historique utilisé pour reconnaître un ndarray."""
+        return all(self.values)
+
 
 class FakeNumpy:
     @staticmethod

--- a/tests/test_noedoc_deplacer_objet_contract.py
+++ b/tests/test_noedoc_deplacer_objet_contract.py
@@ -10,6 +10,31 @@ from pathlib import Path
 SOURCE = Path("noethys/Dlg/DLG_Noedoc.py")
 
 
+class Vector:
+    """Petit vecteur suffisant pour exercer DeplacerObjet sans dépendance numpy."""
+
+    def __init__(self, values):
+        self.values = list(values)
+
+    def __add__(self, other):
+        return Vector(a + b for a, b in zip(self.values, other.values))
+
+    def __sub__(self, other):
+        return Vector(a - b for a, b in zip(self.values, other.values))
+
+    def __iter__(self):
+        return iter(self.values)
+
+    def __getitem__(self, index):
+        return self.values[index]
+
+
+class FakeNumpy:
+    @staticmethod
+    def array(values):
+        return Vector(values)
+
+
 def load_deplacer_objet():
     tree = ast.parse(SOURCE.read_text(encoding="utf-8"))
     fonction = next(
@@ -21,7 +46,7 @@ def load_deplacer_objet():
     module = ast.Module(body=[fonction], type_ignores=[])
     ast.fix_missing_locations(module)
 
-    namespace = {"numpy": __import__("numpy")}
+    namespace = {"numpy": FakeNumpy}
     exec(compile(module, str(SOURCE), "exec"), namespace)
     return namespace["DeplacerObjet"]
 
@@ -74,25 +99,24 @@ class FakeSelf:
 class NoedocDeplacerObjetContractTests(unittest.TestCase):
     def setUp(self):
         self.fonction = load_deplacer_objet()
-        self.numpy = __import__("numpy")
 
     def test_deplacement_avec_sens_reconnu(self):
-        objet = FakeObjet(self.numpy.array([0, 0]))
+        objet = FakeObjet(Vector([0, 0]))
         self.fonction(FakeSelf(), objet, sens="haut")
         self.assertEqual(list(objet.GetXY()), [0, 1])
 
     def test_deplacement_avec_nouvelle_position(self):
-        objet = FakeObjet(self.numpy.array([0, 0]))
-        self.fonction(FakeSelf(), objet, newPosition=self.numpy.array([5, 5]))
+        objet = FakeObjet(Vector([0, 0]))
+        self.fonction(FakeSelf(), objet, newPosition=Vector([5, 5]))
         self.assertEqual(list(objet.GetXY()), [5, 5])
 
     def test_contrat_ambigu_sans_sens_ni_position_leve_une_erreur_explicite(self):
-        objet = FakeObjet(self.numpy.array([0, 0]))
+        objet = FakeObjet(Vector([0, 0]))
         with self.assertRaises(ValueError):
             self.fonction(FakeSelf(), objet)
 
     def test_sens_non_reconnu_leve_une_erreur_explicite(self):
-        objet = FakeObjet(self.numpy.array([0, 0]))
+        objet = FakeObjet(Vector([0, 0]))
         with self.assertRaises(ValueError):
             self.fonction(FakeSelf(), objet, sens="diagonale")
 

--- a/tests/test_noedoc_deplacer_objet_contract.py
+++ b/tests/test_noedoc_deplacer_objet_contract.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import ast
+import types
+import unittest
+from pathlib import Path
+
+
+SOURCE = Path("noethys/Dlg/DLG_Noedoc.py")
+
+
+def load_deplacer_objet():
+    tree = ast.parse(SOURCE.read_text(encoding="utf-8"))
+    fonction = next(
+        node for classe in ast.walk(tree)
+        if isinstance(classe, ast.ClassDef)
+        for node in classe.body
+        if isinstance(node, ast.FunctionDef) and node.name == "DeplacerObjet"
+    )
+    module = ast.Module(body=[fonction], type_ignores=[])
+    ast.fix_missing_locations(module)
+
+    namespace = {"numpy": __import__("numpy")}
+    exec(compile(module, str(SOURCE), "exec"), namespace)
+    return namespace["DeplacerObjet"]
+
+
+class FakeObjet:
+    def __init__(self, xy):
+        self._xy = xy
+        self.verrouillageX = False
+        self.verrouillageY = False
+        self.categorie = "texte"
+
+    def GetXY(self):
+        return self._xy
+
+    def Move(self, delta):
+        self._xy = self._xy + delta
+
+    def CalcBoundingBox(self):
+        pass
+
+
+class FakeCtrlPosition:
+    def SetX(self, x):
+        pass
+
+    def SetY(self, y):
+        pass
+
+
+class FakeCtrlProprietes:
+    def __init__(self):
+        self.ctrl_position = FakeCtrlPosition()
+
+    def SetObjet(self, objet):
+        pass
+
+
+class FakeCanvas:
+    def Draw(self, refresh):
+        pass
+
+
+class FakeSelf:
+    def __init__(self):
+        self.dictSelection = None
+        self.ctrl_proprietes = FakeCtrlProprietes()
+        self.canvas = FakeCanvas()
+
+
+class NoedocDeplacerObjetContractTests(unittest.TestCase):
+    def setUp(self):
+        self.fonction = load_deplacer_objet()
+        self.numpy = __import__("numpy")
+
+    def test_deplacement_avec_sens_reconnu(self):
+        objet = FakeObjet(self.numpy.array([0, 0]))
+        self.fonction(FakeSelf(), objet, sens="haut")
+        self.assertEqual(list(objet.GetXY()), [0, 1])
+
+    def test_deplacement_avec_nouvelle_position(self):
+        objet = FakeObjet(self.numpy.array([0, 0]))
+        self.fonction(FakeSelf(), objet, newPosition=self.numpy.array([5, 5]))
+        self.assertEqual(list(objet.GetXY()), [5, 5])
+
+    def test_contrat_ambigu_sans_sens_ni_position_leve_une_erreur_explicite(self):
+        objet = FakeObjet(self.numpy.array([0, 0]))
+        with self.assertRaises(ValueError):
+            self.fonction(FakeSelf(), objet)
+
+    def test_sens_non_reconnu_leve_une_erreur_explicite(self):
+        objet = FakeObjet(self.numpy.array([0, 0]))
+        with self.assertRaises(ValueError):
+            self.fonction(FakeSelf(), objet, sens="diagonale")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #320 #253

Deux défauts `branch_assignment_gap` à impact concret, repris proprement depuis le `master` courant :

- `Ol/OL_Etiquettes.py::GetListeFamilles — secteur` : une famille absente du dictionnaire des titulaires initialise désormais un secteur neutre comme les autres champs de repli, au lieu de pouvoir lire une variable locale absente ;
- `Dlg/DLG_Noedoc.py::DeplacerObjet — delta` : les quatre directions historiques et une `newPosition` valide restent inchangées ; un appel hors contrat lève désormais un `ValueError` explicite au lieu d'un `UnboundLocalError` tardif.

Tests comportementaux ciblés ajoutés pour les deux cas.

Le contenu utile est porté depuis l'ancienne #264 uniquement après vérification que les deux blobs source de sa base sont strictement identiques au `master` actuel ; aucune ancienne branche n'est utilisée comme base.