### PR TITLE
Noe-062 : protéger les secrets du client mailbox sous Windows

### DIFF
--- a/.github/workflows/interdomain-secrets-windows.yml
+++ b/.github/workflows/interdomain-secrets-windows.yml
@@ -1,0 +1,45 @@
+name: Secrets inter-domaines Windows
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'noethys/Utils/UTILS_Interdomain_Secrets.py'
+      - 'noethys/Utils/UTILS_Interdomain_Mailbox_Client.py'
+      - 'tests/test_noe_062_interdomain_secrets.py'
+      - '.github/workflows/interdomain-secrets-windows.yml'
+  push:
+    branches: [master]
+    paths:
+      - 'noethys/Utils/UTILS_Interdomain_Secrets.py'
+      - 'noethys/Utils/UTILS_Interdomain_Mailbox_Client.py'
+      - 'tests/test_noe_062_interdomain_secrets.py'
+      - '.github/workflows/interdomain-secrets-windows.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  credential-manager:
+    name: Windows Credential Manager
+    runs-on: windows-2022
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Python 3.11
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+
+      - name: Compiler le provider et le client mailbox
+        shell: pwsh
+        run: |
+          python -m py_compile noethys/Utils/UTILS_Interdomain_Secrets.py
+          python -m py_compile noethys/Utils/UTILS_Interdomain_Mailbox_Client.py
+
+      - name: Qualifier le coffre Windows réel
+        shell: pwsh
+        run: python -m unittest discover -s tests -p 'test_noe_062_interdomain_secrets.py' -v

--- a/noethys/Utils/UTILS_Interdomain_Mailbox_Client.py
+++ b/noethys/Utils/UTILS_Interdomain_Mailbox_Client.py
@@ -17,6 +17,7 @@ from urllib import request as urllib_request
 from urllib.parse import urlparse
 
 from Utils import UTILS_Interdomain_Delivery
+from Utils import UTILS_Interdomain_Secrets
 
 
 MAILBOX_VERSION = "inter-domain-mailbox-pull/1"
@@ -160,6 +161,25 @@ class TransportMailboxHTTP(object):
         if status not in UTILS_Interdomain_Delivery.ACK_STATUSES:
             raise MailboxTransportError("statut d'acquittement distant invalide")
         return result
+
+
+def ConstruireClientDepuisCoffre(base_url, key_ids, provider=None, timeout=20, opener=None):
+    """Construit transport + keyring sans faire transiter les secrets par Config.json.
+
+    ``base_url`` et ``key_ids`` sont des métadonnées non sensibles. Bearer et
+    matière HMAC sont chargés uniquement via le ``SecretProvider``.
+    """
+    provider = provider or UTILS_Interdomain_Secrets.DefaultSecretProvider()
+    try:
+        bearer, keyring = UTILS_Interdomain_Secrets.ChargerSecretsMailbox(provider, key_ids)
+    except UTILS_Interdomain_Secrets.SecretProviderError as error:
+        raise MailboxPullError("chargement des secrets mailbox impossible: %s" % error) from error
+    return TransportMailboxHTTP(
+        base_url,
+        bearer,
+        timeout=timeout,
+        opener=opener,
+    ), keyring
 
 
 def SynchroniserMailbox(db, transport, keyring, limit=20, date_reception=None):

--- a/noethys/Utils/UTILS_Interdomain_Secrets.py
+++ b/noethys/Utils/UTILS_Interdomain_Secrets.py
@@ -69,10 +69,10 @@ class UnavailableSecretProvider(SecretProvider):
 def _logical_name(value):
     if not isinstance(value, str):
         raise SecretProviderError("nom logique de secret obligatoire")
-    value = value.strip()
-    if not _NAME_RE.match(value):
+    normalized = value.strip()
+    if value != normalized or not _NAME_RE.match(normalized):
         raise SecretProviderError("nom logique de secret invalide")
-    return value
+    return normalized
 
 
 def _namespace(value):

--- a/noethys/Utils/UTILS_Interdomain_Secrets.py
+++ b/noethys/Utils/UTILS_Interdomain_Secrets.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Stockage local protégé des secrets inter-domaines.
+
+Le contrat ``SecretProvider`` isole le client mailbox du mécanisme de coffre.
+Le premier backend utilise Windows Credential Manager via ``ctypes`` : aucun
+secret n'est écrit dans Config.json, dans sa sauvegarde .bak ou dans le dépôt.
+
+Le namespace et les noms logiques ne sont pas des secrets. Le backend peut être
+remplacé plus tard (keyring système, HSM, identité de workload...) sans modifier
+les contrats ADR-012/ADR-013 ni le client pull.
+"""
+from __future__ import unicode_literals
+
+import ctypes
+from ctypes import wintypes
+import re
+import sys
+
+
+DEFAULT_NAMESPACE = "org.pelemele.inter-domain"
+CRED_TYPE_GENERIC = 1
+CRED_PERSIST_LOCAL_MACHINE = 2
+ERROR_NOT_FOUND = 1168
+MAX_SECRET_BYTES = 2048
+_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,191}$")
+
+
+class SecretProviderError(RuntimeError):
+    pass
+
+
+class SecretProviderUnavailable(SecretProviderError):
+    pass
+
+
+class SecretProvider(object):
+    """Interface minimale d'un coffre de secrets local."""
+
+    def get(self, name):
+        raise NotImplementedError
+
+    def set(self, name, secret):
+        raise NotImplementedError
+
+    def delete(self, name):
+        raise NotImplementedError
+
+
+class UnavailableSecretProvider(SecretProvider):
+    """Backend fail-closed pour un environnement sans coffre supporté."""
+
+    def __init__(self, reason="coffre de secrets indisponible"):
+        self.reason = str(reason)
+
+    def _raise(self):
+        raise SecretProviderUnavailable(self.reason)
+
+    def get(self, name):
+        self._raise()
+
+    def set(self, name, secret):
+        self._raise()
+
+    def delete(self, name):
+        self._raise()
+
+
+def _logical_name(value):
+    if not isinstance(value, str):
+        raise SecretProviderError("nom logique de secret obligatoire")
+    value = value.strip()
+    if not _NAME_RE.match(value):
+        raise SecretProviderError("nom logique de secret invalide")
+    return value
+
+
+def _namespace(value):
+    value = _logical_name(value)
+    if len(value) > 128:
+        raise SecretProviderError("namespace de secrets trop long")
+    return value.rstrip("/")
+
+
+def _secret_bytes(value):
+    if not isinstance(value, str):
+        raise SecretProviderError("secret texte obligatoire")
+    if not value or any(ord(character) < 32 for character in value):
+        raise SecretProviderError("secret texte invalide")
+    encoded = value.encode("utf-8")
+    if len(encoded) > MAX_SECRET_BYTES:
+        raise SecretProviderError("secret trop long")
+    return encoded
+
+
+if sys.platform == "win32":
+    class FILETIME(ctypes.Structure):
+        _fields_ = [
+            ("dwLowDateTime", wintypes.DWORD),
+            ("dwHighDateTime", wintypes.DWORD),
+        ]
+
+
+    class CREDENTIALW(ctypes.Structure):
+        _fields_ = [
+            ("Flags", wintypes.DWORD),
+            ("Type", wintypes.DWORD),
+            ("TargetName", wintypes.LPWSTR),
+            ("Comment", wintypes.LPWSTR),
+            ("LastWritten", FILETIME),
+            ("CredentialBlobSize", wintypes.DWORD),
+            ("CredentialBlob", ctypes.POINTER(ctypes.c_ubyte)),
+            ("Persist", wintypes.DWORD),
+            ("AttributeCount", wintypes.DWORD),
+            ("Attributes", ctypes.c_void_p),
+            ("TargetAlias", wintypes.LPWSTR),
+            ("UserName", wintypes.LPWSTR),
+        ]
+
+
+    PCREDENTIALW = ctypes.POINTER(CREDENTIALW)
+else:
+    FILETIME = None
+    CREDENTIALW = None
+    PCREDENTIALW = None
+
+
+class WindowsCredentialManagerProvider(SecretProvider):
+    """Coffre utilisateur Windows Credential Manager, sans dépendance pywin32."""
+
+    def __init__(self, namespace=DEFAULT_NAMESPACE, api=None):
+        if sys.platform != "win32" and api is None:
+            raise SecretProviderUnavailable("Windows Credential Manager indisponible sur cette plateforme")
+        self.namespace = _namespace(namespace)
+        self._api = api or self._load_api()
+
+    @staticmethod
+    def _load_api():
+        try:
+            library = ctypes.WinDLL("Advapi32.dll", use_last_error=True)
+        except Exception as error:
+            raise SecretProviderUnavailable("Windows Credential Manager indisponible") from error
+
+        library.CredWriteW.argtypes = [ctypes.POINTER(CREDENTIALW), wintypes.DWORD]
+        library.CredWriteW.restype = wintypes.BOOL
+        library.CredReadW.argtypes = [
+            wintypes.LPCWSTR,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            ctypes.POINTER(PCREDENTIALW),
+        ]
+        library.CredReadW.restype = wintypes.BOOL
+        library.CredDeleteW.argtypes = [wintypes.LPCWSTR, wintypes.DWORD, wintypes.DWORD]
+        library.CredDeleteW.restype = wintypes.BOOL
+        library.CredFree.argtypes = [ctypes.c_void_p]
+        library.CredFree.restype = None
+        return library
+
+    def _target(self, name):
+        return "%s/%s" % (self.namespace, _logical_name(name))
+
+    @staticmethod
+    def _last_error():
+        return ctypes.get_last_error()
+
+    def get(self, name):
+        target = self._target(name)
+        pointer = PCREDENTIALW()
+        if not self._api.CredReadW(target, CRED_TYPE_GENERIC, 0, ctypes.byref(pointer)):
+            error = self._last_error()
+            if error == ERROR_NOT_FOUND:
+                return None
+            raise SecretProviderError("lecture du coffre Windows impossible (code %s)" % error)
+        try:
+            credential = pointer.contents
+            size = int(credential.CredentialBlobSize)
+            if size < 1 or size > MAX_SECRET_BYTES:
+                raise SecretProviderError("taille du secret Windows invalide")
+            raw = ctypes.string_at(credential.CredentialBlob, size)
+            try:
+                return raw.decode("utf-8")
+            except UnicodeDecodeError as error:
+                raise SecretProviderError("secret Windows non UTF-8") from error
+        finally:
+            self._api.CredFree(pointer)
+
+    def set(self, name, secret):
+        target = self._target(name)
+        encoded = _secret_bytes(secret)
+        blob = (ctypes.c_ubyte * len(encoded)).from_buffer_copy(encoded)
+        credential = CREDENTIALW()
+        credential.Flags = 0
+        credential.Type = CRED_TYPE_GENERIC
+        credential.TargetName = target
+        credential.Comment = "PMSL inter-domain secret"
+        credential.CredentialBlobSize = len(encoded)
+        credential.CredentialBlob = ctypes.cast(blob, ctypes.POINTER(ctypes.c_ubyte))
+        credential.Persist = CRED_PERSIST_LOCAL_MACHINE
+        credential.AttributeCount = 0
+        credential.Attributes = None
+        credential.TargetAlias = None
+        credential.UserName = self.namespace
+        if not self._api.CredWriteW(ctypes.byref(credential), 0):
+            error = self._last_error()
+            raise SecretProviderError("écriture du coffre Windows impossible (code %s)" % error)
+        return True
+
+    def delete(self, name):
+        target = self._target(name)
+        if self._api.CredDeleteW(target, CRED_TYPE_GENERIC, 0):
+            return True
+        error = self._last_error()
+        if error == ERROR_NOT_FOUND:
+            return False
+        raise SecretProviderError("suppression du coffre Windows impossible (code %s)" % error)
+
+
+def DefaultSecretProvider(namespace=DEFAULT_NAMESPACE):
+    """Retourne le coffre natif supporté ou un provider explicitement indisponible."""
+    if sys.platform == "win32":
+        return WindowsCredentialManagerProvider(namespace=namespace)
+    return UnavailableSecretProvider("aucun backend de secrets local supporté sur cette plateforme")
+
+
+# Noms logiques du vertical actuel. Ils ne contiennent ni produit ni hostname.
+MAILBOX_BEARER = "mailbox/operations_portal/activity_users/bearer"
+HMAC_PREFIX = "delivery/operations_portal/activity_users/hmac/"
+
+
+def HmacSecretName(key_id):
+    key_id = _logical_name(key_id)
+    return HMAC_PREFIX + key_id

--- a/noethys/Utils/UTILS_Interdomain_Secrets.py
+++ b/noethys/Utils/UTILS_Interdomain_Secrets.py
@@ -230,3 +230,34 @@ HMAC_PREFIX = "delivery/operations_portal/activity_users/hmac/"
 def HmacSecretName(key_id):
     key_id = _logical_name(key_id)
     return HMAC_PREFIX + key_id
+
+
+def ChargerSecretsMailbox(provider, key_ids):
+    """Charge séparément le bearer du canal et les clés HMAC ADR-012.
+
+    Les clés HMAC sont stockées comme texte de forte entropie puis converties en
+    bytes au dernier moment pour l'adaptateur de livraison. Aucun fallback vers
+    Config.json ou une variable vide n'est autorisé.
+    """
+    if provider is None or not callable(getattr(provider, "get", None)):
+        raise SecretProviderError("SecretProvider invalide")
+    if not isinstance(key_ids, (tuple, list)) or not key_ids:
+        raise SecretProviderError("au moins un key_id HMAC est requis")
+
+    bearer = provider.get(MAILBOX_BEARER)
+    if not isinstance(bearer, str) or not bearer:
+        raise SecretProviderError("bearer mailbox absent du coffre")
+
+    keyring = {}
+    for raw_key_id in key_ids:
+        key_id = _logical_name(raw_key_id)
+        if key_id in keyring:
+            raise SecretProviderError("key_id HMAC dupliqué")
+        secret = provider.get(HmacSecretName(key_id))
+        if not isinstance(secret, str) or not secret:
+            raise SecretProviderError("secret HMAC absent du coffre pour %s" % key_id)
+        encoded = secret.encode("utf-8")
+        if len(encoded) < 32:
+            raise SecretProviderError("secret HMAC trop court pour %s" % key_id)
+        keyring[key_id] = encoded
+    return bearer, keyring

--- a/tests/test_noe_062_interdomain_secrets.py
+++ b/tests/test_noe_062_interdomain_secrets.py
@@ -9,6 +9,7 @@ NOETHYS = ROOT / "noethys"
 sys.path.insert(0, str(NOETHYS))
 
 from Utils import UTILS_Interdomain_Secrets as secrets
+from Utils import UTILS_Interdomain_Mailbox_Client as mailbox_client
 
 
 class MemoryProvider(secrets.SecretProvider):
@@ -60,6 +61,21 @@ class InterdomainSecretsTests(unittest.TestCase):
         self.assertEqual(keyring["kid-1"], b"h" * 32)
         self.assertEqual(keyring["kid-2"], b"j" * 48)
         self.assertNotEqual(bearer.encode("utf-8"), keyring["kid-1"])
+
+    def test_mailbox_client_is_built_from_vault_only(self):
+        provider = MemoryProvider()
+        provider.set(secrets.MAILBOX_BEARER, "mbx1.token.from-vault")
+        provider.set(secrets.HmacSecretName("kid-1"), "k" * 32)
+
+        transport, keyring = mailbox_client.ConstruireClientDepuisCoffre(
+            "https://portal.example.test",
+            ["kid-1"],
+            provider=provider,
+        )
+
+        self.assertEqual(transport.base_url, "https://portal.example.test")
+        self.assertEqual(transport.bearer_token, "mbx1.token.from-vault")
+        self.assertEqual(keyring, {"kid-1": b"k" * 32})
 
     def test_missing_or_weak_secret_fails_closed(self):
         provider = MemoryProvider()

--- a/tests/test_noe_062_interdomain_secrets.py
+++ b/tests/test_noe_062_interdomain_secrets.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import sys
+import unittest
+from uuid import uuid4
+
+ROOT = Path(__file__).resolve().parents[1]
+NOETHYS = ROOT / "noethys"
+sys.path.insert(0, str(NOETHYS))
+
+from Utils import UTILS_Interdomain_Secrets as secrets
+
+
+class MemoryProvider(secrets.SecretProvider):
+    def __init__(self):
+        self.values = {}
+
+    def get(self, name):
+        return self.values.get(name)
+
+    def set(self, name, secret):
+        self.values[name] = secret
+        return True
+
+    def delete(self, name):
+        return self.values.pop(name, None) is not None
+
+
+class InterdomainSecretsTests(unittest.TestCase):
+    def test_logical_names_are_stable_and_product_agnostic(self):
+        self.assertEqual(
+            secrets.MAILBOX_BEARER,
+            "mailbox/operations_portal/activity_users/bearer",
+        )
+        self.assertEqual(
+            secrets.HmacSecretName("activity-2026-09"),
+            "delivery/operations_portal/activity_users/hmac/activity-2026-09",
+        )
+        for forbidden in ("noethys", "connecthys", "teamworks"):
+            self.assertNotIn(forbidden, secrets.MAILBOX_BEARER.lower())
+            self.assertNotIn(forbidden, secrets.HMAC_PREFIX.lower())
+
+    def test_invalid_names_and_plaintext_controls_are_rejected(self):
+        for name in ("", " space", "../escape", "bad?name", "x" * 193):
+            with self.assertRaises(secrets.SecretProviderError):
+                secrets._logical_name(name)
+        for value in ("", "secret\nleak"):
+            with self.assertRaises(secrets.SecretProviderError):
+                secrets._secret_bytes(value)
+
+    def test_mailbox_secrets_are_loaded_separately(self):
+        provider = MemoryProvider()
+        provider.set(secrets.MAILBOX_BEARER, "mbx1.token.secret-value")
+        provider.set(secrets.HmacSecretName("kid-1"), "h" * 32)
+        provider.set(secrets.HmacSecretName("kid-2"), "j" * 48)
+
+        bearer, keyring = secrets.ChargerSecretsMailbox(provider, ["kid-1", "kid-2"])
+
+        self.assertEqual(bearer, "mbx1.token.secret-value")
+        self.assertEqual(keyring["kid-1"], b"h" * 32)
+        self.assertEqual(keyring["kid-2"], b"j" * 48)
+        self.assertNotEqual(bearer.encode("utf-8"), keyring["kid-1"])
+
+    def test_missing_or_weak_secret_fails_closed(self):
+        provider = MemoryProvider()
+        with self.assertRaisesRegex(secrets.SecretProviderError, "bearer mailbox absent"):
+            secrets.ChargerSecretsMailbox(provider, ["kid-1"])
+
+        provider.set(secrets.MAILBOX_BEARER, "bearer")
+        provider.set(secrets.HmacSecretName("kid-1"), "short")
+        with self.assertRaisesRegex(secrets.SecretProviderError, "HMAC trop court"):
+            secrets.ChargerSecretsMailbox(provider, ["kid-1"])
+
+    def test_non_windows_default_provider_is_fail_closed(self):
+        if sys.platform == "win32":
+            self.skipTest("test réservé aux plateformes non-Windows")
+        provider = secrets.DefaultSecretProvider()
+        with self.assertRaises(secrets.SecretProviderUnavailable):
+            provider.get(secrets.MAILBOX_BEARER)
+
+    @unittest.skipUnless(sys.platform == "win32", "Windows Credential Manager requis")
+    def test_windows_credential_manager_roundtrip(self):
+        namespace = "org.pelemele.test.%s" % uuid4().hex
+        provider = secrets.WindowsCredentialManagerProvider(namespace=namespace)
+        name = "mailbox/test/bearer"
+        value = "credential-%s" % uuid4().hex
+        try:
+            self.assertIsNone(provider.get(name))
+            self.assertTrue(provider.set(name, value))
+            self.assertEqual(provider.get(name), value)
+            self.assertTrue(provider.delete(name))
+            self.assertIsNone(provider.get(name))
+            self.assertFalse(provider.delete(name))
+        finally:
+            try:
+                provider.delete(name)
+            except secrets.SecretProviderError:
+                pass
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Ajoute le premier `SecretProvider` d’exploitation pour le client pull inter-domaines Noethys.

Principes :
- aucun bearer ni secret HMAC dans `Config.json`, sa sauvegarde `.bak`, les arguments ou le dépôt ;
- abstraction `SecretProvider` remplaçable ;
- premier backend : Windows Credential Manager via `ctypes`, sans dépendance pywin32/keyring ;
- stockage lié au profil utilisateur Windows et persistant sur la machine ;
- noms logiques stables par domaines (`operations_portal` → `activity_users`), sans nom de produit ni hostname ;
- bearer du canal et matière HMAC ADR-012 stockés séparément ;
- backend non-Windows fail-closed, sans fallback en clair ;
- `ConstruireClientDepuisCoffre()` ne reçoit que les métadonnées non sensibles (`base_url`, `key_ids`) et charge bearer/keyring via le provider.

Qualification :
- tests portables du contrat/fail-closed ;
- vraie recette Windows `set → get → delete` dans Credential Manager avec namespace éphémère ;
- workflow Windows dédié déclenché sur PR/push des fichiers concernés.

Le vieux chiffrement AES/MD5 de Noethys n’est pas réutilisé pour ces nouveaux secrets.