### PR TITLE
Vanilla: sécuriser la fermeture de la liste des consommations

### DIFF
--- a/noethys/Dlg/DLG_Liste_consommations.py
+++ b/noethys/Dlg/DLG_Liste_consommations.py
@@ -117,6 +117,7 @@ class Dialog(wx.Dialog):
     def __init__(self, parent):
         wx.Dialog.__init__(self, parent, -1, style=wx.DEFAULT_DIALOG_STYLE|wx.RESIZE_BORDER|wx.MAXIMIZE_BOX|wx.MINIMIZE_BOX)
         self.parent = parent
+        self._fermeture_en_cours = False
         
         intro = _(u"Vous pouvez ici consulter la liste complète des consommations saisies dans le logiciel.")
         titre = _(u"Liste détaillée des consommations")
@@ -158,6 +159,8 @@ class Dialog(wx.Dialog):
         self.Bind(wx.EVT_BUTTON, self.ctrl_consommations.ExportExcel, self.bouton_excel)
         self.Bind(wx.EVT_BUTTON, self.ctrl_consommations.Supprimer, self.bouton_supprimer)
         self.Bind(wx.EVT_BUTTON, self.OnBoutonAide, self.bouton_aide)
+        self.Bind(wx.EVT_BUTTON, self.OnFermer, self.bouton_fermer)
+        self.Bind(wx.EVT_CLOSE, self.OnFermer)
         self.Bind(wx.EVT_CHOICE, self.OnParametre, self.ctrl_annee)
         self.Bind(wx.EVT_CHOICE, self.OnParametre, self.ctrl_activite)
 
@@ -237,6 +240,43 @@ class Dialog(wx.Dialog):
     def OnBoutonAide(self, event): 
         from Utils import UTILS_Aide
         UTILS_Aide.Aide("")
+
+    def _NettoieAvantFermeture(self):
+        """Neutralise les callbacks wx d'une liste virtuelle avant sa destruction."""
+        if self._fermeture_en_cours:
+            return
+        self._fermeture_en_cours = True
+
+        # La barre de recherche possède un wx.Timer qui peut encore poster un
+        # EVT_TIMER alors que le dialogue et sa liste sont en cours de destruction.
+        try:
+            timer = self.ctrl_recherche.barreRecherche.timer
+            if timer.IsRunning():
+                timer.Stop()
+        except (AttributeError, RuntimeError):
+            pass
+
+        # FastObjectListView est un wx.ListCtrl virtuel. Sous Windows, le contrôle
+        # natif peut demander une dernière ligne pendant sa destruction. On retire
+        # donc son getter et son cache avant de remettre le compteur à zéro.
+        try:
+            ctrl = self.ctrl_consommations
+            ctrl.SetObjectGetter(None)
+            ctrl.lastGetObjectIndex = -1
+            ctrl.lastGetObject = None
+            ctrl.SetItemCount(0)
+            ctrl.modelObjects = []
+            ctrl.innerList = []
+            ctrl.donnees = []
+        except (AttributeError, RuntimeError):
+            pass
+
+    def OnFermer(self, event=None):
+        self._NettoieAvantFermeture()
+        if self.IsModal():
+            self.EndModal(wx.ID_CANCEL)
+        else:
+            self.Destroy()
 
     def OnParametre(self, event=None):
         listeFiltres = []


### PR DESCRIPTION
## Contexte
Bug Windows reproductible sur la liste détaillée des consommations : fermeture pendant/à l'issue d'un chargement bloqué, puis réouverture immédiate => crash natif `0xc0000005`.

## Cause ciblée
La fenêtre contient un `FastObjectListView` (`wx.ListCtrl` virtuel) qui conserve son `objectGetter` et son cache jusqu'à la destruction native, ainsi qu'un `wx.Timer` dans la barre de recherche. Le dialogue n'avait aucun nettoyage explicite avant `EndModal`/destruction.

## Correction
- chemin de fermeture explicite pour le bouton **Fermer** et `EVT_CLOSE` ;
- arrêt du timer de recherche ;
- neutralisation du getter de la liste virtuelle et de son cache ;
- remise du compteur natif à zéro avant libération des modèles Python ;
- nettoyage idempotent pour éviter les doubles fermetures.

## Périmètre
Correctif local Vanilla/wxPython uniquement. Aucun changement fonctionnel, aucune refonte UI, aucune migration Qt.

## Validation attendue sur Windows / base Docker de recette
1. Ouvrir la liste des consommations.
2. Pendant un chargement long, cliquer **Fermer**.
3. Rouvrir immédiatement la liste.
4. Répéter plusieurs fois, y compris avec la croix de la fenêtre.
5. Vérifier l'absence d'`Application Error 1000` / `0xc0000005` et l'absence de traitement résiduel.

La lenteur initiale peut avoir une cause de performance distincte (notamment chargement global des réponses de questionnaires) ; elle n'est volontairement pas mélangée à ce correctif de cycle de vie natif.