### PR TITLE
Vanilla — réparer Affichage et Liste d’attente sur dates Python 3

### DIFF
--- a/.github/workflows/windows-package-master.yml
+++ b/.github/workflows/windows-package-master.yml
@@ -11,6 +11,8 @@ on:
       - 'noethys/Utils/UTILS_Fichiers.py'
       - 'noethys/Utils/UTILS_Config.py'
       - 'noethys/Ctrl/CTRL_Recherche_individus.py'
+      - 'noethys/Ctrl/CTRL_Grille_periode.py'
+      - 'noethys/Ctrl/CTRL_Attente.py'
       - 'noethys/Dlg/DLG_Echelle_interface.py'
       - 'packaging/**'
       - 'requirements*.txt'

--- a/docs/VANILLA_STABILISATION.md
+++ b/docs/VANILLA_STABILISATION.md
@@ -1,12 +1,62 @@
-# Stabilisation Vanilla — décisions de recette humaine
+# Stabilisation Vanilla — décisions et recettes
 
 ## Statut
 
-**VALIDATION MANUELLE REQUISE** — ne pas taguer Vanilla stable avant une nouvelle recette humaine Windows du candidat issu de cette stabilisation.
+**VALIDATION MANUELLE REQUISE** — ne pas taguer ni déclarer Vanilla stable avant une nouvelle recette humaine Windows du prochain candidat.
 
-Le candidat précédent `74d25fdd8431eb7a167ab35cab8e1e8aa4e3bdc9` reste la référence des qualifications acquises avant ces corrections UX, mais il est remplacé pour la poursuite de la recette.
+Vanilla reste la baseline wxPython techniquement durcie et fonctionnellement compatible avec Noethys historique. Les évolutions graphiques profondes sont réservées à la future branche Qt.
 
-## Décisions UX issues de la recette humaine
+## Chronologie et candidats
+
+### Candidat `74d25fdd8431eb7a167ab35cab8e1e8aa4e3bdc9`
+
+Ce candidat était **techniquement suffisamment abouti pour recette humaine** : Python 3 / wxPython, audits runtime, sauvegarde-restauration, CI et packaging Windows avaient atteint le niveau attendu pour ouvrir la recette réelle.
+
+Qualifications automatisées acquises :
+
+- CI `#2389`, run `34114566920` : succès ; **761 tests OK** ; contrôle de schéma sans modification SQL applicative ;
+- packaging Windows exact, run `34114567033` : succès ;
+- installateur `Noethys-Windows-installer`, artifact `10015844325`, SHA-256 `2a3d58c16b7381f0694d02dcc3beb9a2a6df9bd7901651cb11925ed994920f94` ;
+- portable `Noethys-Windows-portable`, artifact `10015847439`, SHA-256 `6175ada64c72a454ed54bcf8b38eb6422d667cf6e1c999a1b67ef3335f3f308c`.
+
+**Rejeté graphiquement lors de la recette humaine du 07/09/2026.** Motifs initiaux : thème sombre actuel non retenu et ergonomie de certaines listes avec étape « Voir tout » non retenue. Ce rejet **ne concernait pas l'ensemble des améliorations techniques** du candidat, qui devaient être conservées.
+
+La décision UX a ensuite été affinée pendant la même recette : le **thème clair actuel est retenu**, le suivi automatique du thème système est désactivé pour Vanilla, et le rendu sombre wxPython reste temporairement non supporté.
+
+### Candidat `f777c6cf4d9208d2e756271dfad95a7a7027acdd`
+
+Issu de la PR `#358`, ce candidat a supprimé l'étape « Voir tout » de la recherche d'accueil et verrouillé Vanilla en thème clair, sans changement métier, BDD ou Connecthys.
+
+Qualifications automatisées :
+
+- CI master `#2392`, run `34139688567` : succès ; **771 tests OK** ; imports, AUI, layout et cycle de vie wx verts ; contrôle push : « Aucune modification du schéma applicatif SQL ajoutée. » ;
+- packaging Windows exact, run `34139688552` : succès ;
+- installateur `Noethys-Windows-installer`, artifact `10025520253`, SHA-256 `360afb57744bd685257f45d2effd2c6df1cb4ea9c2dfc03e79fc0af7ac6ec7fd` ;
+- portable `Noethys-Windows-portable`, artifact `10025523339`, SHA-256 `df83a632bba6387777cc81955308ce5dda38f2d68f8ed6a94d8ced441f10267a` ;
+- smoke installable : mise à niveau sans perte de configuration, succès ;
+- smoke portable : lancement après extraction sans environnement Python externe, succès.
+
+La recette humaine suivante a toutefois révélé des **P1 runtime/UI** non couverts par ces tests :
+
+- bouton **Affichage** du tableau de fréquentation inopérant ;
+- bouton **Liste d'attente** inopérant ;
+- disparition brutale du processus observée en fin de vidéo de recette. La nouvelle recette devra confirmer si ce dernier symptôme est entièrement résolu par le correctif des parcours concernés ; il n'est pas déclaré résolu par simple déduction.
+
+Le candidat `f777c6cf4d9208d2e756271dfad95a7a7027acdd` reste donc **non validé pour une baseline stable** malgré ses qualifications automatisées réussies.
+
+### Correctif suivant
+
+Branche : `fix/vanilla-remplissage-dialogs`, créée depuis exactement `f777c6cf4d9208d2e756271dfad95a7a7027acdd`.
+
+L'analyse des deux commandes a isolé un point commun reproductible : `DLG_Parametres_remplissage` et `DLG_Attente` construisent tous les deux `CTRL_Grille_periode.CTRL`. La page `Vacances` de ce contrôle est initialisée immédiatement et convertissait encore les champs SQL `date_debut` / `date_fin` par découpage de chaîne (`date[:10]`). Les pilotes Python 3/MySQL peuvent déjà fournir des objets `datetime.date`, qui ne sont pas indexables et provoquent alors une exception avant `ShowModal()`.
+
+La liste d'attente contenait en plus une conversion locale équivalente pour `consommations.date` et `date_saisie`.
+
+Décision de correction : réutiliser `Utils.UTILS_Dates.DateEngEnDateDD`, déjà prévu pour les chaînes historiques et les dates Python natives, avec prise en charge explicite d'un éventuel `datetime.datetime` dans la liste d'attente. **Les requêtes, le chargement, les actions et les structures de données restent inchangés.**
+
+Le SHA exact du nouveau candidat sera celui du master après intégration verte de cette correction et sera communiqué avec l'artefact Windows correspondant ; il ne sera pas tagué stable avant recette humaine.
+
+## Décisions UX Vanilla
 
 - **Thème sombre rejeté en recette humaine.**
 - **Thème clair retenu** pour Vanilla.
@@ -14,12 +64,13 @@ Le candidat précédent `74d25fdd8431eb7a167ab35cab8e1e8aa4e3bdc9` reste la réf
 - **Décision : retour à l'affichage direct de la liste complète** quand aucun texte de recherche n'est saisi.
 - **Suivi automatique du thème système désactivé pour Vanilla.**
 - **Thème sombre wxPython / widgets wx temporairement non supporté** tant qu'un rendu sombre cohérent n'a pas été conçu et validé.
+- Les commandes historiques doivent rester directement opérantes ; une modernisation visuelle ne doit pas interposer ou neutraliser leur comportement.
 
-## Périmètre technique de la correction
+## Périmètre technique des corrections UX
 
 ### Liste d'accueil
 
-Le composant concerné est `noethys/Ctrl/CTRL_Recherche_individus.py`, dans `BarreRechercheAccueil.Recherche` et le bouton `ctrl_voir_tout` du `Panel`.
+Le composant concerné est `noethys/Ctrl/CTRL_Recherche_individus.py`, dans `BarreRechercheAccueil.Recherche` et l'ancien bouton `ctrl_voir_tout` du `Panel`.
 
 Avant correction, une recherche vide vidait les objets affichés et basculait vers un état d'attente ; le bouton « Voir tout » réinjectait ensuite `listView.donnees`. La stabilisation supprime cette étape intermédiaire : une recherche vide affiche directement `listView.donnees`.
 
@@ -31,21 +82,40 @@ La préférence active `interface_apparence` est forcée à `clair` par la couch
 
 Le dialogue d'apparence reste présent pour l'échelle, la taille du texte et la couleur d'accent, mais le choix d'apparence est désactivé et conserve `clair` comme valeur active. Les palettes sombres et les upgrades techniques existants ne sont pas supprimés : ils sont simplement non activables dans la baseline Vanilla.
 
-Les listes, AUI, champs de saisie et boutons continuent de consommer les rôles sémantiques existants. Les menus restent natifs wx ; avec le dark mode wxMSW désactivé, ils restent sur le rendu clair. La lisibilité visuelle finale de ces composants doit être confirmée pendant la nouvelle recette humaine Windows, y compris lorsque Windows lui-même est configuré en mode sombre.
+Les listes, AUI, champs de saisie et boutons continuent de consommer les rôles sémantiques existants. Les menus restent natifs wx ; avec le dark mode wxMSW désactivé, ils restent sur le rendu clair.
+
+### Affichage et liste d'attente du tableau de fréquentation
+
+Le correctif P1 ne modifie pas la logique de la toolbar Repens. Les événements restent reliés à `OnParametres` et `OnListeAttente`, qui ouvrent les mêmes dialogues historiques. Seule la conversion des valeurs DATE renvoyées par le pilote Python 3 est sécurisée dans :
+
+- `noethys/Ctrl/CTRL_Grille_periode.py` ;
+- `noethys/Ctrl/CTRL_Attente.py`.
 
 ## Invariants hors périmètre
 
 - aucune modification de logique métier ;
 - aucune modification du chargement des données ;
-- aucune modification de schéma de base de données ;
+- aucune migration ni modification de schéma de base de données ;
 - aucun changement de format de données ;
-- aucun changement de protocole ou de comportement Connecthys ;
-- compatibilité avec le Connecthys d'Ivan conservée par non-modification de ces interfaces ;
+- aucun changement de protocole ou de comportement Connecthys / Ivan ;
+- aucun changement des requêtes métier de remplissage ou de liste d'attente ;
 - aucun revert global des commits UI ;
-- thème clair actuel et upgrades techniques conservés.
+- thème clair actuel et upgrades Python 3, wxPython, runtime, imports, packaging, sauvegarde-restauration et stabilité conservés.
 
 ## Validation attendue
 
-Les contrats automatisés doivent vérifier l'affichage direct de `listView.donnees`, l'absence du contrôle/méthode « Voir tout », la conservation du chargement métier existant, le verrouillage de l'apparence claire et le routage sémantique clair des principaux widgets.
+Les contrats automatisés doivent vérifier :
 
-Après CI et packaging Windows verts, une nouvelle recette humaine doit confirmer sur Windows réel : liste complète immédiatement visible, recherche/actions inchangées, thème clair même lorsque Windows est sombre, lisibilité des listes/AUI/champs/boutons/menus, puis les contrôles métier/backup-restauration déjà prévus sur une copie réelle de base.
+- l'affichage direct de `listView.donnees` et l'absence de l'étape « Voir tout » ;
+- le verrouillage de l'apparence claire ;
+- la conservation du câblage des boutons **Affichage** et **Liste d'attente** ;
+- l'acceptation des valeurs SQL DATE sous forme historique chaîne et sous forme Python native ;
+- l'absence de changement des requêtes de ces parcours.
+
+Après CI et packaging Windows verts, une nouvelle recette humaine doit confirmer sur Windows réel :
+
+1. **Affichage** ouvre bien les paramètres et permet de les valider ;
+2. **Liste d'attente** ouvre bien la liste et reste utilisable ;
+3. les quatre modes Capacité / Occupé / Disponible / Attente restent fonctionnels ;
+4. le parcours filmé jusqu'à la fin ne fait plus disparaître Noethys ;
+5. liste complète d'accueil, thème clair forcé et autres acquis de `f777c6cf…` restent inchangés.

--- a/docs/adr/ADR-001-vanilla-ui-historique.md
+++ b/docs/adr/ADR-001-vanilla-ui-historique.md
@@ -1,0 +1,33 @@
+# ADR-001 — Vanilla conserve l'ergonomie Noethys et réserve la refonte à Qt
+
+**Statut : ACCEPTED**
+
+## Contexte
+
+La modernisation graphique introduite dans Vanilla a modifié sensiblement l'apparence et certains comportements d'interface historiques de Noethys. La recette humaine du 07/09/2026 a notamment rejeté le thème sombre comme baseline et l'étape intermédiaire « Voir tout » qui remplaçait l'affichage direct d'une liste utile.
+
+La suite de la recette a retenu le thème clair actuel, mais a également montré qu'une modernisation de contrôle ne peut être acceptée si des commandes historiques deviennent inopérantes. Vanilla doit rester une référence wxPython fiable avant la future branche Qt.
+
+## Décision
+
+Vanilla reste la référence fonctionnelle et ergonomique fidèle à Noethys historique :
+
+- interface claire ;
+- suivi automatique du thème système désactivé pour Vanilla ;
+- rendu sombre wxPython temporairement non supporté ;
+- organisation générale des écrans conservée ;
+- listes utiles visibles directement ;
+- commandes et actions historiques directement opérantes ;
+- améliorations techniques modernes Python 3, wxPython, runtime, imports, tests, packaging et stabilité conservées.
+
+La refonte graphique profonde, les thèmes clair/sombre modernes et les évolutions structurelles de l'interface seront réalisées ultérieurement dans la branche **Qt**, séparément de Vanilla.
+
+## Conséquences
+
+- les évolutions graphiques Repens/Material/sombre incompatibles avec cette décision sont neutralisées ou retirées de Vanilla uniquement lorsqu'elles changent l'ergonomie retenue ;
+- les correctifs techniques introduits pendant ces travaux restent conservés ;
+- aucune modernisation visuelle ne doit modifier la logique métier, le chargement des données ou les actions disponibles ;
+- les futures évolutions UI importantes ne devront plus être introduites directement dans Vanilla ;
+- aucune décision UI Vanilla ne justifie une migration BDD, un changement de schéma ou de format, ni un changement du protocole ou du comportement Connecthys/Ivan.
+
+La validation automatisée reste nécessaire mais ne remplace pas la recette humaine Windows pour les parcours interactifs.

--- a/noethys/Ctrl/CTRL_Attente.py
+++ b/noethys/Ctrl/CTRL_Attente.py
@@ -23,6 +23,7 @@ import os
 import GestionDB
 from Ctrl import CTRL_Saisie_euros
 import FonctionsPerso
+from Utils import UTILS_Dates
 from Utils import UTILS_Organisateur
 from Utils import UTILS_Utilisateurs
 
@@ -41,7 +42,9 @@ def DateComplete(dateDD):
     return dateComplete
 
 def DateEngEnDateDD(dateEng):
-    return datetime.date.fromisoformat(dateEng[:10])
+    if isinstance(dateEng, datetime.datetime):
+        return dateEng.date()
+    return UTILS_Dates.DateEngEnDateDD(dateEng)
         
 def PeriodeComplete(mois, annee):
     listeMois = (_(u"Janvier"), _(u"Février"), _(u"Mars"), _(u"Avril"), _(u"Mai"), _(u"Juin"), _(u"Juillet"), _(u"Août"), _(u"Septembre"), _(u"Octobre"), _(u"Novembre"), _(u"Décembre"))

--- a/noethys/Ctrl/CTRL_Grille_periode.py
+++ b/noethys/Ctrl/CTRL_Grille_periode.py
@@ -14,6 +14,7 @@ import datetime
 import wx
 
 import GestionDB
+from Utils import UTILS_Dates
 from Utils import UTILS_StyleRepens as Style
 from Utils.UTILS_Traduction import _
 
@@ -249,8 +250,8 @@ class Vacances(wx.Panel):
         DB.Close()
         listeChoix = []
         for nom, date_debut, date_fin in listeVacances:
-            date_debutDD = datetime.date.fromisoformat(date_debut[:10])
-            date_finDD = datetime.date.fromisoformat(date_fin[:10])
+            date_debutDD = UTILS_Dates.DateEngEnDateDD(date_debut)
+            date_finDD = UTILS_Dates.DateEngEnDateDD(date_fin)
             listeChoix.append((nom, date_debutDD, date_finDD))
         self.ctrl_periode.SetListeChoix(listeChoix, conserveSelections=False)
 

--- a/tests/test_remplissage_dialog_dates_contract.py
+++ b/tests/test_remplissage_dialog_dates_contract.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import ast
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def lire(chemin):
+    return (ROOT / chemin).read_text(encoding="utf-8")
+
+
+def source_fonction(chemin, nom_fonction, nom_classe=None):
+    source = lire(chemin)
+    arbre = ast.parse(source)
+    noeuds = arbre.body
+    if nom_classe is not None:
+        classe = next(
+            noeud for noeud in arbre.body
+            if isinstance(noeud, ast.ClassDef) and noeud.name == nom_classe
+        )
+        noeuds = classe.body
+    fonction = next(
+        noeud for noeud in noeuds
+        if isinstance(noeud, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and noeud.name == nom_fonction
+    )
+    return ast.get_source_segment(source, fonction)
+
+
+class RemplissageDialogDatesContractTests(unittest.TestCase):
+    def test_les_deux_dialogues_passent_par_le_selecteur_de_periode_commun(self):
+        parametres = lire("noethys/Dlg/DLG_Parametres_remplissage.py")
+        attente = lire("noethys/Dlg/DLG_Attente.py")
+
+        self.assertIn("CTRL_Grille_periode.CTRL(self)", parametres)
+        self.assertIn("CTRL_Grille_periode.CTRL(self)", attente)
+
+    def test_vacances_accepte_les_dates_natives_du_pilote_python3(self):
+        maj = source_fonction(
+            "noethys/Ctrl/CTRL_Grille_periode.py",
+            "MAJ",
+            nom_classe="Vacances",
+        )
+
+        self.assertIn("UTILS_Dates.DateEngEnDateDD(date_debut)", maj)
+        self.assertIn("UTILS_Dates.DateEngEnDateDD(date_fin)", maj)
+        self.assertNotIn("date_debut[:10]", maj)
+        self.assertNotIn("date_fin[:10]", maj)
+
+    def test_liste_attente_accepte_date_datetime_et_chaine_historique(self):
+        conversion = source_fonction(
+            "noethys/Ctrl/CTRL_Attente.py",
+            "DateEngEnDateDD",
+        )
+
+        self.assertIn("isinstance(dateEng, datetime.datetime)", conversion)
+        self.assertIn("return dateEng.date()", conversion)
+        self.assertIn("return UTILS_Dates.DateEngEnDateDD(dateEng)", conversion)
+        self.assertNotIn("dateEng[:10]", conversion)
+
+    def test_boutons_repens_restent_branches_sur_les_actions_existantes(self):
+        source = lire("noethys/Dlg/DLG_Remplissage_Repens.py")
+
+        self.assertIn(
+            "self.Bind(wx.EVT_TOOL, self.OnListeAttente, id=Legacy.ID_LISTE_ATTENTE)",
+            source,
+        )
+        self.assertIn(
+            "self.Bind(wx.EVT_TOOL, self.OnParametres, id=Legacy.ID_PARAMETRES)",
+            source,
+        )
+        self.assertIn("self.GetParent().OuvrirListeAttente()", source)
+        self.assertIn("DLG_Parametres_remplissage.Dialog(", source)
+
+    def test_correctif_ne_change_pas_les_requetes_des_deux_parcours(self):
+        grille = source_fonction(
+            "noethys/Ctrl/CTRL_Grille_periode.py",
+            "MAJ",
+            nom_classe="Vacances",
+        )
+        attente = source_fonction(
+            "noethys/Ctrl/CTRL_Attente.py",
+            "Importation",
+            nom_classe="CTRL",
+        )
+
+        self.assertIn("FROM vacances", grille)
+        self.assertIn("WHERE annee=%d", grille)
+        self.assertIn("FROM consommations", attente)
+        self.assertIn("WHERE consommations.etat = '%s'", attente)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Correction P1 issue de la recette humaine du 07/09/2026.

Cause isolée : les deux parcours construisent `CTRL_Grille_periode`, dont la page Vacances découpait encore les valeurs SQL DATE comme des chaînes (`date[:10]`). Avec les pilotes Python 3/MySQL, ces valeurs peuvent être des `datetime.date`, ce qui lève une exception avant l'ouverture du dialogue. `CTRL_Attente` contenait la même hypothèse pour `consommations.date` / `date_saisie`.

Correction minimale : réutilisation de `UTILS_Dates.DateEngEnDateDD`, sans modifier les requêtes, le chargement, les actions, le schéma, les formats ni Connecthys/Ivan. Tests contractuels ajoutés pour les deux boutons et les conversions. Traçabilité Vanilla et ADR ajoutées/mises à jour.

Le déclencheur du packaging master est étendu uniquement aux deux fichiers runtime concernés afin de produire l'artefact Windows du SHA exact après intégration.

Ne pas taguer Vanilla stable avant nouvelle recette humaine.