### PR TITLE
Audit: protéger les filtres de tarification en mode track

### DIFF
--- a/noethys/Dlg/DLG_Saisie_tarification.py
+++ b/noethys/Dlg/DLG_Saisie_tarification.py
@@ -431,7 +431,7 @@ class Dialog(wx.Dialog):
         if self.track_tarif != None :
             self.track_tarif.SetFiltres(liste_filtres)
 
-        if self.toolbook.GetPage("conditions") != None :
+        if self.track_tarif == None and self.toolbook.GetPage("conditions") != None :
             for dictInitialFiltre in self.toolbook.GetPage("conditions").GetListeInitialeFiltres() :
                 if dictInitialFiltre["IDfiltre"] not in listeID :
                     DB.ReqDEL("questionnaire_filtres", "IDfiltre", dictInitialFiltre["IDfiltre"])

--- a/tests/test_tarification_track_filter_delete.py
+++ b/tests/test_tarification_track_filter_delete.py
@@ -1,0 +1,93 @@
+import ast
+import copy
+from pathlib import Path
+import types
+import unittest
+
+
+SOURCE = Path("noethys/Dlg/DLG_Saisie_tarification.py")
+
+
+def load_sauvegarde():
+    tree = ast.parse(SOURCE.read_text(encoding="utf-8"))
+    dialog = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "Dialog")
+    method = next(node for node in dialog.body if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "Sauvegarde")
+    method = ast.fix_missing_locations(method)
+    module = ast.Module(body=[method], type_ignores=[])
+
+    class ForbiddenGestionDB:
+        @staticmethod
+        def DB():
+            raise AssertionError("La base ne doit pas être ouverte en mode track_tarif")
+
+    namespace = {"copy": copy, "GestionDB": ForbiddenGestionDB}
+    exec(compile(module, str(SOURCE), "exec"), namespace)
+    return namespace["Sauvegarde"]
+
+
+class Generalites:
+    def GetDateDebut(self): return None
+    def GetDateFin(self): return None
+    def GetDescription(self): return ""
+    def GetObservations(self): return ""
+    def GetCategories(self): return None
+    def GetTVA(self): return None
+    def GetCodeComptable(self): return None
+    def GetCPL(self): return None
+    def GetLabelPrestation(self): return None
+
+
+class Conditions:
+    def GetGroupes(self): return None
+    def GetEtiquettes(self): return None
+    def GetCotisations(self): return None
+    def GetCaisses(self): return None
+    def GetFiltres(self): return []
+    def GetPeriodes(self): return (None, None)
+    def GetListeInitialeFiltres(self):
+        return [{"IDfiltre": 41, "IDquestion": 3, "choix": "x", "criteres": "y"}]
+
+
+class Calcul:
+    def GetCodeMethode(self): return "montant_unique"
+    def GetTarifsCompatibles(self): return ["EVENEMENT"]
+    def GetTypeQuotient(self): return None
+
+
+class Toolbook:
+    def __init__(self):
+        self.pages = {"generalites": Generalites(), "conditions": Conditions(), "type": None, "calcul": Calcul()}
+    def GetPage(self, name):
+        return self.pages.get(name)
+
+
+class Track:
+    def __init__(self):
+        self.updated = None
+        self.filters = None
+    def MAJ(self, values):
+        self.updated = values
+    def SetFiltres(self, filters):
+        self.filters = filters
+
+
+class TarificationTrackFilterDeleteTest(unittest.TestCase):
+    def test_removing_initial_filter_in_track_mode_does_not_touch_database(self):
+        sauvegarde = load_sauvegarde()
+        track = Track()
+        dialog = types.SimpleNamespace(toolbook=Toolbook(), track_tarif=track, IDtarif=None)
+
+        result = sauvegarde(dialog)
+
+        self.assertIsNone(result)
+        self.assertIsNotNone(track.updated)
+        self.assertEqual(track.filters, [])
+
+    def test_database_filter_deletion_is_guarded_by_non_track_mode(self):
+        source = SOURCE.read_text(encoding="utf-8")
+        guarded = 'if self.track_tarif == None and self.toolbook.GetPage("conditions") != None :'
+        self.assertIn(guarded, source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #346
Relates #253

Le mode `track_tarif` est utilisé par les tarifs d'événements avec la page `conditions`. Dans ce mode, `Dialog.Sauvegarde` n'ouvre volontairement aucune connexion `DB`, mais la suppression d'un filtre initial absent de la nouvelle sélection appelait encore `DB.ReqDEL(...)` sans garde, ce qui rendait un `UnboundLocalError` réellement atteignable.

Correctif minimal : la suppression physique des filtres n'est exécutée que lorsque `self.track_tarif == None`, comme les insertions/mises à jour et la fermeture de la connexion. En mode track, la nouvelle liste reste portée par `track_tarif.SetFiltres(...)` et aucune base n'est touchée.

Régression ciblée : extraction/exécution réelle de `Dialog.Sauvegarde` avec un track, une page conditions et un filtre initial supprimé ; toute ouverture de `GestionDB.DB()` fait échouer le test. Le test vérifie aussi que le track reçoit bien une liste de filtres vide.

Le scanner conserve après correction le signal structurel `DB` (tous les accès sont désormais gardés) : il sera qualifié comme invariant sûr avec une empreinte AST post-correctif dans un lot de qualification ultérieur, plutôt que de masquer le défaut dans ce PR.