### PR TITLE
Vanilla — afficher directement la liste et verrouiller le thème clair

### DIFF
--- a/.github/workflows/windows-package-master.yml
+++ b/.github/workflows/windows-package-master.yml
@@ -9,6 +9,9 @@ on:
       - master
     paths:
       - 'noethys/Utils/UTILS_Fichiers.py'
+      - 'noethys/Utils/UTILS_Config.py'
+      - 'noethys/Ctrl/CTRL_Recherche_individus.py'
+      - 'noethys/Dlg/DLG_Echelle_interface.py'
       - 'packaging/**'
       - 'requirements*.txt'
       - 'tests/test_noe_041_portable_paths.py'

--- a/docs/VANILLA_STABILISATION.md
+++ b/docs/VANILLA_STABILISATION.md
@@ -1,0 +1,51 @@
+# Stabilisation Vanilla — décisions de recette humaine
+
+## Statut
+
+**VALIDATION MANUELLE REQUISE** — ne pas taguer Vanilla stable avant une nouvelle recette humaine Windows du candidat issu de cette stabilisation.
+
+Le candidat précédent `74d25fdd8431eb7a167ab35cab8e1e8aa4e3bdc9` reste la référence des qualifications acquises avant ces corrections UX, mais il est remplacé pour la poursuite de la recette.
+
+## Décisions UX issues de la recette humaine
+
+- **Thème sombre rejeté en recette humaine.**
+- **Thème clair retenu** pour Vanilla.
+- **Comportement « Voir tout » rejeté** sur la recherche individus/familles de l'accueil.
+- **Décision : retour à l'affichage direct de la liste complète** quand aucun texte de recherche n'est saisi.
+- **Suivi automatique du thème système désactivé pour Vanilla.**
+- **Thème sombre wxPython / widgets wx temporairement non supporté** tant qu'un rendu sombre cohérent n'a pas été conçu et validé.
+
+## Périmètre technique de la correction
+
+### Liste d'accueil
+
+Le composant concerné est `noethys/Ctrl/CTRL_Recherche_individus.py`, dans `BarreRechercheAccueil.Recherche` et le bouton `ctrl_voir_tout` du `Panel`.
+
+Avant correction, une recherche vide vidait les objets affichés et basculait vers un état d'attente ; le bouton « Voir tout » réinjectait ensuite `listView.donnees`. La stabilisation supprime cette étape intermédiaire : une recherche vide affiche directement `listView.donnees`.
+
+Le chargement reste exclusivement assuré par `ctrl_listview.MAJ(forceActualisation=True)` dans `Panel.MAJ`. La recherche, ses critères, sa limite de résultats, les actions disponibles et la logique métier ne sont pas modifiés.
+
+### Thème clair Vanilla
+
+La préférence active `interface_apparence` est forcée à `clair` par la couche de configuration UI. Sur Windows, l'option wxMSW `msw.dark-mode` est explicitement positionnée à `0` avant la création de `wx.App`, afin que le rendu natif wx ne suive pas le mode sombre Windows.
+
+Le dialogue d'apparence reste présent pour l'échelle, la taille du texte et la couleur d'accent, mais le choix d'apparence est désactivé et conserve `clair` comme valeur active. Les palettes sombres et les upgrades techniques existants ne sont pas supprimés : ils sont simplement non activables dans la baseline Vanilla.
+
+Les listes, AUI, champs de saisie et boutons continuent de consommer les rôles sémantiques existants. Les menus restent natifs wx ; avec le dark mode wxMSW désactivé, ils restent sur le rendu clair. La lisibilité visuelle finale de ces composants doit être confirmée pendant la nouvelle recette humaine Windows, y compris lorsque Windows lui-même est configuré en mode sombre.
+
+## Invariants hors périmètre
+
+- aucune modification de logique métier ;
+- aucune modification du chargement des données ;
+- aucune modification de schéma de base de données ;
+- aucun changement de format de données ;
+- aucun changement de protocole ou de comportement Connecthys ;
+- compatibilité avec le Connecthys d'Ivan conservée par non-modification de ces interfaces ;
+- aucun revert global des commits UI ;
+- thème clair actuel et upgrades techniques conservés.
+
+## Validation attendue
+
+Les contrats automatisés doivent vérifier l'affichage direct de `listView.donnees`, l'absence du contrôle/méthode « Voir tout », la conservation du chargement métier existant, le verrouillage de l'apparence claire et le routage sémantique clair des principaux widgets.
+
+Après CI et packaging Windows verts, une nouvelle recette humaine doit confirmer sur Windows réel : liste complète immédiatement visible, recherche/actions inchangées, thème clair même lorsque Windows est sombre, lisibilité des listes/AUI/champs/boutons/menus, puis les contrôles métier/backup-restauration déjà prévus sur une copie réelle de base.

--- a/noethys/Ctrl/CTRL_Recherche_individus.py
+++ b/noethys/Ctrl/CTRL_Recherche_individus.py
@@ -202,9 +202,14 @@ class BarreRechercheAccueil(OL_Individus.BarreRecherche):
         self.ShowCancelButton(bool(texte))
 
         if not texte:
-            self.listView.SetObjects([])
-            self._MajResume("", 0)
-            self.parent.AfficherEtatVide()
+            # La liste est déjà chargée par ListeIndividusAccueil/MAJ : une
+            # recherche vide affiche directement toutes ces données, sans
+            # étape « Voir tout » et sans relancer le chargement métier.
+            self.listView.SetObjects(self.listView.donnees)
+            self.parent.ctrl_resume.SetLabel(
+                _(u"%d individu(s) · liste complète") % len(self.listView.donnees)
+            )
+            self.parent.AfficherResultats()
             self.listView.Refresh()
             return
 
@@ -237,20 +242,6 @@ class BarreRechercheAccueil(OL_Individus.BarreRecherche):
         self.listView.SelectObject(track)
         self.listView.OuvrirFicheFamille(track)
         self.ouvrir_fiche = False
-
-    def AfficherTout(self):
-        self.InvaliderIndex()
-        try:
-            self.ChangeValue("")
-        except Exception:
-            self.SetValue("")
-        if self.timer.IsRunning():
-            self.timer.Stop()
-        self.ShowCancelButton(False)
-        self.listView.SetObjects(self.listView.donnees)
-        self.parent.ctrl_resume.SetLabel(_(u"%d individu(s) · liste complète") % len(self.listView.donnees))
-        self.parent.AfficherResultats()
-        self.listView.Refresh()
 
 
 class BarreCommandes(wx.Panel):
@@ -375,10 +366,6 @@ class Panel(wx.Panel):
         )
         self.ctrl_recherche = BarreRechercheAccueil(self)
 
-        self.ctrl_voir_tout = CTRL_ActionRepens.CTRL(
-            self, label=_(u"Voir tout"), icone="people", variante="ghost",
-            tooltip=_(u"Afficher toute la liste"),
-        )
         self.ctrl_email = CTRL_ActionRepens.CTRL(
             self, label=u"", icone="mail", variante="secondaire",
             tooltip=_(u"Envoyer un email"),
@@ -395,7 +382,6 @@ class Panel(wx.Panel):
         self.ctrl_commandes = BarreCommandes(self)
         self.ctrl_indication = IndicationRecherche(self)
 
-        self.ctrl_voir_tout.Bind(wx.EVT_BUTTON, lambda evt: self.ctrl_recherche.AfficherTout())
         self.ctrl_email.Bind(wx.EVT_BUTTON, self.OnEmail)
         self.ctrl_sms.Bind(wx.EVT_BUTTON, self.OnSMS)
         self.ctrl_nouvelle_famille.Bind(wx.EVT_BUTTON, lambda evt: self.ctrl_listview.Ajouter(None))
@@ -404,7 +390,7 @@ class Panel(wx.Panel):
 
         self.__do_layout()
         self.ActualiseParametresAffichage()
-        wx.CallAfter(self.AfficherEtatVide)
+        wx.CallAfter(self.ctrl_recherche.Recherche)
         wx.CallAfter(self._ConfigurerPaneAui)
 
     def __do_layout(self):
@@ -416,7 +402,6 @@ class Panel(wx.Panel):
         entete = wx.BoxSizer(wx.HORIZONTAL)
         entete.Add(self.ctrl_resume, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, marge)
         entete.Add(self.ctrl_recherche, 1, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, petit)
-        entete.Add(self.ctrl_voir_tout, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, petit)
         entete.Add(self.ctrl_email, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, petit)
         entete.Add(self.ctrl_sms, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, petit)
         entete.Add(self.ctrl_nouvelle_famille, 0, wx.ALIGN_CENTER_VERTICAL)

--- a/noethys/Dlg/DLG_Echelle_interface.py
+++ b/noethys/Dlg/DLG_Echelle_interface.py
@@ -19,11 +19,11 @@ class Apercu(wx.Panel):
         self.SetMinSize((500, 205))
         self.echelle = 100
         self.taille_texte = 100
-        self.apparence = "systeme"
+        self.apparence = "clair"
         self.theme = "Vert"
         self.Bind(wx.EVT_PAINT, self.OnPaint)
 
-    def SetValeurs(self, echelle=100, taille_texte=100, apparence="systeme", theme="Vert"):
+    def SetValeurs(self, echelle=100, taille_texte=100, apparence="clair", theme="Vert"):
         self.echelle = echelle
         self.taille_texte = taille_texte
         self.apparence = apparence
@@ -128,11 +128,14 @@ class Dialog(wx.Dialog):
             style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER,
         )
 
-        # Apparence
+        # Apparence. Vanilla reste temporairement verrouillé en clair : les
+        # autres valeurs historiques sont conservées pour une réactivation
+        # future mais ne sont pas sélectionnables dans cette baseline.
         self.liste_codes_apparence = [code for code, label in UTILS_Interface.APPARENCES]
         self.liste_labels_apparence = [label for code, label in UTILS_Interface.APPARENCES]
         self.label_apparence = wx.StaticText(self, -1, _(u"Apparence :"))
         self.ctrl_apparence = wx.Choice(self, -1, choices=self.liste_labels_apparence)
+        self.ctrl_apparence.Enable(False)
 
         # Couleur d'accent / thème historique Noethys
         self.liste_codes_theme = [code for code, label in UTILS_Interface.THEMES]
@@ -156,7 +159,11 @@ class Dialog(wx.Dialog):
             choices=[u"%d %%" % valeur for valeur in UTILS_Interface.TAILLES_TEXTE],
         )
 
-        self.info_systeme = wx.StaticText(self, -1, "")
+        self.info_systeme = wx.StaticText(
+            self,
+            -1,
+            _(u"Vanilla utilise temporairement le thème clair ; le thème système et le mode sombre ne sont pas activés."),
+        )
         self.info_accessibilite = wx.StaticText(
             self,
             -1,
@@ -241,14 +248,14 @@ class Dialog(wx.Dialog):
 
     def GetValeurs(self):
         return {
-            "apparence": self.liste_codes_apparence[self.ctrl_apparence.GetSelection()],
+            "apparence": UTILS_Interface.GetApparence(),
             "theme": self.liste_codes_theme[self.ctrl_theme.GetSelection()],
             "echelle": UTILS_Interface.ECHELLES[self.ctrl_echelle.GetSelection()],
             "taille_texte": UTILS_Interface.TAILLES_TEXTE[self.ctrl_texte.GetSelection()],
         }
 
     def OnValeursDefaut(self, event):
-        self.ctrl_apparence.SetSelection(self.liste_codes_apparence.index("systeme"))
+        self.ctrl_apparence.SetSelection(self.liste_codes_apparence.index("clair"))
         self.ctrl_theme.SetSelection(self.liste_codes_theme.index("Vert"))
         self.ctrl_echelle.SetSelection(UTILS_Interface.ECHELLES.index(100))
         self.ctrl_texte.SetSelection(UTILS_Interface.TAILLES_TEXTE.index(100))
@@ -261,11 +268,9 @@ class Dialog(wx.Dialog):
     def MAJaperçu(self):
         valeurs = self.GetValeurs()
         self.apercu.SetValeurs(**valeurs)
-        if valeurs["apparence"] == "systeme":
-            etat = _(u"sombre") if UTILS_Interface.SystemeEstSombre() else _(u"clair")
-            self.info_systeme.SetLabel(_(u"Mode système détecté actuellement : %s.") % etat)
-        else:
-            self.info_systeme.SetLabel("")
+        self.info_systeme.SetLabel(
+            _(u"Vanilla utilise temporairement le thème clair ; le thème système et le mode sombre ne sont pas activés.")
+        )
         self.Layout()
 
 

--- a/noethys/Utils/UTILS_Config.py
+++ b/noethys/Utils/UTILS_Config.py
@@ -20,6 +20,20 @@ from Utils import UTILS_Fichiers
 from Utils import UTILS_Json
 
 
+# Vanilla conserve temporairement une apparence claire unique. Le choix
+# système/sombre reste dans la couche UI pour une réactivation future, mais il
+# ne doit plus influencer le rendu du candidat stabilisé.
+VANILLA_APPARENCE = "clair"
+
+# wxMSW n'active son rendu sombre que sur opt-in. Poser explicitement l'option
+# à 0 avant la création de wx.App rend la décision Vanilla indépendante du
+# thème Windows et neutralise aussi un éventuel wx_msw_dark_mode externe.
+if os.name == "nt":
+    try:
+        wx.SystemOptions.SetOption("msw.dark-mode", 0)
+    except Exception:
+        pass
+
 
 def GetNomFichierConfig(nomFichier="Config.json"):
     return UTILS_Fichiers.GetRepUtilisateur(nomFichier)
@@ -174,6 +188,9 @@ class FichierConfig():
 
 
 def GetParametre(nomParametre="", defaut=None):
+    if nomParametre == "interface_apparence":
+        return VANILLA_APPARENCE
+
     parametre = None
     try :
         topWindow = wx.GetApp().GetTopWindow()
@@ -193,6 +210,9 @@ def GetParametre(nomParametre="", defaut=None):
     return parametre
 
 def SetParametre(nomParametre="", parametre=None):
+    if nomParametre == "interface_apparence":
+        parametre = VANILLA_APPARENCE
+
     try :
         topWindow = wx.GetApp().GetTopWindow()
         nomWindow = topWindow.GetName()

--- a/tests/test_recherche_accueil_ui_contract.py
+++ b/tests/test_recherche_accueil_ui_contract.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
+"""Contrats UI de la recherche individus/familles de l'accueil."""
 
 import ast
+import unittest
 from pathlib import Path
 
 
@@ -8,33 +10,58 @@ ROOT = Path(__file__).resolve().parents[1]
 FICHIER = ROOT / "noethys" / "Ctrl" / "CTRL_Recherche_individus.py"
 
 
-def source():
-    texte = FICHIER.read_text(encoding="utf-8")
-    ast.parse(texte)
-    return texte
+class RechercheAccueilUIContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.texte = FICHIER.read_text(encoding="utf-8")
+        cls.arbre = ast.parse(cls.texte)
+
+    def _methode(self, nom):
+        for noeud in ast.walk(self.arbre):
+            if isinstance(noeud, (ast.FunctionDef, ast.AsyncFunctionDef)) and noeud.name == nom:
+                return ast.get_source_segment(self.texte, noeud)
+        self.fail("Méthode introuvable : %s" % nom)
+
+    def test_recherche_vide_affiche_directement_toutes_les_donnees_chargees(self):
+        recherche = self._methode("Recherche")
+        branche_vide = recherche.split("if not texte:", 1)[1].split("resultats =", 1)[0]
+        self.assertIn("self.listView.SetObjects(self.listView.donnees)", branche_vide)
+        self.assertIn("self.parent.AfficherResultats()", branche_vide)
+        self.assertNotIn("AfficherEtatVide", branche_vide)
+        self.assertNotIn(".MAJ(", branche_vide)
+
+    def test_etape_intermediaire_voir_tout_est_supprimee(self):
+        self.assertNotIn("ctrl_voir_tout", self.texte)
+        self.assertNotIn("def AfficherTout", self.texte)
+
+    def test_chargement_metier_et_limite_de_recherche_restent_inchanges(self):
+        maj = self._methode("MAJ")
+        recherche = self._methode("Recherche")
+        self.assertIn("self.ctrl_listview.MAJ(forceActualisation=True)", maj)
+        self.assertIn("self.ctrl_recherche.Recherche()", maj)
+        self.assertIn("LIMITE_RESULTATS_ACCUEIL = 30", self.texte)
+        self.assertIn("resultats[:LIMITE_RESULTATS_ACCUEIL]", recherche)
+        self.assertNotIn("ctrl_listview.MAJ", recherche)
+
+    def test_actions_existantes_restent_disponibles(self):
+        for marqueur in (
+            "Nouvelle famille",
+            "Envoyer un email",
+            "Envoyer un SMS",
+            "Modifier",
+            "Calendrier",
+            "Fiche individuelle",
+            "Aperçu avant impression",
+            "Exporter au format Excel",
+        ):
+            self.assertIn(marqueur, self.texte)
+
+    def test_liste_reste_responsive_et_sans_grille_agressive(self):
+        self.assertNotIn("wx.LC_HRULES", self.texte)
+        self.assertNotIn("wx.LC_VRULES", self.texte)
+        self.assertIn("UTILS_ColonnesResponsive.Installer", self.texte)
+        self.assertIn('UTILS_UIMetrics.action_target("compact")', self.texte)
 
 
-def test_recherche_accueil_est_search_first():
-    texte = source()
-    assert "class EtatRecherche(wx.Panel)" in texte
-    assert "Rechercher une famille ou un individu" in texte
-    assert "AfficherEtatVide" in texte
-    assert "AfficherAucunResultat" in texte
-    assert "AfficherResultats" in texte
-    assert "LIMITE_RESULTATS_ACCUEIL = 30" in texte
-
-
-def test_recherche_accueil_reste_responsive_et_sans_grille_agressive():
-    texte = source()
-    assert "wx.LC_HRULES" not in texte
-    assert "wx.LC_VRULES" not in texte
-    assert "wx.FlexGridSizer" not in texte
-    assert "UTILS_ColonnesResponsive.Installer" in texte
-    assert "UTILS_UIMetrics.action_target(\"standard\")" in texte
-
-
-def test_actions_principales_sont_identifiables():
-    texte = source()
-    assert "Nouvelle famille" in texte
-    assert "Voir tout" in texte
-    assert 'UTILS_FluentIcons.GetBitmap("add"' in texte
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_vanilla_light_theme_contract.py
+++ b/tests/test_vanilla_light_theme_contract.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+"""Contrats de stabilisation du thème clair Vanilla."""
+
+import ast
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG = ROOT / "noethys" / "Utils" / "UTILS_Config.py"
+INTERFACE = ROOT / "noethys" / "Utils" / "UTILS_Interface.py"
+DIALOG = ROOT / "noethys" / "Dlg" / "DLG_Echelle_interface.py"
+STYLE = ROOT / "noethys" / "Utils" / "UTILS_StyleRepens.py"
+AUI = ROOT / "noethys" / "Utils" / "UTILS_Aui.py"
+ACTION = ROOT / "noethys" / "Ctrl" / "CTRL_ActionRepens.py"
+RECHERCHE = ROOT / "noethys" / "Ctrl" / "CTRL_Recherche_individus.py"
+
+
+def lire(path):
+    texte = path.read_text(encoding="utf-8")
+    ast.parse(texte)
+    return texte
+
+
+class VanillaLightThemeContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.config = lire(CONFIG)
+        cls.interface = lire(INTERFACE)
+        cls.dialog = lire(DIALOG)
+        cls.style = lire(STYLE)
+        cls.aui = lire(AUI)
+        cls.action = lire(ACTION)
+        cls.recherche = lire(RECHERCHE)
+
+    def test_preference_active_est_forcee_en_clair(self):
+        self.assertIn('VANILLA_APPARENCE = "clair"', self.config)
+        self.assertIn('if nomParametre == "interface_apparence":\n        return VANILLA_APPARENCE', self.config)
+        self.assertIn('if nomParametre == "interface_apparence":\n        parametre = VANILLA_APPARENCE', self.config)
+        self.assertIn('UTILS_Config.GetParametre("interface_apparence", "systeme")', self.interface)
+
+    def test_rendu_sombre_wxmsw_est_explicitement_desactive(self):
+        self.assertIn('wx.SystemOptions.SetOption("msw.dark-mode", 0)', self.config)
+        self.assertIn('if os.name == "nt":', self.config)
+
+    def test_dialogue_apparence_ne_permet_plus_systeme_ou_sombre(self):
+        self.assertIn('self.ctrl_apparence.Enable(False)', self.dialog)
+        self.assertIn('"apparence": UTILS_Interface.GetApparence()', self.dialog)
+        self.assertIn('self.liste_codes_apparence.index("clair")', self.dialog)
+        self.assertIn('le thème système et le mode sombre ne sont pas activés', self.dialog)
+
+    def test_listes_champs_boutons_et_aui_restent_sur_les_roles_semantiques(self):
+        self.assertIn('def appliquer_saisie(ctrl):', self.style)
+        self.assertIn('ctrl.SetForegroundColour(couleur("on_surface"))', self.style)
+        self.assertIn('ctrl.SetBackgroundColour(couleur("surface_container_lowest"))', self.style)
+        self.assertIn('def appliquer_liste(ctrl):', self.style)
+        self.assertIn('book.SetBackgroundColour(UTILS_Interface.GetCouleurRole("surface"))', self.aui)
+        self.assertIn('book.SetForegroundColour(UTILS_Interface.GetCouleurRole("on_surface"))', self.aui)
+        self.assertIn('Style.couleur("on_surface")', self.action)
+        self.assertIn('Style.couleur("surface_container_high")', self.action)
+        self.assertIn('self.SetForegroundColour(UTILS_Interface.GetCouleurRole("on_surface"))', self.recherche)
+
+    def test_menus_restent_natifs_et_heriteront_du_wxmsw_clair(self):
+        self.assertIn('menu = UTILS_Adaptations.Menu()', self.recherche)
+        self.assertIn('wx.SystemOptions.SetOption("msw.dark-mode", 0)', self.config)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Objet

Correction strictement ciblée issue de la recette humaine Vanilla.

- supprime l’étape intermédiaire « Voir tout » de la liste individus/familles de l’accueil ;
- affiche directement `listView.donnees` lorsqu’aucun texte de recherche n’est saisi ;
- conserve le chargement existant dans `Panel.MAJ()` et toutes les actions métier ;
- force l’apparence Vanilla en thème clair, indépendamment du thème Windows ;
- désactive explicitement le dark mode wxMSW pour Vanilla ;
- désactive temporairement le choix système/sombre dans le dialogue d’apparence ;
- documente les décisions dans `docs/VANILLA_STABILISATION.md` ;
- ajoute/actualise uniquement les contrats de non-régression correspondants ;
- étend le wrapper Windows master aux trois fichiers runtime modifiés afin de fabriquer l’artefact du SHA exact après fusion.

## Périmètre

7 fichiers seulement : 3 runtime UI/config, 2 tests, 1 document, 1 déclencheur CI Windows. Aucun revert global UI.

Aucune modification de logique métier, de chargement de données, de schéma SQL, de format de données, de protocole ou de comportement Connecthys. La compatibilité avec le Connecthys d’Ivan est conservée par non-modification de ces interfaces.

## Validation

Une nouvelle recette humaine Windows reste obligatoire après CI et packaging. Ne pas taguer Vanilla stable avec cette PR seule.