### PR TITLE
Vanilla — candidat consolidé #360 + #359

### DIFF
--- a/.github/workflows/vanilla-r2.yml
+++ b/.github/workflows/vanilla-r2.yml
@@ -5,7 +5,11 @@ on:
     paths:
       - 'noethys/Utils/UTILS_Fichiers.py'
       - 'noethys/Utils/UTILS_Rapport_bugs.py'
+      - 'noethys/Ctrl/CTRL_Grille_periode.py'
+      - 'noethys/Ctrl/CTRL_Attente.py'
+      - 'noethys/Dlg/DLG_Liste_consommations.py'
       - 'tests/test_vanilla_crash_recipient.py'
+      - 'tests/test_vanilla_candidate_contract.py'
       - 'packaging/vanilla-installer.iss'
       - 'packaging/vanilla-noethys.spec'
       - '.github/workflows/vanilla-r2.yml'
@@ -49,8 +53,8 @@ jobs:
       - name: Compiler les sources
         run: python -m compileall -q noethys
 
-      - name: Tester la migration du destinataire de crashreports
-        run: python -m unittest tests.test_vanilla_crash_recipient
+      - name: Tester les contrats Vanilla du candidat
+        run: python -m unittest tests.test_vanilla_crash_recipient tests.test_vanilla_candidate_contract
 
       - name: Vérifier wxPython sous Windows
         shell: pwsh

--- a/noethys/Ctrl/CTRL_Attente.py
+++ b/noethys/Ctrl/CTRL_Attente.py
@@ -64,11 +64,11 @@ class CTRL(HTL.HyperTreeList):
         UTILS_Linux.AdaptePolice(self)
 
         self.dictDonnees = dictDonnees
-        self.listeActivites = self.dictDonnees["listeActivites"] if len(self.dictDonnees) > 0 else []
-        self.listePeriodes = self.dictDonnees["listePeriodes"] if len(self.dictDonnees) > 0 else []
         self.dictEtatPlaces = dictEtatPlaces # copy.deepcopy(dictEtatPlaces)
         self.dictUnitesRemplissage = dictUnitesRemplissage
         self.listeTracks = []
+        self.listePeriodes = []
+        self.listeActivites = []
         self.listeImpression = []
                 
         # Création des colonnes

--- a/noethys/Ctrl/CTRL_Attente.py
+++ b/noethys/Ctrl/CTRL_Attente.py
@@ -23,6 +23,7 @@ import os
 import GestionDB
 from Ctrl import CTRL_Saisie_euros
 import FonctionsPerso
+from Utils import UTILS_Dates
 from Utils import UTILS_Organisateur
 from Utils import UTILS_Utilisateurs
 
@@ -41,7 +42,9 @@ def DateComplete(dateDD):
     return dateComplete
 
 def DateEngEnDateDD(dateEng):
-    return datetime.date(int(dateEng[:4]), int(dateEng[5:7]), int(dateEng[8:10]))
+    if isinstance(dateEng, datetime.datetime):
+        return dateEng.date()
+    return UTILS_Dates.DateEngEnDateDD(dateEng)
         
 def PeriodeComplete(mois, annee):
     listeMois = (_(u"Janvier"), _(u"Février"), _(u"Mars"), _(u"Avril"), _(u"Mai"), _(u"Juin"), _(u"Juillet"), _(u"Août"), _(u"Septembre"), _(u"Octobre"), _(u"Novembre"), _(u"Décembre"))
@@ -61,11 +64,11 @@ class CTRL(HTL.HyperTreeList):
         UTILS_Linux.AdaptePolice(self)
 
         self.dictDonnees = dictDonnees
+        self.listeActivites = self.dictDonnees["listeActivites"] if len(self.dictDonnees) > 0 else []
+        self.listePeriodes = self.dictDonnees["listePeriodes"] if len(self.dictDonnees) > 0 else []
         self.dictEtatPlaces = dictEtatPlaces # copy.deepcopy(dictEtatPlaces)
         self.dictUnitesRemplissage = dictUnitesRemplissage
         self.listeTracks = []
-        self.listePeriodes = []
-        self.listeActivites = []
         self.listeImpression = []
                 
         # Création des colonnes

--- a/noethys/Ctrl/CTRL_Grille_periode.py
+++ b/noethys/Ctrl/CTRL_Grille_periode.py
@@ -11,6 +11,7 @@
 
 import Chemins
 from Utils import UTILS_Adaptations
+from Utils import UTILS_Dates
 from Utils.UTILS_Traduction import _
 import wx
 from Ctrl import CTRL_Bouton_image
@@ -244,8 +245,8 @@ class Vacances(wx.Panel):
         listeChoix = []
         index = 0
         for nom, date_debut, date_fin in listeVacances :
-            date_debutDD = datetime.date(year=int(date_debut[:4]), month=int(date_debut[5:7]), day=int(date_debut[8:10]))
-            date_finDD = datetime.date(year=int(date_fin[:4]), month=int(date_fin[5:7]), day=int(date_fin[8:10]))
+            date_debutDD = UTILS_Dates.DateEngEnDateDD(date_debut)
+            date_finDD = UTILS_Dates.DateEngEnDateDD(date_fin)
             listeChoix.append( (nom, date_debutDD, date_finDD) )
             index += 1
         self.ctrl_periode.SetListeChoix(listeChoix, conserveSelections=False)

--- a/noethys/Dlg/DLG_Liste_consommations.py
+++ b/noethys/Dlg/DLG_Liste_consommations.py
@@ -117,6 +117,7 @@ class Dialog(wx.Dialog):
     def __init__(self, parent):
         wx.Dialog.__init__(self, parent, -1, style=wx.DEFAULT_DIALOG_STYLE|wx.RESIZE_BORDER|wx.MAXIMIZE_BOX|wx.MINIMIZE_BOX)
         self.parent = parent
+        self._fermeture_en_cours = False
         
         intro = _(u"Vous pouvez ici consulter la liste complète des consommations saisies dans le logiciel.")
         titre = _(u"Liste détaillée des consommations")
@@ -158,6 +159,8 @@ class Dialog(wx.Dialog):
         self.Bind(wx.EVT_BUTTON, self.ctrl_consommations.ExportExcel, self.bouton_excel)
         self.Bind(wx.EVT_BUTTON, self.ctrl_consommations.Supprimer, self.bouton_supprimer)
         self.Bind(wx.EVT_BUTTON, self.OnBoutonAide, self.bouton_aide)
+        self.Bind(wx.EVT_BUTTON, self.OnFermer, self.bouton_fermer)
+        self.Bind(wx.EVT_CLOSE, self.OnFermer)
         self.Bind(wx.EVT_CHOICE, self.OnParametre, self.ctrl_annee)
         self.Bind(wx.EVT_CHOICE, self.OnParametre, self.ctrl_activite)
 
@@ -237,6 +240,43 @@ class Dialog(wx.Dialog):
     def OnBoutonAide(self, event): 
         from Utils import UTILS_Aide
         UTILS_Aide.Aide("")
+
+    def _NettoieAvantFermeture(self):
+        """Neutralise les callbacks wx d'une liste virtuelle avant sa destruction."""
+        if self._fermeture_en_cours:
+            return
+        self._fermeture_en_cours = True
+
+        # La barre de recherche possède un wx.Timer qui peut encore poster un
+        # EVT_TIMER alors que le dialogue et sa liste sont en cours de destruction.
+        try:
+            timer = self.ctrl_recherche.barreRecherche.timer
+            if timer.IsRunning():
+                timer.Stop()
+        except (AttributeError, RuntimeError):
+            pass
+
+        # FastObjectListView est un wx.ListCtrl virtuel. Sous Windows, le contrôle
+        # natif peut demander une dernière ligne pendant sa destruction. On retire
+        # donc son getter et son cache avant de remettre le compteur à zéro.
+        try:
+            ctrl = self.ctrl_consommations
+            ctrl.SetObjectGetter(None)
+            ctrl.lastGetObjectIndex = -1
+            ctrl.lastGetObject = None
+            ctrl.SetItemCount(0)
+            ctrl.modelObjects = []
+            ctrl.innerList = []
+            ctrl.donnees = []
+        except (AttributeError, RuntimeError):
+            pass
+
+    def OnFermer(self, event=None):
+        self._NettoieAvantFermeture()
+        if self.IsModal():
+            self.EndModal(wx.ID_CANCEL)
+        else:
+            self.Destroy()
 
     def OnParametre(self, event=None):
         listeFiltres = []

--- a/tests/test_vanilla_candidate_contract.py
+++ b/tests/test_vanilla_candidate_contract.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+import ast
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def lire(path):
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def source_fonction(path, name, class_name=None):
+    source = lire(path)
+    tree = ast.parse(source)
+    nodes = tree.body
+    if class_name is not None:
+        cls = next(node for node in nodes if isinstance(node, ast.ClassDef) and node.name == class_name)
+        nodes = cls.body
+    func = next(node for node in nodes if isinstance(node, ast.FunctionDef) and node.name == name)
+    return ast.get_source_segment(source, func)
+
+
+class VanillaCandidateContractTests(unittest.TestCase):
+    def test_vacances_accepte_les_dates_python3(self):
+        maj = source_fonction("noethys/Ctrl/CTRL_Grille_periode.py", "MAJ", "Vacances")
+        self.assertIn("UTILS_Dates.DateEngEnDateDD(date_debut)", maj)
+        self.assertIn("UTILS_Dates.DateEngEnDateDD(date_fin)", maj)
+        self.assertNotIn("date_debut[:", maj)
+        self.assertNotIn("date_fin[:", maj)
+
+    def test_liste_attente_accepte_date_datetime_et_chaine(self):
+        conversion = source_fonction("noethys/Ctrl/CTRL_Attente.py", "DateEngEnDateDD")
+        self.assertIn("isinstance(dateEng, datetime.datetime)", conversion)
+        self.assertIn("return dateEng.date()", conversion)
+        self.assertIn("return UTILS_Dates.DateEngEnDateDD(dateEng)", conversion)
+        self.assertNotIn("dateEng[:", conversion)
+
+    def test_fermeture_consommations_nettoie_la_liste_virtuelle(self):
+        source = lire("noethys/Dlg/DLG_Liste_consommations.py")
+        self.assertIn("self.Bind(wx.EVT_CLOSE, self.OnFermer)", source)
+        self.assertIn("def _NettoieAvantFermeture(self):", source)
+        self.assertIn("ctrl.SetObjectGetter(None)", source)
+        self.assertIn("ctrl.SetItemCount(0)", source)
+        self.assertIn("timer.Stop()", source)
+
+    def test_fermeture_consommations_est_idempotente(self):
+        cleanup = source_fonction("noethys/Dlg/DLG_Liste_consommations.py", "_NettoieAvantFermeture", "Dialog")
+        fermer = source_fonction("noethys/Dlg/DLG_Liste_consommations.py", "OnFermer", "Dialog")
+        self.assertIn("if self._fermeture_en_cours", cleanup)
+        self.assertIn("self._fermeture_en_cours = True", cleanup)
+        self.assertIn("self._NettoieAvantFermeture()", fermer)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Consolide exclusivement la ligne `maintenance/vanilla` depuis `37b562d05f89812204b36df0193f751d33bc7fbf`.

Inclus :
- backport ciblé du correctif #360 Affichage + Liste d’attente / dates Python 3 ;
- intégration bit pour bit du correctif #359 fermeture/réouverture de la liste des consommations ;
- tests contractuels ciblés sur ces deux correctifs ;
- extension du déclenchement de la CI Vanilla aux fichiers du candidat.

Exclus explicitement : migration BDD, Connecthys/Ivan, performance questionnaires, bouton Modifier, autre bug d’audit, refonte UI, thème sombre, tag/release stable.

Le but de cette PR est de produire un SHA unique qualifié par la CI/packaging Vanilla avant fast-forward de `maintenance/vanilla`.